### PR TITLE
feat: add consistent API error handling

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,9 +4,17 @@ use App\Http\Middleware\ApiResponseWrapper;
 use App\Http\Middleware\ForceJsonResponse;
 use App\Http\Middleware\RequireAdmin;
 use App\Http\Middleware\SecurityHeaders;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -32,5 +40,71 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias(['admin' => RequireAdmin::class]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        // Consistent JSON error responses for API routes
+        $exceptions->render(function (ModelNotFoundException $e, Request $request) {
+            if ($request->expectsJson() || $request->is('api/*')) {
+                return response()->json([
+                    'error' => 'NOT_FOUND',
+                    'message' => 'The requested resource was not found.',
+                ], 404);
+            }
+        });
+
+        $exceptions->render(function (NotFoundHttpException $e, Request $request) {
+            if ($request->expectsJson() || $request->is('api/*')) {
+                return response()->json([
+                    'error' => 'NOT_FOUND',
+                    'message' => $e->getMessage() ?: 'The requested endpoint does not exist.',
+                ], 404);
+            }
+        });
+
+        $exceptions->render(function (AuthenticationException $e, Request $request) {
+            if ($request->expectsJson() || $request->is('api/*')) {
+                return response()->json([
+                    'error' => 'UNAUTHENTICATED',
+                    'message' => 'Authentication required.',
+                ], 401);
+            }
+        });
+
+        $exceptions->render(function (AccessDeniedHttpException $e, Request $request) {
+            if ($request->expectsJson() || $request->is('api/*')) {
+                return response()->json([
+                    'error' => 'FORBIDDEN',
+                    'message' => $e->getMessage() ?: 'You do not have permission to perform this action.',
+                ], 403);
+            }
+        });
+
+        $exceptions->render(function (MethodNotAllowedHttpException $e, Request $request) {
+            if ($request->expectsJson() || $request->is('api/*')) {
+                return response()->json([
+                    'error' => 'METHOD_NOT_ALLOWED',
+                    'message' => 'The HTTP method is not supported for this endpoint.',
+                ], 405);
+            }
+        });
+
+        $exceptions->render(function (TooManyRequestsHttpException $e, Request $request) {
+            if ($request->expectsJson() || $request->is('api/*')) {
+                $retryAfter = $e->getHeaders()['Retry-After'] ?? null;
+
+                return response()->json([
+                    'error' => 'RATE_LIMITED',
+                    'message' => 'Too many requests. Please try again later.',
+                    'retry_after' => $retryAfter,
+                ], 429);
+            }
+        });
+
+        $exceptions->render(function (ValidationException $e, Request $request) {
+            if ($request->expectsJson() || $request->is('api/*')) {
+                return response()->json([
+                    'error' => 'VALIDATION_ERROR',
+                    'message' => $e->getMessage(),
+                    'errors' => $e->errors(),
+                ], 422);
+            }
+        });
     })->create();


### PR DESCRIPTION
## Summary
- Adds structured exception rendering for all API routes
- Consistent error response format: `{error, message, errors?}`
- Covers 404, 401, 403, 405, 422, 429 status codes
- Rate limiting responses include `retry_after` header value

## Test plan
- [x] 586 tests pass
- [x] Pint clean