### PR TITLE
ci: add arm64 platform to Docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 


### PR DESCRIPTION
## Summary
- Adds QEMU setup and linux/arm64 to Docker buildx platforms (closes #56)
- Enables deployment on ARM-based hosts (Raspberry Pi, AWS Graviton, Apple Silicon)

## Test plan
- [x] Workflow YAML validated
- [x] QEMU step added before Buildx setup