### PR TITLE
ci: PostgreSQL test job, composer audit, arm64 Docker build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@ DB_CONNECTION=sqlite
 # DB_USERNAME=parkhub
 # DB_PASSWORD=
 
+# Uncomment and configure for PostgreSQL:
+# DB_CONNECTION=pgsql
+# DB_HOST=127.0.0.1
+# DB_PORT=5432
+# DB_DATABASE=parkhub
+# DB_USERNAME=parkhub
+# DB_PASSWORD=
+
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
 SESSION_ENCRYPT=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,80 @@ jobs:
           DB_CONNECTION: sqlite
           DB_DATABASE: ":memory:"
 
+  test-postgres:
+    name: PHP Tests (PostgreSQL)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: parkhub_test
+          POSTGRES_USER: parkhub
+          POSTGRES_PASSWORD: secret
+        ports: ['5432:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, xml, bcmath, pdo_pgsql, gd, zip, curl
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Copy .env
+        run: cp .env.example .env
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Generate key
+        run: php artisan key:generate
+
+      - name: Run tests (PostgreSQL)
+        run: php artisan test
+        env:
+          DB_CONNECTION: pgsql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 5432
+          DB_DATABASE: parkhub_test
+          DB_USERNAME: parkhub
+          DB_PASSWORD: secret
+
+  security-audit:
+    name: Composer Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run composer audit
+        run: composer audit --format=plain
+
   lint:
     name: PHP Lint (Pint)
     runs-on: ubuntu-latest
@@ -113,13 +187,21 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [test, lint, frontend]
+    needs: [test, test-postgres, security-audit, lint, frontend]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
           if [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "test failed: ${{ needs.test.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.test-postgres.result }}" != "success" ]]; then
+            echo "test-postgres failed: ${{ needs.test-postgres.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.security-audit.result }}" != "success" ]]; then
+            echo "security-audit failed: ${{ needs.security-audit.result }}"
             exit 1
           fi
           if [[ "${{ needs.lint.result }}" != "success" ]]; then

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU (for arm64 cross-compilation)
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -51,7 +54,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
       - name: Ensure Render env vars
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')

--- a/app/Http/Controllers/Api/AdminReportController.php
+++ b/app/Http/Controllers/Api/AdminReportController.php
@@ -67,17 +67,24 @@ class AdminReportController extends Controller
         $request->validate(['days' => 'integer|min:1|max:365']);
         $days = (int) $request->get('days', 30);
 
-        // Use DB-agnostic expressions: DAYOFWEEK (MySQL) vs strftime (SQLite)
+        // Use DB-specific date expressions per driver
         $driver = DB::getDriverName();
+        $query = Booking::where('start_time', '>=', now()->subDays($days));
 
         if ($driver === 'sqlite') {
-            $bookings = Booking::where('start_time', '>=', now()->subDays($days))
+            $bookings = $query
                 ->selectRaw('CAST(strftime("%w", start_time) AS INTEGER) as day_of_week, CAST(strftime("%H", start_time) AS INTEGER) as hour, COUNT(*) as count')
+                ->groupBy('day_of_week', 'hour')
+                ->get();
+        } elseif ($driver === 'pgsql') {
+            // PostgreSQL: EXTRACT(DOW ...) returns 0=Sunday...6=Saturday (same as SQLite strftime %w)
+            $bookings = $query
+                ->selectRaw('EXTRACT(DOW FROM start_time)::integer as day_of_week, EXTRACT(HOUR FROM start_time)::integer as hour, COUNT(*) as count')
                 ->groupBy('day_of_week', 'hour')
                 ->get();
         } else {
             // MySQL / MariaDB (DAYOFWEEK returns 1=Sunday...7=Saturday, normalise to 0=Sunday...6=Saturday)
-            $bookings = Booking::where('start_time', '>=', now()->subDays($days))
+            $bookings = $query
                 ->selectRaw('(DAYOFWEEK(start_time) - 1) as day_of_week, HOUR(start_time) as hour, COUNT(*) as count')
                 ->groupBy('day_of_week', 'hour')
                 ->get();


### PR DESCRIPTION
## Summary
- Add PostgreSQL 16 CI test job with service container (closes #51)
- Add `composer audit` security check job to CI pipeline (partially closes #55)
- Add QEMU + arm64 platform to Docker publish workflow (closes #56)
- Fix `AdminReportController::heatmap()` PostgreSQL compatibility — adds `EXTRACT(DOW/HOUR)` path instead of falling through to MySQL-only `DAYOFWEEK()`
- Add PostgreSQL connection example to `.env.example`
- Update CI gate job to require all new jobs pass

## Test plan
- [ ] CI PostgreSQL job runs and passes with `pgsql` driver
- [ ] Existing SQLite test job still passes
- [ ] Composer audit job runs without failures
- [ ] Docker multi-arch build produces both amd64 and arm64 images
- [ ] Heatmap endpoint returns correct day_of_week values on PostgreSQL