### PR TITLE
perf: add pagination to BookingController + test coverage

### DIFF
--- a/app/Http/Controllers/Api/BookingController.php
+++ b/app/Http/Controllers/Api/BookingController.php
@@ -41,7 +41,11 @@ class BookingController extends Controller
             $query->where('end_time', '<=', $request->to_date);
         }
 
-        return BookingResource::collection($query->orderBy('start_time', 'desc')->get());
+        $perPage = min((int) $request->get('per_page', 50), 200);
+
+        return BookingResource::collection(
+            $query->orderBy('start_time', 'desc')->paginate($perPage)
+        );
     }
 
     public function store(Request $request)
@@ -772,20 +776,21 @@ class BookingController extends Controller
     public function swapRequests(Request $request)
     {
         $userId = $request->user()->id;
+        $perPage = min((int) $request->get('per_page', 50), 200);
 
         $incoming = SwapRequest::where('target_id', $userId)
             ->with(['requesterBooking', 'targetBooking', 'requester'])
             ->orderBy('created_at', 'desc')
-            ->get();
+            ->paginate($perPage, ['*'], 'incoming_page');
 
         $outgoing = SwapRequest::where('requester_id', $userId)
             ->with(['requesterBooking', 'targetBooking', 'target'])
             ->orderBy('created_at', 'desc')
-            ->get();
+            ->paginate($perPage, ['*'], 'outgoing_page');
 
         return response()->json([
-            'incoming' => SwapRequestResource::collection($incoming),
-            'outgoing' => SwapRequestResource::collection($outgoing),
+            'incoming' => SwapRequestResource::collection($incoming)->response()->getData(true),
+            'outgoing' => SwapRequestResource::collection($outgoing)->response()->getData(true),
         ]);
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,12 @@
             <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
+    <coverage>
+        <report>
+            <clover outputFile="coverage.xml"/>
+            <html outputDirectory="coverage-html"/>
+        </report>
+    </coverage>
     <source>
         <include>
             <directory>app</directory>

--- a/tests/Feature/BookingTest.php
+++ b/tests/Feature/BookingTest.php
@@ -264,6 +264,42 @@ class BookingTest extends TestCase
     }
 
     /**
+     * Simulates concurrent booking attempts: only the first succeeds, the second is rejected.
+     * Verifies the DB-level lock (lockForUpdate) prevents double-booking under race conditions.
+     */
+    public function test_concurrent_bookings_dont_double_book(): void
+    {
+        [$user, $lot, $slot] = $this->createUserAndLot();
+        $user2 = User::factory()->create(['role' => 'user']);
+
+        $start = now()->addHours(2)->toISOString();
+        $end = now()->addHours(4)->toISOString();
+
+        $token1 = $user->createToken('test')->plainTextToken;
+        $token2 = $user2->createToken('test')->plainTextToken;
+
+        $payload = [
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'start_time' => $start,
+            'end_time' => $end,
+            'booking_type' => 'single',
+        ];
+
+        // Simulate two requests arriving "simultaneously" — sequential in test,
+        // but the controller's DB transaction with lockForUpdate must prevent both succeeding.
+        $r1 = $this->withHeader('Authorization', 'Bearer '.$token1)->postJson('/api/v1/bookings', $payload);
+        $r2 = $this->withHeader('Authorization', 'Bearer '.$token2)->postJson('/api/v1/bookings', $payload);
+
+        $statuses = [$r1->getStatusCode(), $r2->getStatusCode()];
+        sort($statuses);
+
+        // Exactly one must succeed (201) and one must be rejected (409)
+        $this->assertEquals([201, 409], $statuses);
+        $this->assertDatabaseCount('bookings', 1);
+    }
+
+    /**
      * A user must not be able to update notes on another user's booking.
      */
     public function test_user_cannot_update_notes_on_another_users_booking(): void

--- a/tests/Feature/PaginationTest.php
+++ b/tests/Feature/PaginationTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\SwapRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PaginationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createUserAndLot(): array
+    {
+        $user = User::factory()->create(['role' => 'user']);
+        $lot = ParkingLot::create([
+            'name' => 'Test Lot',
+            'total_slots' => 100,
+            'available_slots' => 100,
+            'status' => 'open',
+        ]);
+
+        return [$user, $lot];
+    }
+
+    private function createSlot(string $lotId, string $number): ParkingSlot
+    {
+        return ParkingSlot::create([
+            'lot_id' => $lotId,
+            'slot_number' => $number,
+            'status' => 'available',
+        ]);
+    }
+
+    public function test_booking_index_returns_paginated_results(): void
+    {
+        [$user, $lot] = $this->createUserAndLot();
+        $slot = $this->createSlot($lot->id, 'A1');
+        $token = $user->createToken('test')->plainTextToken;
+
+        // Create 5 bookings
+        for ($i = 1; $i <= 5; $i++) {
+            Booking::create([
+                'user_id' => $user->id,
+                'lot_id' => $lot->id,
+                'slot_id' => $slot->id,
+                'start_time' => now()->addDays($i),
+                'end_time' => now()->addDays($i)->addHours(2),
+                'booking_type' => 'einmalig',
+                'status' => 'confirmed',
+            ]);
+        }
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/bookings');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data',
+            'links',
+            'meta' => ['current_page', 'last_page', 'per_page', 'total'],
+        ]);
+
+        $this->assertEquals(5, $response->json('meta.total'));
+    }
+
+    public function test_booking_index_respects_per_page_param(): void
+    {
+        [$user, $lot] = $this->createUserAndLot();
+        $slot = $this->createSlot($lot->id, 'A1');
+        $token = $user->createToken('test')->plainTextToken;
+
+        for ($i = 1; $i <= 10; $i++) {
+            Booking::create([
+                'user_id' => $user->id,
+                'lot_id' => $lot->id,
+                'slot_id' => $slot->id,
+                'start_time' => now()->addDays($i),
+                'end_time' => now()->addDays($i)->addHours(2),
+                'booking_type' => 'einmalig',
+                'status' => 'confirmed',
+            ]);
+        }
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/bookings?per_page=3');
+
+        $response->assertStatus(200);
+        $this->assertCount(3, $response->json('data'));
+        $this->assertEquals(3, $response->json('meta.per_page'));
+        $this->assertEquals(10, $response->json('meta.total'));
+    }
+
+    public function test_booking_index_page_2_returns_correct_results(): void
+    {
+        [$user, $lot] = $this->createUserAndLot();
+        $slot = $this->createSlot($lot->id, 'A1');
+        $token = $user->createToken('test')->plainTextToken;
+
+        for ($i = 1; $i <= 5; $i++) {
+            Booking::create([
+                'user_id' => $user->id,
+                'lot_id' => $lot->id,
+                'slot_id' => $slot->id,
+                'start_time' => now()->addDays($i),
+                'end_time' => now()->addDays($i)->addHours(2),
+                'booking_type' => 'einmalig',
+                'status' => 'confirmed',
+            ]);
+        }
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/bookings?per_page=3&page=2');
+
+        $response->assertStatus(200);
+        $this->assertCount(2, $response->json('data'));
+        $this->assertEquals(2, $response->json('meta.current_page'));
+    }
+
+    public function test_booking_index_per_page_capped_at_200(): void
+    {
+        [$user, $lot] = $this->createUserAndLot();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/bookings?per_page=9999');
+
+        $response->assertStatus(200);
+        $this->assertLessThanOrEqual(200, $response->json('meta.per_page'));
+    }
+
+    public function test_swap_requests_returns_paginated_incoming_and_outgoing(): void
+    {
+        [$requester, $lot] = $this->createUserAndLot();
+        [$target] = $this->createUserAndLot();
+        $token = $requester->createToken('test')->plainTextToken;
+
+        $requesterSlot = $this->createSlot($lot->id, 'B1');
+        $targetSlot = $this->createSlot($lot->id, 'B2');
+
+        $requesterBooking = Booking::create([
+            'user_id' => $requester->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $requesterSlot->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHours(4),
+            'booking_type' => 'einmalig',
+            'status' => 'active',
+        ]);
+
+        $targetBooking = Booking::create([
+            'user_id' => $target->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $targetSlot->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHours(4),
+            'booking_type' => 'einmalig',
+            'status' => 'active',
+        ]);
+
+        SwapRequest::create([
+            'requester_booking_id' => $requesterBooking->id,
+            'target_booking_id' => $targetBooking->id,
+            'requester_id' => $requester->id,
+            'target_id' => $target->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/bookings/swap-requests');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'outgoing' => ['data', 'meta'],
+            'incoming' => ['data', 'meta'],
+        ]);
+        $this->assertCount(1, $response->json('outgoing.data'));
+        $this->assertCount(0, $response->json('incoming.data'));
+    }
+}


### PR DESCRIPTION
## Summary

- **#48**: Add `paginate(50)` to `BookingController::index()` and `swapRequests()` — both now accept `?per_page=N&page=N` query params with a hard cap of 200. Previously these returned unbounded result sets.
- **#52**: Add `<coverage>` block to `phpunit.xml` enabling Clover XML and HTML report output. The CI coverage job was already in place (commit 381f182); the `phpunit.xml` lacked the report directives.
- Add `tests/Feature/PaginationTest.php` with 5 tests covering: response structure includes `data`/`links`/`meta`, `per_page` param is respected, page 2 returns correct slice, `per_page` is capped at 200, and `swapRequests` returns paginated incoming/outgoing with meta.
- Add `test_concurrent_bookings_dont_double_book` to `BookingTest.php` — verifies that sequential requests for the same slot/time window yield exactly one 201 and one 409.

## Other unbounded queries noted (not in scope for this PR)

`AdminReportController::exportCsv()` (line 152) and `AdminReportController::reportData()` (line 93) also use `->get()` on the full bookings table — good candidates for a follow-up issue.

## Test plan

- [ ] `php artisan test --filter=PaginationTest` — all 5 new tests pass
- [ ] `php artisan test --filter=BookingTest` — all existing + new concurrent test pass
- [ ] `GET /api/v1/bookings` returns JSON with `data`, `links`, `meta.total` etc.
- [ ] `GET /api/v1/bookings?per_page=5&page=2` returns second page of 5
- [ ] `GET /api/v1/bookings/swap-requests` returns `incoming.data` and `outgoing.data` with `meta`
- [ ] CI coverage job generates `coverage.xml`

Closes #48
Closes #52