### PR TITLE
test: add 74 new tests for models, conflicts, auth, and validation

### DIFF
--- a/tests/Feature/AuthorizationTest.php
+++ b/tests/Feature/AuthorizationTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_cannot_access_other_users_booking(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $lot = ParkingLot::create(['name' => 'Test', 'total_slots' => 5]);
+        $slot = ParkingSlot::create(['lot_id' => $lot->id, 'slot_number' => '001', 'status' => 'available']);
+
+        $booking = Booking::create([
+            'user_id' => $user1->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHours(8),
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+
+        $this->actingAs($user2)->getJson("/api/bookings/{$booking->id}")
+            ->assertStatus(403);
+    }
+
+    public function test_user_cannot_cancel_other_users_booking(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $lot = ParkingLot::create(['name' => 'Test', 'total_slots' => 5]);
+        $slot = ParkingSlot::create(['lot_id' => $lot->id, 'slot_number' => '001', 'status' => 'available']);
+
+        $booking = Booking::create([
+            'user_id' => $user1->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHours(8),
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+
+        $this->actingAs($user2)->deleteJson("/api/bookings/{$booking->id}")
+            ->assertStatus(404);
+    }
+
+    public function test_user_cannot_delete_other_users_vehicle(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $vehicle = Vehicle::create([
+            'user_id' => $user1->id,
+            'plate' => 'AB-CD-1234',
+        ]);
+
+        $this->actingAs($user2)->deleteJson("/api/vehicles/{$vehicle->id}")
+            ->assertStatus(404);
+    }
+
+    public function test_non_admin_cannot_access_admin_endpoints(): void
+    {
+        $user = User::factory()->create();
+        $user->role = 'user';
+        $user->save();
+
+        $this->actingAs($user)->getJson('/api/admin/stats')->assertStatus(403);
+        $this->actingAs($user)->getJson('/api/admin/users')->assertStatus(403);
+        $this->actingAs($user)->getJson('/api/admin/settings')->assertStatus(403);
+        $this->actingAs($user)->getJson('/api/admin/audit-log')->assertStatus(403);
+    }
+
+    public function test_admin_can_access_admin_endpoints(): void
+    {
+        $admin = User::factory()->create();
+        $admin->role = 'admin';
+        $admin->save();
+
+        $this->actingAs($admin)->getJson('/api/admin/stats')->assertStatus(200);
+        $this->actingAs($admin)->getJson('/api/admin/users')->assertStatus(200);
+        $this->actingAs($admin)->getJson('/api/admin/settings')->assertStatus(200);
+    }
+
+    public function test_unauthenticated_user_cannot_access_protected_routes(): void
+    {
+        $this->getJson('/api/me')->assertStatus(401);
+        $this->getJson('/api/bookings')->assertStatus(401);
+        $this->getJson('/api/vehicles')->assertStatus(401);
+        $this->getJson('/api/lots')->assertStatus(401);
+    }
+
+    public function test_user_can_only_see_own_bookings(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $lot = ParkingLot::create(['name' => 'Test', 'total_slots' => 5]);
+        $slot1 = ParkingSlot::create(['lot_id' => $lot->id, 'slot_number' => '001', 'status' => 'available']);
+        $slot2 = ParkingSlot::create(['lot_id' => $lot->id, 'slot_number' => '002', 'status' => 'available']);
+
+        Booking::create([
+            'user_id' => $user1->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot1->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHours(8),
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+
+        Booking::create([
+            'user_id' => $user2->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot2->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHours(8),
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+
+        $response = $this->actingAs($user1)->getJson('/api/bookings');
+        $response->assertStatus(200);
+        // The response is paginated and wrapped; check that we see exactly 1 booking
+        $data = $response->json('data.data') ?? $response->json('data');
+        // Ensure only user1's booking is returned (not user2's)
+        $this->assertNotEmpty($data);
+        $bookingUserIds = collect($data)->pluck('user_id')->unique()->values()->all();
+        $this->assertEquals([$user1->id], $bookingUserIds);
+    }
+
+    public function test_user_cannot_update_other_users_vehicle(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $vehicle = Vehicle::create([
+            'user_id' => $user1->id,
+            'plate' => 'AB-CD-1234',
+        ]);
+
+        $this->actingAs($user2)->putJson("/api/vehicles/{$vehicle->id}", [
+            'plate' => 'STOLEN',
+        ])->assertStatus(404);
+    }
+}

--- a/tests/Feature/BookingConflictTest.php
+++ b/tests/Feature/BookingConflictTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BookingConflictTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private User $otherUser;
+
+    private ParkingLot $lot;
+
+    private ParkingSlot $slot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->otherUser = User::factory()->create();
+        $this->lot = ParkingLot::create(['name' => 'Conflict Test Lot', 'total_slots' => 1]);
+        $this->slot = ParkingSlot::create(['lot_id' => $this->lot->id, 'slot_number' => '001', 'status' => 'available']);
+    }
+
+    public function test_booking_same_slot_same_time_rejected(): void
+    {
+        // First booking succeeds
+        $response = $this->actingAs($this->user)->postJson('/api/bookings', [
+            'lot_id' => $this->lot->id,
+            'slot_id' => $this->slot->id,
+            'start_time' => now()->addDay()->setHour(9)->format('Y-m-d H:i:s'),
+            'end_time' => now()->addDay()->setHour(17)->format('Y-m-d H:i:s'),
+        ]);
+        $response->assertStatus(201);
+
+        // Second booking on same slot overlapping time is rejected
+        $response = $this->actingAs($this->otherUser)->postJson('/api/bookings', [
+            'lot_id' => $this->lot->id,
+            'slot_id' => $this->slot->id,
+            'start_time' => now()->addDay()->setHour(12)->format('Y-m-d H:i:s'),
+            'end_time' => now()->addDay()->setHour(18)->format('Y-m-d H:i:s'),
+        ]);
+        $response->assertStatus(409);
+    }
+
+    public function test_booking_same_slot_non_overlapping_succeeds(): void
+    {
+        // Morning booking
+        $this->actingAs($this->user)->postJson('/api/bookings', [
+            'lot_id' => $this->lot->id,
+            'slot_id' => $this->slot->id,
+            'start_time' => now()->addDay()->setHour(8)->format('Y-m-d H:i:s'),
+            'end_time' => now()->addDay()->setHour(12)->format('Y-m-d H:i:s'),
+        ])->assertStatus(201);
+
+        // Afternoon booking (non-overlapping)
+        $this->actingAs($this->otherUser)->postJson('/api/bookings', [
+            'lot_id' => $this->lot->id,
+            'slot_id' => $this->slot->id,
+            'start_time' => now()->addDay()->setHour(13)->format('Y-m-d H:i:s'),
+            'end_time' => now()->addDay()->setHour(17)->format('Y-m-d H:i:s'),
+        ])->assertStatus(201);
+    }
+
+    public function test_booking_past_start_time_rejected(): void
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/bookings', [
+            'lot_id' => $this->lot->id,
+            'slot_id' => $this->slot->id,
+            'start_time' => now()->subHour()->format('Y-m-d H:i:s'),
+            'end_time' => now()->addHour()->format('Y-m-d H:i:s'),
+        ]);
+        $response->assertStatus(422);
+    }
+
+    public function test_cancelled_booking_does_not_block_slot(): void
+    {
+        // Create and cancel a booking
+        $booking = Booking::create([
+            'user_id' => $this->user->id,
+            'lot_id' => $this->lot->id,
+            'slot_id' => $this->slot->id,
+            'start_time' => now()->addDay()->setHour(9),
+            'end_time' => now()->addDay()->setHour(17),
+            'status' => Booking::STATUS_CANCELLED,
+        ]);
+
+        // Same slot same time should work since previous was cancelled
+        $response = $this->actingAs($this->otherUser)->postJson('/api/bookings', [
+            'lot_id' => $this->lot->id,
+            'slot_id' => $this->slot->id,
+            'start_time' => now()->addDay()->setHour(9)->format('Y-m-d H:i:s'),
+            'end_time' => now()->addDay()->setHour(17)->format('Y-m-d H:i:s'),
+        ]);
+        $response->assertStatus(201);
+    }
+
+    public function test_auto_assign_slot_when_not_provided(): void
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/bookings', [
+            'lot_id' => $this->lot->id,
+            'start_time' => now()->addDay()->setHour(9)->format('Y-m-d H:i:s'),
+            'end_time' => now()->addDay()->setHour(17)->format('Y-m-d H:i:s'),
+        ]);
+        $response->assertStatus(201);
+    }
+
+    public function test_no_slots_available_returns_409(): void
+    {
+        // Book the only slot
+        Booking::create([
+            'user_id' => $this->user->id,
+            'lot_id' => $this->lot->id,
+            'slot_id' => $this->slot->id,
+            'start_time' => now()->addDay()->setHour(9),
+            'end_time' => now()->addDay()->setHour(17),
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+
+        // Try to book without slot_id — no slots available
+        $response = $this->actingAs($this->otherUser)->postJson('/api/bookings', [
+            'lot_id' => $this->lot->id,
+            'start_time' => now()->addDay()->setHour(10)->format('Y-m-d H:i:s'),
+            'end_time' => now()->addDay()->setHour(16)->format('Y-m-d H:i:s'),
+        ]);
+        $response->assertStatus(409);
+    }
+}

--- a/tests/Feature/FormRequestValidationTest.php
+++ b/tests/Feature/FormRequestValidationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ParkingLot;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FormRequestValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_requires_username_and_password(): void
+    {
+        $this->postJson('/api/login', [])
+            ->assertStatus(422);
+    }
+
+    public function test_register_validates_password_complexity(): void
+    {
+        $this->postJson('/api/register', [
+            'username' => 'testuser',
+            'email' => 'test@example.com',
+            'password' => 'weak',
+            'password_confirmation' => 'weak',
+            'name' => 'Test User',
+        ])
+            ->assertStatus(422);
+    }
+
+    public function test_register_validates_email_uniqueness(): void
+    {
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        $this->postJson('/api/register', [
+            'username' => 'newuser',
+            'email' => 'taken@example.com',
+            'password' => 'ValidPass1',
+            'password_confirmation' => 'ValidPass1',
+            'name' => 'New User',
+        ])
+            ->assertStatus(422);
+    }
+
+    public function test_register_validates_username_uniqueness(): void
+    {
+        User::factory()->create(['username' => 'existing']);
+
+        $this->postJson('/api/register', [
+            'username' => 'existing',
+            'email' => 'new@example.com',
+            'password' => 'ValidPass1',
+            'password_confirmation' => 'ValidPass1',
+            'name' => 'New User',
+        ])
+            ->assertStatus(422);
+    }
+
+    public function test_register_succeeds_with_valid_data(): void
+    {
+        $this->postJson('/api/register', [
+            'username' => 'validuser',
+            'email' => 'valid@example.com',
+            'password' => 'ValidPass1',
+            'password_confirmation' => 'ValidPass1',
+            'name' => 'Valid User',
+        ])
+            ->assertStatus(201);
+    }
+
+    public function test_booking_requires_lot_id(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/bookings', [
+            'start_time' => now()->addDay()->format('Y-m-d H:i:s'),
+        ])
+            ->assertStatus(422);
+    }
+
+    public function test_booking_requires_start_time(): void
+    {
+        $user = User::factory()->create();
+        $lot = ParkingLot::create(['name' => 'Test', 'total_slots' => 5]);
+
+        $this->actingAs($user)->postJson('/api/bookings', [
+            'lot_id' => $lot->id,
+        ])
+            ->assertStatus(422);
+    }
+
+    public function test_vehicle_requires_plate(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/vehicles', [
+            'make' => 'BMW',
+        ])
+            ->assertStatus(422);
+    }
+
+    public function test_vehicle_plate_max_length(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/vehicles', [
+            'plate' => str_repeat('X', 21),
+        ])
+            ->assertStatus(422);
+    }
+
+    public function test_vehicle_create_succeeds_with_valid_data(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/vehicles', [
+            'plate' => 'AB-CD-1234',
+            'make' => 'BMW',
+            'model' => '320i',
+            'color' => 'black',
+        ])
+            ->assertStatus(201);
+    }
+
+    public function test_change_password_requires_current_password(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/auth/change-password', [
+            'new_password' => 'NewPass123',
+        ])
+            ->assertStatus(422);
+    }
+
+    public function test_change_password_validates_complexity(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/auth/change-password', [
+            'current_password' => 'password',
+            'new_password' => 'nouppercaseornumber',
+        ])
+            ->assertStatus(422);
+    }
+}

--- a/tests/Feature/PublicEndpointTest.php
+++ b/tests/Feature/PublicEndpointTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Announcement;
+use App\Models\ParkingLot;
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublicEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_health_check(): void
+    {
+        $this->getJson('/api/health')
+            ->assertStatus(200)
+            ->assertJsonStructure(['status', 'version']);
+    }
+
+    public function test_legal_privacy(): void
+    {
+        $this->getJson('/api/legal/privacy')
+            ->assertStatus(200)
+            ->assertJsonPath('data.type', 'privacy');
+    }
+
+    public function test_legal_impressum(): void
+    {
+        $this->getJson('/api/legal/impressum')
+            ->assertStatus(200)
+            ->assertJsonPath('data.type', 'impressum');
+    }
+
+    public function test_public_occupancy(): void
+    {
+        ParkingLot::create(['name' => 'Public Test', 'total_slots' => 10]);
+
+        $this->getJson('/api/public/occupancy')
+            ->assertStatus(200);
+    }
+
+    public function test_public_display(): void
+    {
+        ParkingLot::create(['name' => 'Display Test', 'total_slots' => 5]);
+
+        $this->getJson('/api/public/display')
+            ->assertStatus(200);
+    }
+
+    public function test_setup_status(): void
+    {
+        $this->getJson('/api/setup/status')
+            ->assertStatus(200);
+    }
+
+    public function test_metrics_endpoint_accessible(): void
+    {
+        $this->get('/api/metrics')
+            ->assertStatus(200)
+            ->assertHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+    }
+
+    public function test_v1_health_check(): void
+    {
+        $this->getJson('/api/v1/health')
+            ->assertStatus(200);
+    }
+
+    public function test_v1_branding(): void
+    {
+        Setting::set('company_name', 'TestCorp');
+
+        $this->getJson('/api/v1/branding')
+            ->assertStatus(200);
+    }
+
+    public function test_v1_vapid_key(): void
+    {
+        $this->getJson('/api/v1/push/vapid-key')
+            ->assertStatus(200);
+    }
+
+    public function test_v1_active_announcements(): void
+    {
+        Announcement::create([
+            'title' => 'Test',
+            'message' => 'Hello',
+            'severity' => 'info',
+            'active' => true,
+        ]);
+
+        $this->getJson('/api/v1/announcements/active')
+            ->assertStatus(200);
+    }
+}

--- a/tests/Unit/Models/BookingModelTest.php
+++ b/tests/Unit/Models/BookingModelTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BookingModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_booking_has_fillable_attributes(): void
+    {
+        $booking = new Booking;
+        $this->assertContains('user_id', $booking->getFillable());
+        $this->assertContains('lot_id', $booking->getFillable());
+        $this->assertContains('slot_id', $booking->getFillable());
+        $this->assertContains('status', $booking->getFillable());
+    }
+
+    public function test_booking_status_constants(): void
+    {
+        $this->assertEquals('confirmed', Booking::STATUS_CONFIRMED);
+        $this->assertEquals('active', Booking::STATUS_ACTIVE);
+        $this->assertEquals('cancelled', Booking::STATUS_CANCELLED);
+        $this->assertEquals('completed', Booking::STATUS_COMPLETED);
+        $this->assertEquals('no_show', Booking::STATUS_NO_SHOW);
+    }
+
+    public function test_booking_uses_uuid(): void
+    {
+        $user = User::factory()->create();
+        $lot = ParkingLot::create(['name' => 'Test', 'total_slots' => 5]);
+        $slot = ParkingSlot::create(['lot_id' => $lot->id, 'slot_number' => '001', 'status' => 'available']);
+
+        $booking = Booking::create([
+            'user_id' => $user->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHours(4),
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $booking->id);
+    }
+
+    public function test_booking_belongs_to_user(): void
+    {
+        $booking = new Booking;
+        $this->assertInstanceOf(BelongsTo::class, $booking->user());
+    }
+
+    public function test_booking_belongs_to_lot(): void
+    {
+        $booking = new Booking;
+        $this->assertInstanceOf(BelongsTo::class, $booking->lot());
+    }
+
+    public function test_booking_belongs_to_slot(): void
+    {
+        $booking = new Booking;
+        $this->assertInstanceOf(BelongsTo::class, $booking->slot());
+    }
+
+    public function test_booking_has_many_notes(): void
+    {
+        $booking = new Booking;
+        $this->assertInstanceOf(HasMany::class, $booking->bookingNotes());
+    }
+
+    public function test_start_time_cast_to_datetime(): void
+    {
+        $user = User::factory()->create();
+        $lot = ParkingLot::create(['name' => 'Test', 'total_slots' => 5]);
+        $slot = ParkingSlot::create(['lot_id' => $lot->id, 'slot_number' => '001', 'status' => 'available']);
+
+        $booking = Booking::create([
+            'user_id' => $user->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'start_time' => '2026-06-01 08:00:00',
+            'end_time' => '2026-06-01 17:00:00',
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+
+        $this->assertInstanceOf(Carbon::class, $booking->start_time);
+        $this->assertInstanceOf(Carbon::class, $booking->end_time);
+    }
+
+    public function test_pricing_fields_are_decimal_cast(): void
+    {
+        $booking = new Booking;
+        $casts = $booking->getCasts();
+        $this->assertEquals('decimal:2', $casts['base_price']);
+        $this->assertEquals('decimal:2', $casts['tax_amount']);
+        $this->assertEquals('decimal:2', $casts['total_price']);
+    }
+}

--- a/tests/Unit/Models/ParkingLotModelTest.php
+++ b/tests/Unit/Models/ParkingLotModelTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\ParkingLot;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ParkingLotModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lot_has_fillable_attributes(): void
+    {
+        $lot = new ParkingLot;
+        $this->assertContains('name', $lot->getFillable());
+        $this->assertContains('address', $lot->getFillable());
+        $this->assertContains('total_slots', $lot->getFillable());
+    }
+
+    public function test_lot_has_slots_relationship(): void
+    {
+        $lot = new ParkingLot;
+        $this->assertInstanceOf(HasMany::class, $lot->slots());
+    }
+
+    public function test_lot_has_zones_relationship(): void
+    {
+        $lot = new ParkingLot;
+        $this->assertInstanceOf(HasMany::class, $lot->zones());
+    }
+
+    public function test_lot_has_bookings_relationship(): void
+    {
+        $lot = new ParkingLot;
+        $this->assertInstanceOf(HasMany::class, $lot->bookings());
+    }
+
+    public function test_layout_cast_to_array(): void
+    {
+        $lot = ParkingLot::create([
+            'name' => 'Test Lot',
+            'total_slots' => 5,
+            'layout' => ['rows' => [['id' => 'r1', 'slots' => []]]],
+        ]);
+
+        $this->assertIsArray($lot->layout);
+        $this->assertArrayHasKey('rows', $lot->layout);
+    }
+
+    public function test_pricing_fields_are_decimal_cast(): void
+    {
+        $lot = new ParkingLot;
+        $casts = $lot->getCasts();
+        $this->assertEquals('decimal:2', $casts['hourly_rate']);
+        $this->assertEquals('decimal:2', $casts['daily_max']);
+        $this->assertEquals('decimal:2', $casts['monthly_pass']);
+    }
+
+    public function test_lot_uses_uuid(): void
+    {
+        $lot = ParkingLot::create(['name' => 'UUID Test', 'total_slots' => 1]);
+        $this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $lot->id);
+    }
+}

--- a/tests/Unit/Models/UserModelTest.php
+++ b/tests/Unit/Models/UserModelTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_has_fillable_attributes(): void
+    {
+        $user = new User;
+        $this->assertContains('username', $user->getFillable());
+        $this->assertContains('email', $user->getFillable());
+        $this->assertContains('password', $user->getFillable());
+        $this->assertContains('name', $user->getFillable());
+    }
+
+    public function test_role_is_not_fillable(): void
+    {
+        $user = new User;
+        $this->assertNotContains('role', $user->getFillable());
+    }
+
+    public function test_password_is_hidden(): void
+    {
+        $user = new User;
+        $this->assertContains('password', $user->getHidden());
+    }
+
+    public function test_is_admin_returns_true_for_admin_role(): void
+    {
+        $user = new User;
+        $user->role = 'admin';
+        $this->assertTrue($user->isAdmin());
+    }
+
+    public function test_is_admin_returns_true_for_superadmin_role(): void
+    {
+        $user = new User;
+        $user->role = 'superadmin';
+        $this->assertTrue($user->isAdmin());
+    }
+
+    public function test_is_admin_returns_false_for_user_role(): void
+    {
+        $user = new User;
+        $user->role = 'user';
+        $this->assertFalse($user->isAdmin());
+    }
+
+    public function test_is_premium_returns_true_for_premium_role(): void
+    {
+        $user = new User;
+        $user->role = 'premium';
+        $this->assertTrue($user->isPremium());
+    }
+
+    public function test_is_premium_returns_false_for_user_role(): void
+    {
+        $user = new User;
+        $user->role = 'user';
+        $this->assertFalse($user->isPremium());
+    }
+
+    public function test_user_has_bookings_relationship(): void
+    {
+        $user = User::factory()->create();
+        $this->assertInstanceOf(HasMany::class, $user->bookings());
+    }
+
+    public function test_user_has_vehicles_relationship(): void
+    {
+        $user = User::factory()->create();
+        $this->assertInstanceOf(HasMany::class, $user->vehicles());
+    }
+
+    public function test_user_has_absences_relationship(): void
+    {
+        $user = User::factory()->create();
+        $this->assertInstanceOf(HasMany::class, $user->absences());
+    }
+
+    public function test_user_has_favorites_relationship(): void
+    {
+        $user = User::factory()->create();
+        $this->assertInstanceOf(HasMany::class, $user->favorites());
+    }
+
+    public function test_user_has_recurring_bookings_relationship(): void
+    {
+        $user = User::factory()->create();
+        $this->assertInstanceOf(HasMany::class, $user->recurringBookings());
+    }
+
+    public function test_user_uses_uuid(): void
+    {
+        $user = User::factory()->create();
+        $this->assertNotNull($user->id);
+        $this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $user->id);
+    }
+
+    public function test_preferences_cast_to_array(): void
+    {
+        $user = User::factory()->create(['preferences' => ['language' => 'de', 'theme' => 'dark']]);
+        $this->assertIsArray($user->preferences);
+        $this->assertEquals('de', $user->preferences['language']);
+    }
+
+    public function test_user_soft_deletes(): void
+    {
+        $user = User::factory()->create();
+        $user->delete();
+        $this->assertSoftDeleted('users', ['id' => $user->id]);
+        $this->assertNotNull(User::withTrashed()->find($user->id));
+    }
+
+    public function test_is_active_cast_to_boolean(): void
+    {
+        $user = User::factory()->create(['is_active' => true]);
+        $this->assertIsBool($user->is_active);
+        $this->assertTrue($user->is_active);
+    }
+}

--- a/tests/Unit/Models/VehicleModelTest.php
+++ b/tests/Unit/Models/VehicleModelTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\User;
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VehicleModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_vehicle_has_fillable_attributes(): void
+    {
+        $vehicle = new Vehicle;
+        $this->assertContains('plate', $vehicle->getFillable());
+        $this->assertContains('make', $vehicle->getFillable());
+        $this->assertContains('model', $vehicle->getFillable());
+        $this->assertContains('color', $vehicle->getFillable());
+        $this->assertContains('user_id', $vehicle->getFillable());
+    }
+
+    public function test_vehicle_belongs_to_user(): void
+    {
+        $vehicle = new Vehicle;
+        $this->assertInstanceOf(BelongsTo::class, $vehicle->user());
+    }
+
+    public function test_is_default_cast_to_boolean(): void
+    {
+        $user = User::factory()->create();
+        $vehicle = Vehicle::create([
+            'user_id' => $user->id,
+            'plate' => 'AB-CD-1234',
+            'is_default' => true,
+        ]);
+
+        $this->assertIsBool($vehicle->is_default);
+        $this->assertTrue($vehicle->is_default);
+    }
+
+    public function test_vehicle_uses_uuid(): void
+    {
+        $user = User::factory()->create();
+        $vehicle = Vehicle::create([
+            'user_id' => $user->id,
+            'plate' => 'XY-ZZ-9999',
+        ]);
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $vehicle->id);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 74 new tests (512 -> 586 total)
- Unit tests for User, Booking, ParkingLot, Vehicle models
- Booking conflict edge case tests
- Form Request validation tests
- Authorization and access control tests
- Public endpoint accessibility tests

## Test plan
- [x] All 586 tests pass
- [x] Pint clean