### PR TITLE
fix: security and config fixes (metrics, VAPID, QR auth, version)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,15 @@ AWS_DEFAULT_REGION=us-east-1
 AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
+# Prometheus metrics endpoint protection — set a strong random token.
+# Requests to /api/metrics must include Authorization: Bearer <METRICS_TOKEN>.
+# Leave empty to allow unauthenticated access (not recommended in production).
+# METRICS_TOKEN=
+
+# VAPID keys for Web Push notifications.
+# Generate with: php artisan vapid:generate (or use web-push-libs/webpush-php)
+# VAPID_SUBJECT=mailto:admin@your-domain.com
+
 VITE_APP_NAME="${APP_NAME}"
 
 # Broadcasting — set BROADCAST_CONNECTION=soketi for self-hosted real-time events

--- a/app/Http/Controllers/Api/AdminReportController.php
+++ b/app/Http/Controllers/Api/AdminReportController.php
@@ -70,14 +70,22 @@ class AdminReportController extends Controller
         // Use DB-agnostic expressions: DAYOFWEEK (MySQL) vs strftime (SQLite)
         $driver = DB::getDriverName();
 
+        $query = Booking::where('start_time', '>=', now()->subDays($days));
+
         if ($driver === 'sqlite') {
-            $bookings = Booking::where('start_time', '>=', now()->subDays($days))
+            $bookings = $query
                 ->selectRaw('CAST(strftime("%w", start_time) AS INTEGER) as day_of_week, CAST(strftime("%H", start_time) AS INTEGER) as hour, COUNT(*) as count')
+                ->groupBy('day_of_week', 'hour')
+                ->get();
+        } elseif ($driver === 'pgsql') {
+            // PostgreSQL: EXTRACT(DOW ...) returns 0=Sunday...6=Saturday (same as SQLite strftime %w)
+            $bookings = $query
+                ->selectRaw('EXTRACT(DOW FROM start_time)::integer as day_of_week, EXTRACT(HOUR FROM start_time)::integer as hour, COUNT(*) as count')
                 ->groupBy('day_of_week', 'hour')
                 ->get();
         } else {
             // MySQL / MariaDB (DAYOFWEEK returns 1=Sunday...7=Saturday, normalise to 0=Sunday...6=Saturday)
-            $bookings = Booking::where('start_time', '>=', now()->subDays($days))
+            $bookings = $query
                 ->selectRaw('(DAYOFWEEK(start_time) - 1) as day_of_week, HOUR(start_time) as hour, COUNT(*) as count')
                 ->groupBy('day_of_week', 'hour')
                 ->get();

--- a/app/Http/Controllers/Api/MiscController.php
+++ b/app/Http/Controllers/Api/MiscController.php
@@ -64,9 +64,14 @@ class MiscController extends Controller
     }
 
     // QR Code
-    public function qrCode(string $bookingId)
+    public function qrCode(Request $request, string $bookingId)
     {
-        $booking = Booking::findOrFail($bookingId);
+        $user = $request->user();
+        if ($user->isAdmin()) {
+            $booking = Booking::findOrFail($bookingId);
+        } else {
+            $booking = Booking::where('user_id', $user->id)->findOrFail($bookingId);
+        }
         $data = json_encode([
             'booking_id' => $booking->id,
             'slot' => $booking->slot_number,

--- a/app/Http/Controllers/Api/SystemController.php
+++ b/app/Http/Controllers/Api/SystemController.php
@@ -11,9 +11,25 @@ class SystemController extends Controller
     public function version(Request $request)
     {
         return response()->json([
-            'version' => '1.0.0-php',
+            'version' => self::appVersion(),
             'build' => 'php-laravel',
         ]);
+    }
+
+    /**
+     * Read application version from the VERSION file (single source of truth).
+     */
+    public static function appVersion(): string
+    {
+        static $version = null;
+        if ($version === null) {
+            $versionFile = base_path('VERSION');
+            $version = file_exists($versionFile)
+                ? trim(file_get_contents($versionFile))
+                : '0.0.0';
+        }
+
+        return $version;
     }
 
     public function maintenance(Request $request)

--- a/app/Services/PushNotificationService.php
+++ b/app/Services/PushNotificationService.php
@@ -24,7 +24,7 @@ class PushNotificationService
 
         $auth = [
             'VAPID' => [
-                'subject' => 'mailto:admin@parkhub.test',
+                'subject' => Setting::get('vapid_subject', env('VAPID_SUBJECT', 'mailto:admin@parkhub.test')),
                 'publicKey' => $publicKey,
                 'privateKey' => $privateKey,
             ],

--- a/config/app.php
+++ b/config/app.php
@@ -136,4 +136,17 @@ return [
 
     'hsts' => (bool) env('APP_HSTS', false),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Metrics Token
+    |--------------------------------------------------------------------------
+    |
+    | Optional bearer token for protecting the /api/metrics endpoint.
+    | When set, requests must include Authorization: Bearer <token>.
+    | Leave empty to allow unauthenticated access (NOT recommended in production).
+    |
+    */
+
+    'metrics_token' => env('METRICS_TOKEN'),
+
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\PulseController;
 use App\Http\Controllers\Api\RecurringBookingController;
 use App\Http\Controllers\Api\SetupController;
 use App\Http\Controllers\Api\SlotController;
+use App\Http\Controllers\Api\SystemController;
 use App\Http\Controllers\Api\TeamController;
 use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Api\VehicleController;
@@ -26,7 +27,7 @@ use Illuminate\Support\Facades\Route;
 
 // Health check (no auth)
 Route::get('/health', function () {
-    return response()->json(['status' => 'ok', 'version' => '1.3.0']);
+    return response()->json(['status' => 'ok', 'version' => SystemController::appVersion()]);
 });
 
 // Public routes (no auth) — rate limited to prevent brute-force and registration spam

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -260,7 +260,7 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
         Route::delete('/announcements/{id}', [AdminAnnouncementController::class, 'deleteAnnouncement']);
 
         Route::get('/updates/check', function () {
-            return response()->json(['update_available' => false, 'current_version' => '1.3.0-php']);
+            return response()->json(['update_available' => false, 'current_version' => SystemController::appVersion()]);
         });
 
         // Credits management
@@ -310,7 +310,7 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
     Route::delete('/webhooks/{id}', [MiscController::class, 'deleteWebhook']);
     Route::post('/webhooks/{id}/test', [MiscController::class, 'testWebhook']);
     Route::get('/update/check', function () {
-        return response()->json(['update_available' => false, 'current_version' => '1.3.0']);
+        return response()->json(['update_available' => false, 'current_version' => SystemController::appVersion()]);
     });
 
     // Translation management (overrides is public — see above)
@@ -325,7 +325,7 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
 
 // Health (no auth)
 Route::get('/health', function () {
-    return response()->json(['status' => 'ok', 'version' => '1.3.0']);
+    return response()->json(['status' => 'ok', 'version' => SystemController::appVersion()]);
 });
 Route::get('/health/live', [HealthController::class, 'live']);
 Route::get('/health/ready', [HealthController::class, 'ready']);


### PR DESCRIPTION
## Summary
- **#76**: Register `metrics_token` in `config/app.php` so `METRICS_TOKEN` env var actually gates the `/api/metrics` endpoint
- **#37**: Make VAPID subject configurable via `Setting::get('vapid_subject')` / `VAPID_SUBJECT` env var instead of hardcoded `admin@parkhub.test`
- **#79**: Add ownership check to QR code endpoint — prevents any authenticated user from viewing any booking's QR data (IDOR)
- **#47**: Read version from `VERSION` file instead of hardcoded `1.3.0` strings across 4 route files
- **#85**: Add PostgreSQL `EXTRACT(DOW/HOUR)` branch to heatmap query (from closed PR #74)
- Add `METRICS_TOKEN` and `VAPID_SUBJECT` to `.env.example`

## Test plan
- [x] All 512 tests pass
- [x] Pint lint clean
- [x] No regressions

Closes #76, #37, #47, #79, #85