### PR TITLE
feat: add PostgreSQL support + harden docker-entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,9 @@ FROM docker.io/library/php:8.4-apache-bookworm AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libpng-dev libjpeg-dev libfreetype6-dev \
         libzip-dev unzip sqlite3 libsqlite3-dev wget \
+        libpq-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j"$(nproc)" pdo pdo_mysql pdo_sqlite gd zip bcmath opcache \
+    && docker-php-ext-install -j"$(nproc)" pdo pdo_mysql pdo_sqlite pdo_pgsql pgsql gd zip bcmath opcache \
     && a2enmod rewrite headers \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,64 +4,84 @@ set -e
 # Configure Apache port from PORT env var (default: 10000 for Render, override for self-hosting)
 if [ -n "$PORT" ]; then
     sed -i "s/Listen 80/Listen $PORT/" /etc/apache2/ports.conf 2>/dev/null || true
-    sed -i "s/:80/:$PORT/" /etc/apache2/sites-available/*.conf 2>/dev/null || true
+    sed -i "s/<VirtualHost \*:80>/<VirtualHost *:$PORT>/" /etc/apache2/sites-available/*.conf 2>/dev/null || true
 fi
 
-# Generate app key if not provided via environment and not already in .env
+# Ensure .env exists so artisan commands work
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+
+# Generate app key if not provided via environment
 if [ -z "$APP_KEY" ]; then
-    if [ ! -f .env ]; then
-        cp .env.example .env
-    fi
-    php artisan key:generate --force
+    php artisan key:generate --force --no-interaction
     echo "App key generated."
 else
     echo "Using APP_KEY from environment."
-    # Ensure .env exists so artisan commands work
-    if [ ! -f .env ]; then
-        cp .env.example .env
-    fi
 fi
 
 # Override .env with Docker env vars (env vars take precedence over .env.example defaults)
-[ -n "$PARKHUB_ADMIN_PASSWORD" ] && sed -i "s|^PARKHUB_ADMIN_PASSWORD=.*|PARKHUB_ADMIN_PASSWORD=$PARKHUB_ADMIN_PASSWORD|" .env
-[ -n "$PARKHUB_ADMIN_EMAIL" ] && sed -i "s|^PARKHUB_ADMIN_EMAIL=.*|PARKHUB_ADMIN_EMAIL=$PARKHUB_ADMIN_EMAIL|" .env
-[ -n "$DEMO_MODE" ] && (grep -q "^DEMO_MODE=" .env && sed -i "s|^DEMO_MODE=.*|DEMO_MODE=$DEMO_MODE|" .env || echo "DEMO_MODE=$DEMO_MODE" >> .env)
-[ -n "$DB_CONNECTION" ] && sed -i "s|^DB_CONNECTION=.*|DB_CONNECTION=$DB_CONNECTION|" .env
-[ -n "$DB_DATABASE" ] && sed -i "s|^DB_DATABASE=.*|DB_DATABASE=$DB_DATABASE|" .env
+env_vars=(
+    "PARKHUB_ADMIN_EMAIL"
+    "PARKHUB_ADMIN_PASSWORD"
+    "DEMO_MODE"
+    "DB_CONNECTION"
+    "DB_HOST"
+    "DB_PORT"
+    "DB_DATABASE"
+    "DB_USERNAME"
+    "DB_PASSWORD"
+)
 
-# Ensure storage directories exist
+for var in "${env_vars[@]}"; do
+    value="${!var}"
+    if [ -n "$value" ]; then
+        if grep -q "^${var}=" .env 2>/dev/null; then
+            sed -i "s|^${var}=.*|${var}=${value}|" .env
+        else
+            echo "${var}=${value}" >> .env
+        fi
+    fi
+done
+
+# Support DATABASE_URL (e.g. from Render PostgreSQL addon)
+[ -n "$DATABASE_URL" ] && echo "DATABASE_URL present — Laravel will use it preferentially."
+
+# Ensure storage directories exist with correct permissions
 mkdir -p storage/framework/{sessions,views,cache} storage/logs bootstrap/cache
-chown -R www-data:www-data storage bootstrap/cache
+chown -R www-data:www-data storage bootstrap/cache database 2>/dev/null || true
+chmod -R 775 storage bootstrap/cache 2>/dev/null || true
 
 # Demo mode: fresh DB + seed with realistic data on every container start
 # SEED_DEMO_DATA=true: seed data once in production mode (no demo UI/auto-reset)
 # Non-demo: incremental migrations only
 if [ "${DEMO_MODE}" = "true" ] || [ "${SEED_DEMO_DATA}" = "true" ]; then
     echo "DEMO_MODE=true — running migrate:fresh + ProductionSimulationSeeder..."
-    php artisan migrate:fresh --force 2>&1 || { echo "WARNING: Migrations failed"; }
-    php artisan db:seed --class=ProductionSimulationSeeder --force 2>&1 || { echo "WARNING: Demo seeding failed"; }
+    php artisan migrate:fresh --force --no-interaction 2>&1 || { echo "WARNING: Migrations failed"; }
+    php artisan db:seed --class=ProductionSimulationSeeder --force --no-interaction 2>&1 || { echo "WARNING: Demo seeding failed"; }
     echo "Demo data seeded."
 else
     echo "Running migrations..."
-    php artisan migrate --force 2>&1 || { echo "WARNING: Migrations failed"; }
+    php artisan migrate --force --no-interaction 2>&1 || { echo "WARNING: Migrations failed"; }
     # Create default admin if none exists (works without tinker in --no-dev)
-    php artisan parkhub:create-admin 2>&1 || true
+    php artisan parkhub:create-admin --no-interaction 2>&1 || true
 fi
 
 # Generate VAPID keys for push notifications (once)
 php artisan vapid:generate 2>&1 || true
 
 # Prune expired Sanctum tokens (7 day expiry = 168 hours)
-php artisan sanctum:prune-expired --hours=168 2>&1 || true
+php artisan sanctum:prune-expired --hours=168 --no-interaction 2>&1 || true
 
 # Clear old cache then rebuild — ensures Docker env vars are picked up
-php artisan config:clear 2>&1 || true
-php artisan route:clear 2>&1 || true
-php artisan config:cache 2>&1 || true
-php artisan route:cache 2>&1 || true
+php artisan config:clear --no-interaction 2>&1 || true
+php artisan route:clear --no-interaction 2>&1 || true
+php artisan view:clear --no-interaction 2>&1 || true
+php artisan config:cache --no-interaction 2>&1 || true
+php artisan route:cache --no-interaction 2>&1 || true
 
 # Start Laravel scheduler in background (needed for auto-release, demo resets, etc.)
 # Render free tier doesn't support separate worker processes
-(while true; do php artisan schedule:run >> storage/logs/scheduler.log 2>&1; sleep 60; done) &
+(while true; do php artisan schedule:run --no-interaction >> storage/logs/scheduler.log 2>&1; sleep 60; done) &
 
 exec "$@"


### PR DESCRIPTION
## Summary
- Install `pdo_pgsql` and `pgsql` PHP extensions in Dockerfile
- Support DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD env overrides
- Support `DATABASE_URL` for PaaS platforms (Render PostgreSQL addon)
- Fix VirtualHost port replacement
- Add `view:clear` + `--no-interaction` to all artisan commands
- Improve storage directory permissions

Inspired by community PR #24 from @gobeti, with APP_KEY fix and cleaner structure.