### PR TITLE
refactor: extract Form Request classes from controllers

### DIFF
--- a/app/Http/Controllers/Api/AdminController.php
+++ b/app/Http/Controllers/Api/AdminController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\ImportUsersRequest;
+use App\Http\Requests\UpdateUserRequest;
 use App\Http\Resources\BookingResource;
 use App\Http\Resources\ParkingSlotResource;
 use App\Http\Resources\UserResource;
@@ -45,17 +47,9 @@ class AdminController extends Controller
         ]);
     }
 
-    public function updateUser(Request $request, string $id)
+    public function updateUser(UpdateUserRequest $request, string $id)
     {
         $this->requireAdmin($request);
-        $request->validate([
-            'name' => 'sometimes|string|max:255',
-            'email' => 'sometimes|email|max:255|unique:users,email,'.$id,
-            'role' => 'sometimes|in:user,admin,superadmin',
-            'is_active' => 'sometimes|boolean',
-            'department' => 'sometimes|nullable|string|max:255',
-            'password' => 'sometimes|string|min:8',
-        ]);
         $user = User::findOrFail($id);
         $data = $request->only(['name', 'email', 'is_active', 'department']);
         if ($request->filled('password')) {
@@ -83,19 +77,9 @@ class AdminController extends Controller
         return response()->json(['message' => 'User deleted']);
     }
 
-    public function importUsers(Request $request): JsonResponse
+    public function importUsers(ImportUsersRequest $request): JsonResponse
     {
         $this->requireAdmin($request);
-
-        $request->validate([
-            'users' => 'required|array|max:500',
-            'users.*.username' => 'required|string|min:3|max:50|alpha_dash',
-            'users.*.email' => 'required|email|max:255',
-            'users.*.name' => 'nullable|string|max:255',
-            'users.*.role' => 'nullable|in:user,admin',
-            'users.*.department' => 'nullable|string|max:255',
-            'users.*.password' => 'nullable|string|min:8|max:128',
-        ]);
 
         $imported = 0;
         $usersCollection = collect($request->users);

--- a/app/Http/Controllers/Api/AdminSettingsController.php
+++ b/app/Http/Controllers/Api/AdminSettingsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateSettingsRequest;
 use App\Models\Absence;
 use App\Models\AuditLog;
 use App\Models\Booking;
@@ -50,7 +51,7 @@ class AdminSettingsController extends Controller
         return response()->json(array_merge($defaults, $settings));
     }
 
-    public function updateSettings(Request $request): JsonResponse
+    public function updateSettings(UpdateSettingsRequest $request): JsonResponse
     {
         $this->requireAdmin($request);
 
@@ -64,38 +65,6 @@ class AdminSettingsController extends Controller
             'credits_enabled', 'credits_per_booking',
             'primary_color', 'secondary_color',
         ];
-
-        // Normalize string booleans before validation so Laravel's boolean rule accepts them
-        $booleanKeys = ['self_registration', 'allow_guest_bookings', 'require_vehicle', 'waitlist_enabled', 'credits_enabled'];
-        foreach ($booleanKeys as $bk) {
-            if ($request->has($bk)) {
-                $val = $request->input($bk);
-                if ($val === 'true' || $val === '1') {
-                    $request->merge([$bk => true]);
-                } elseif ($val === 'false' || $val === '0') {
-                    $request->merge([$bk => false]);
-                }
-            }
-        }
-
-        $request->validate([
-            'company_name' => 'sometimes|string|max:255',
-            'use_case' => 'sometimes|in:corporate,university,residential,other',
-            'self_registration' => 'sometimes|boolean',
-            'license_plate_mode' => 'sometimes|in:required,optional,disabled,visible,hidden',
-            'display_name_format' => 'sometimes|in:first_name,full_name,username',
-            'max_bookings_per_day' => 'sometimes|integer|min:0|max:50',
-            'allow_guest_bookings' => 'sometimes|boolean',
-            'auto_release_minutes' => 'sometimes|integer|min:0|max:480',
-            'require_vehicle' => 'sometimes|boolean',
-            'waitlist_enabled' => 'sometimes|boolean',
-            'min_booking_duration_hours' => 'sometimes|numeric|min:0|max:24',
-            'max_booking_duration_hours' => 'sometimes|numeric|min:0|max:72',
-            'credits_enabled' => 'sometimes|boolean',
-            'credits_per_booking' => 'sometimes|integer|min:1|max:100',
-            'primary_color' => 'sometimes|string|regex:/^#[0-9a-fA-F]{6}$/',
-            'secondary_color' => 'sometimes|string|regex:/^#[0-9a-fA-F]{6}$/',
-        ]);
 
         foreach ($request->only($allowed) as $key => $value) {
             // Normalize booleans to 'true'/'false' strings for consistent Setting::get() checks

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -3,6 +3,10 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\ChangePasswordRequest;
+use App\Http\Requests\LoginRequest;
+use App\Http\Requests\RegisterRequest;
+use App\Http\Requests\ResetPasswordRequest;
 use App\Jobs\SendPasswordResetNotificationJob;
 use App\Mail\WelcomeEmail;
 use App\Models\AuditLog;
@@ -17,12 +21,8 @@ use Illuminate\Support\Str;
 
 class AuthController extends Controller
 {
-    public function login(Request $request): JsonResponse
+    public function login(LoginRequest $request): JsonResponse
     {
-        $request->validate([
-            'username' => 'required|string',
-            'password' => 'required|string',
-        ]);
 
         $user = User::where('username', $request->username)
             ->orWhere('email', $request->username)
@@ -62,18 +62,11 @@ class AuthController extends Controller
         ]);
     }
 
-    public function register(Request $request): JsonResponse
+    public function register(RegisterRequest $request): JsonResponse
     {
         if (Setting::get('self_registration', 'true') !== 'true') {
             return response()->json(['message' => 'Registration is currently disabled'], 403);
         }
-
-        $request->validate([
-            'username' => 'required|string|min:3|max:50|unique:users|alpha_dash',
-            'email' => 'required|email|max:255|unique:users',
-            'password' => ['required', 'string', 'min:8', 'max:128', 'confirmed', 'regex:/[a-z]/', 'regex:/[A-Z]/', 'regex:/[0-9]/'],
-            'name' => 'required|string|max:255',
-        ]);
 
         $user = User::create([
             'username' => $request->username,
@@ -235,14 +228,8 @@ class AuthController extends Controller
         return response()->json(['message' => 'If an account with that email exists, a reset link has been sent.']);
     }
 
-    public function resetPassword(Request $request): JsonResponse
+    public function resetPassword(ResetPasswordRequest $request): JsonResponse
     {
-        $request->validate([
-            'email' => 'required|email',
-            'token' => 'required|string',
-            'password' => ['required', 'string', 'min:8', 'regex:/[a-z]/', 'regex:/[A-Z]/', 'regex:/[0-9]/'],
-            'password_confirmation' => 'required|same:password',
-        ]);
 
         // Look up the single token row by email (O(1) instead of scanning all rows)
         $record = DB::table('password_reset_tokens')
@@ -277,12 +264,8 @@ class AuthController extends Controller
         return response()->json(['message' => 'Passwort erfolgreich zurückgesetzt. Sie können sich nun anmelden.']);
     }
 
-    public function changePassword(Request $request): JsonResponse
+    public function changePassword(ChangePasswordRequest $request): JsonResponse
     {
-        $request->validate([
-            'current_password' => 'required|string',
-            'new_password' => ['required', 'string', 'min:8', 'regex:/[a-z]/', 'regex:/[A-Z]/', 'regex:/[0-9]/'],
-        ]);
         $user = $request->user();
         if (! Hash::check($request->current_password, $user->password)) {
             return response()->json(['error' => 'INVALID_PASSWORD', 'message' => 'Current password is incorrect'], 400);

--- a/app/Http/Controllers/Api/BookingController.php
+++ b/app/Http/Controllers/Api/BookingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Events\BookingCancelled;
 use App\Events\BookingCreated;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreBookingRequest;
 use App\Http\Resources\BookingResource;
 use App\Http\Resources\GuestBookingResource;
 use App\Http\Resources\SwapRequestResource;
@@ -51,18 +52,9 @@ class BookingController extends Controller
         );
     }
 
-    public function store(Request $request)
+    public function store(StoreBookingRequest $request)
     {
-        $validated = $request->validate([
-            'lot_id' => 'required|uuid',
-            'slot_id' => 'nullable|uuid',
-            'start_time' => 'required|date',
-            'end_time' => 'nullable|date|after:start_time',
-            'booking_type' => 'nullable|string|max:50',
-            'notes' => 'nullable|string|max:2000',
-            'vehicle_plate' => 'nullable|string|max:20',
-            'license_plate' => 'nullable|string|max:20',
-        ]);
+        $validated = $request->validated();
 
         $startTime = Carbon::parse($request->start_time);
         if ($startTime->isPast()) {

--- a/app/Http/Controllers/Api/VehicleController.php
+++ b/app/Http/Controllers/Api/VehicleController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreVehicleRequest;
+use App\Http\Requests\UpdateVehicleRequest;
 use App\Http\Resources\VehicleResource;
 use App\Models\Vehicle;
 use Illuminate\Http\JsonResponse;
@@ -17,15 +19,8 @@ class VehicleController extends Controller
         return VehicleResource::collection(Vehicle::where('user_id', $request->user()->id)->get());
     }
 
-    public function store(Request $request)
+    public function store(StoreVehicleRequest $request)
     {
-        $request->validate([
-            'plate' => 'required|string|max:20',
-            'make' => 'nullable|string|max:100',
-            'model' => 'nullable|string|max:100',
-            'color' => 'nullable|string|max:50',
-            'is_default' => 'nullable|boolean',
-        ]);
         $vehicle = Vehicle::create(array_merge(
             $request->only(['plate', 'make', 'model', 'color', 'is_default']),
             ['user_id' => $request->user()->id]
@@ -34,15 +29,8 @@ class VehicleController extends Controller
         return VehicleResource::make($vehicle)->response()->setStatusCode(201);
     }
 
-    public function update(Request $request, string $id)
+    public function update(UpdateVehicleRequest $request, string $id)
     {
-        $request->validate([
-            'plate' => 'sometimes|required|string|max:20',
-            'make' => 'nullable|string|max:100',
-            'model' => 'nullable|string|max:100',
-            'color' => 'nullable|string|max:50',
-            'is_default' => 'nullable|boolean',
-        ]);
         $vehicle = Vehicle::where('user_id', $request->user()->id)->findOrFail($id);
         $vehicle->update($request->only(['plate', 'make', 'model', 'color', 'is_default']));
 

--- a/app/Http/Requests/ChangePasswordRequest.php
+++ b/app/Http/Requests/ChangePasswordRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChangePasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'current_password' => 'required|string',
+            'new_password' => ['required', 'string', 'min:8', 'regex:/[a-z]/', 'regex:/[A-Z]/', 'regex:/[0-9]/'],
+        ];
+    }
+}

--- a/app/Http/Requests/ImportUsersRequest.php
+++ b/app/Http/Requests/ImportUsersRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportUsersRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'users' => 'required|array|max:500',
+            'users.*.username' => 'required|string|min:3|max:50|alpha_dash',
+            'users.*.email' => 'required|email|max:255',
+            'users.*.name' => 'nullable|string|max:255',
+            'users.*.role' => 'nullable|in:user,admin',
+            'users.*.department' => 'nullable|string|max:255',
+            'users.*.password' => 'nullable|string|min:8|max:128',
+        ];
+    }
+}

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'username' => 'required|string',
+            'password' => 'required|string',
+        ];
+    }
+}

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RegisterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'username' => 'required|string|min:3|max:50|unique:users|alpha_dash',
+            'email' => 'required|email|max:255|unique:users',
+            'password' => ['required', 'string', 'min:8', 'max:128', 'confirmed', 'regex:/[a-z]/', 'regex:/[A-Z]/', 'regex:/[0-9]/'],
+            'name' => 'required|string|max:255',
+        ];
+    }
+}

--- a/app/Http/Requests/ResetPasswordRequest.php
+++ b/app/Http/Requests/ResetPasswordRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ResetPasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email',
+            'token' => 'required|string',
+            'password' => ['required', 'string', 'min:8', 'regex:/[a-z]/', 'regex:/[A-Z]/', 'regex:/[0-9]/'],
+            'password_confirmation' => 'required|same:password',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreBookingRequest.php
+++ b/app/Http/Requests/StoreBookingRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreBookingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'lot_id' => 'required|uuid',
+            'slot_id' => 'nullable|uuid',
+            'start_time' => 'required|date',
+            'end_time' => 'nullable|date|after:start_time',
+            'booking_type' => 'nullable|string|max:50',
+            'notes' => 'nullable|string|max:2000',
+            'vehicle_plate' => 'nullable|string|max:20',
+            'license_plate' => 'nullable|string|max:20',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreVehicleRequest.php
+++ b/app/Http/Requests/StoreVehicleRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreVehicleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'plate' => 'required|string|max:20',
+            'make' => 'nullable|string|max:100',
+            'model' => 'nullable|string|max:100',
+            'color' => 'nullable|string|max:50',
+            'is_default' => 'nullable|boolean',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateSettingsRequest.php
+++ b/app/Http/Requests/UpdateSettingsRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'company_name' => 'sometimes|string|max:255',
+            'use_case' => 'sometimes|in:corporate,university,residential,other',
+            'self_registration' => 'sometimes|boolean',
+            'license_plate_mode' => 'sometimes|in:required,optional,disabled,visible,hidden',
+            'display_name_format' => 'sometimes|in:first_name,full_name,username',
+            'max_bookings_per_day' => 'sometimes|integer|min:0|max:50',
+            'allow_guest_bookings' => 'sometimes|boolean',
+            'auto_release_minutes' => 'sometimes|integer|min:0|max:480',
+            'require_vehicle' => 'sometimes|boolean',
+            'waitlist_enabled' => 'sometimes|boolean',
+            'min_booking_duration_hours' => 'sometimes|numeric|min:0|max:24',
+            'max_booking_duration_hours' => 'sometimes|numeric|min:0|max:72',
+            'credits_enabled' => 'sometimes|boolean',
+            'credits_per_booking' => 'sometimes|integer|min:1|max:100',
+            'primary_color' => 'sometimes|string|regex:/^#[0-9a-fA-F]{6}$/',
+            'secondary_color' => 'sometimes|string|regex:/^#[0-9a-fA-F]{6}$/',
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $booleanKeys = ['self_registration', 'allow_guest_bookings', 'require_vehicle', 'waitlist_enabled', 'credits_enabled'];
+        foreach ($booleanKeys as $bk) {
+            if ($this->has($bk)) {
+                $val = $this->input($bk);
+                if ($val === 'true' || $val === '1') {
+                    $this->merge([$bk => true]);
+                } elseif ($val === 'false' || $val === '0') {
+                    $this->merge([$bk => false]);
+                }
+            }
+        }
+    }
+}

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $userId = $this->route('id');
+
+        return [
+            'name' => 'sometimes|string|max:255',
+            'email' => 'sometimes|email|max:255|unique:users,email,'.$userId,
+            'role' => 'sometimes|in:user,admin,superadmin',
+            'is_active' => 'sometimes|boolean',
+            'department' => 'sometimes|nullable|string|max:255',
+            'password' => 'sometimes|string|min:8',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateVehicleRequest.php
+++ b/app/Http/Requests/UpdateVehicleRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateVehicleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'plate' => 'sometimes|required|string|max:20',
+            'make' => 'nullable|string|max:100',
+            'model' => 'nullable|string|max:100',
+            'color' => 'nullable|string|max:50',
+            'is_default' => 'nullable|boolean',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts validation logic from 5 controllers into 10 dedicated Form Request classes
- Closes #57
- All 512 tests pass, Pint clean

## Changes
- `LoginRequest`, `RegisterRequest`, `ChangePasswordRequest`, `ResetPasswordRequest`
- `StoreBookingRequest`, `StoreVehicleRequest`, `UpdateVehicleRequest`
- `UpdateUserRequest`, `ImportUsersRequest`, `UpdateSettingsRequest`
- `UpdateSettingsRequest` includes `prepareForValidation()` for boolean normalization

## Test plan
- [x] All 512 existing tests pass
- [x] Pint formatting verified