### PR TITLE
feat: full module system — 22 toggleable modules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,34 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 # Generate with: php artisan vapid:generate (or use web-push-libs/webpush-php)
 # VAPID_SUBJECT=mailto:admin@your-domain.com
 
+# ── Module Toggles ──────────────────────────────────────────────────────────
+# Each module can be independently enabled (true) or disabled (false).
+# Disabled modules return 404 for their routes and are hidden from /api/v1/modules.
+# All default to true unless noted otherwise.
+
+MODULE_BOOKINGS=true
+MODULE_VEHICLES=true
+MODULE_ABSENCES=true
+MODULE_PAYMENTS=true
+MODULE_WEBHOOKS=true
+MODULE_NOTIFICATIONS=true
+MODULE_BRANDING=true
+MODULE_IMPORT=true
+MODULE_QR_CODES=true
+MODULE_FAVORITES=true
+MODULE_SWAP_REQUESTS=true
+MODULE_RECURRING_BOOKINGS=true
+MODULE_ZONES=true
+MODULE_CREDITS=true
+MODULE_METRICS=true
+MODULE_BROADCASTING=true
+MODULE_ADMIN_REPORTS=true
+MODULE_DATA_EXPORT=true
+MODULE_SETUP_WIZARD=true
+MODULE_GDPR=true
+MODULE_PUSH_NOTIFICATIONS=true
+# MODULE_STRIPE=false            # Requires Stripe API keys — disabled by default
+
 VITE_APP_NAME="${APP_NAME}"
 
 # Broadcasting — set BROADCAST_CONNECTION=soketi for self-hosted real-time events

--- a/app/Http/Controllers/Api/ModuleController.php
+++ b/app/Http/Controllers/Api/ModuleController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Providers\ModuleServiceProvider;
+use Illuminate\Http\JsonResponse;
+
+class ModuleController extends Controller
+{
+    /**
+     * GET /api/v1/modules — list all modules with their enabled state.
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json([
+            'modules' => ModuleServiceProvider::all(),
+            'version' => SystemController::appVersion(),
+        ]);
+    }
+}

--- a/app/Http/Middleware/CheckModule.php
+++ b/app/Http/Middleware/CheckModule.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Reject requests to routes whose module is disabled.
+ *
+ * Usage in route files:
+ *   Route::middleware('module:bookings')->group(fn () => …);
+ */
+class CheckModule
+{
+    public function handle(Request $request, Closure $next, string $module): Response
+    {
+        if (! config("modules.{$module}")) {
+            return response()->json([
+                'error' => 'MODULE_DISABLED',
+                'message' => "The {$module} module is not enabled",
+            ], 404);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/ModuleServiceProvider.php
+++ b/app/Providers/ModuleServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Conditionally registers per-module route files based on config/modules.php.
+ *
+ * When a module is disabled its routes are never registered, so the
+ * framework returns 404 naturally — no extra middleware needed for
+ * routes that live inside a module file.
+ */
+class ModuleServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(config_path('modules.php'), 'modules');
+    }
+
+    public function boot(): void
+    {
+        // Module route files are loaded by the route files themselves
+        // (api.php and api_v1.php) using the module_routes() helper.
+    }
+
+    /**
+     * Check whether a module is enabled.
+     */
+    public static function enabled(string $module): bool
+    {
+        return (bool) config("modules.{$module}", false);
+    }
+
+    /**
+     * Return all modules with their enabled/disabled state.
+     */
+    public static function all(): array
+    {
+        return array_map(fn ($v) => (bool) $v, config('modules', []));
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+if (! function_exists('module_enabled')) {
+    /**
+     * Check whether a module is enabled in config/modules.php.
+     */
+    function module_enabled(string $module): bool
+    {
+        return (bool) config("modules.{$module}", false);
+    }
+}
+
+if (! function_exists('module_routes')) {
+    /**
+     * Load a module route file only if the module is enabled.
+     *
+     * @param  string  $module  Module key from config/modules.php
+     * @param  string  $file  Route file name (without path), e.g. 'bookings.php'
+     * @param  array  $middleware  Additional middleware to wrap the routes
+     */
+    function module_routes(string $module, string $file, array $middleware = []): void
+    {
+        if (! module_enabled($module)) {
+            return;
+        }
+
+        $path = base_path("routes/modules/{$file}");
+        if (! file_exists($path)) {
+            return;
+        }
+
+        if (! empty($middleware)) {
+            Route::middleware($middleware)->group($path);
+        } else {
+            Route::group([], $path);
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\ApiResponseWrapper;
+use App\Http\Middleware\CheckModule;
 use App\Http\Middleware\ForceJsonResponse;
 use App\Http\Middleware\RequireAdmin;
 use App\Http\Middleware\SecurityHeaders;
@@ -37,7 +38,10 @@ return Application::configure(basePath: dirname(__DIR__))
             ApiResponseWrapper::class,
         ]);
 
-        $middleware->alias(['admin' => RequireAdmin::class]);
+        $middleware->alias([
+            'admin' => RequireAdmin::class,
+            'module' => CheckModule::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         // Consistent JSON error responses for API routes

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use App\Providers\ModuleServiceProvider;
 
 return [
     AppServiceProvider::class,
+    ModuleServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
         "phpunit/phpunit": "^11.5.50"
     },
     "autoload": {
+        "files": [
+            "app/helpers.php"
+        ],
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",

--- a/config/modules.php
+++ b/config/modules.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Module Configuration
+ *
+ * Toggle individual modules on/off via environment variables.
+ * When a module is disabled its routes are not registered (404),
+ * and the GET /api/v1/modules endpoint reflects the current state.
+ *
+ * All modules default to enabled except where noted.
+ */
+
+return [
+    'bookings' => env('MODULE_BOOKINGS', true),
+    'vehicles' => env('MODULE_VEHICLES', true),
+    'absences' => env('MODULE_ABSENCES', true),
+    'payments' => env('MODULE_PAYMENTS', true),
+    'webhooks' => env('MODULE_WEBHOOKS', true),
+    'notifications' => env('MODULE_NOTIFICATIONS', true),
+    'branding' => env('MODULE_BRANDING', true),
+    'import' => env('MODULE_IMPORT', true),
+    'qr_codes' => env('MODULE_QR_CODES', true),
+    'favorites' => env('MODULE_FAVORITES', true),
+    'swap_requests' => env('MODULE_SWAP_REQUESTS', true),
+    'recurring_bookings' => env('MODULE_RECURRING_BOOKINGS', true),
+    'zones' => env('MODULE_ZONES', true),
+    'credits' => env('MODULE_CREDITS', true),
+    'metrics' => env('MODULE_METRICS', true),
+    'broadcasting' => env('MODULE_BROADCASTING', true),
+    'admin_reports' => env('MODULE_ADMIN_REPORTS', true),
+    'data_export' => env('MODULE_DATA_EXPORT', true),
+    'setup_wizard' => env('MODULE_SETUP_WIZARD', true),
+    'gdpr' => env('MODULE_GDPR', true),
+    'push_notifications' => env('MODULE_PUSH_NOTIFICATIONS', true),
+    'stripe' => env('MODULE_STRIPE', false), // disabled by default — requires Stripe keys
+];

--- a/parkhub-web/src/App.tsx
+++ b/parkhub-web/src/App.tsx
@@ -6,6 +6,7 @@ import { AuthProvider, useAuth } from './context/AuthContext';
 import { ThemeProvider } from './context/ThemeContext';
 import { UseCaseProvider } from './context/UseCaseContext';
 import { FeaturesProvider } from './context/FeaturesContext';
+import { ModuleProvider } from './context/ModuleContext';
 import './i18n';
 
 // Eagerly loaded shell
@@ -153,6 +154,7 @@ export function App() {
         <ThemeLoader>
         <UseCaseProvider>
         <FeaturesProvider>
+        <ModuleProvider>
         <AuthProvider>
           <AppRoutes />
           <Suspense fallback={null}><DemoOverlay /></Suspense>
@@ -166,6 +168,7 @@ export function App() {
             }}
           />
         </AuthProvider>
+        </ModuleProvider>
         </FeaturesProvider>
         </UseCaseProvider>
         </ThemeLoader>

--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -70,6 +70,9 @@ export const api = {
       method: 'PUT', body: JSON.stringify({ current_password, password, password_confirmation }),
     }),
 
+  // ── Modules ──
+  getModules: () => request<{ modules: Record<string, boolean>; version: string }>('/api/v1/modules'),
+
   // ── Setup ──
   getSetupStatus: () => request<SetupStatus>('/api/v1/setup/status'),
   completeSetup: (data: any) => request('/api/v1/setup/complete', { method: 'POST', body: JSON.stringify(data) }),

--- a/parkhub-web/src/context/ModuleContext.test.tsx
+++ b/parkhub-web/src/context/ModuleContext.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ModuleProvider, useModules } from './ModuleContext';
+
+// Helper component to consume the context
+function ModuleConsumer() {
+  const { modules, version, loaded, loading, error, isModuleEnabled } = useModules();
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="loaded">{String(loaded)}</span>
+      <span data-testid="error">{error ?? 'null'}</span>
+      <span data-testid="version">{version}</span>
+      <span data-testid="bookings">{String(isModuleEnabled('bookings'))}</span>
+      <span data-testid="stripe">{String(isModuleEnabled('stripe'))}</span>
+      <span data-testid="module-count">{Object.keys(modules).length}</span>
+    </div>
+  );
+}
+
+describe('ModuleContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('useModules throws outside ModuleProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<ModuleConsumer />)).toThrow(
+      'useModules must be used within ModuleProvider',
+    );
+
+    spy.mockRestore();
+  });
+
+  it('loads modules from API and sets state', async () => {
+    const mockResponse = {
+      success: true,
+      data: {
+        modules: {
+          bookings: true,
+          vehicles: true,
+          absences: true,
+          payments: true,
+          webhooks: true,
+          notifications: true,
+          branding: true,
+          import: true,
+          qr_codes: true,
+          favorites: true,
+          swap_requests: true,
+          recurring_bookings: true,
+          zones: true,
+          credits: true,
+          metrics: true,
+          broadcasting: true,
+          admin_reports: true,
+          data_export: true,
+          setup_wizard: true,
+          gdpr: true,
+          push_notifications: true,
+          stripe: false,
+        },
+        version: '1.9.2',
+      },
+    };
+
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response);
+
+    render(
+      <ModuleProvider>
+        <ModuleConsumer />
+      </ModuleProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loaded').textContent).toBe('true');
+    });
+
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+    expect(screen.getByTestId('error').textContent).toBe('null');
+    expect(screen.getByTestId('version').textContent).toBe('1.9.2');
+    expect(screen.getByTestId('bookings').textContent).toBe('true');
+    expect(screen.getByTestId('stripe').textContent).toBe('false');
+    expect(Number(screen.getByTestId('module-count').textContent)).toBe(22);
+  });
+
+  it('falls back to defaults on network error', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+
+    render(
+      <ModuleProvider>
+        <ModuleConsumer />
+      </ModuleProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    expect(screen.getByTestId('error').textContent).toBe('Network error');
+    // Defaults: bookings enabled, stripe disabled
+    expect(screen.getByTestId('bookings').textContent).toBe('true');
+    expect(screen.getByTestId('stripe').textContent).toBe('false');
+  });
+
+  it('handles API error (non-200)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    render(
+      <ModuleProvider>
+        <ModuleConsumer />
+      </ModuleProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    expect(screen.getByTestId('error').textContent).toBe('HTTP 500');
+  });
+});

--- a/parkhub-web/src/context/ModuleContext.tsx
+++ b/parkhub-web/src/context/ModuleContext.tsx
@@ -1,0 +1,131 @@
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
+
+// ── Types ──
+
+/** All backend module keys from config/modules.php */
+export type ModuleKey =
+  | 'bookings'
+  | 'vehicles'
+  | 'absences'
+  | 'payments'
+  | 'webhooks'
+  | 'notifications'
+  | 'branding'
+  | 'import'
+  | 'qr_codes'
+  | 'favorites'
+  | 'swap_requests'
+  | 'recurring_bookings'
+  | 'zones'
+  | 'credits'
+  | 'metrics'
+  | 'broadcasting'
+  | 'admin_reports'
+  | 'data_export'
+  | 'setup_wizard'
+  | 'gdpr'
+  | 'push_notifications'
+  | 'stripe';
+
+export interface ModulesResponse {
+  modules: Record<ModuleKey, boolean>;
+  version: string;
+}
+
+interface ModuleState {
+  /** Map of module key -> enabled/disabled */
+  modules: Record<string, boolean>;
+  /** Backend version string */
+  version: string;
+  /** Whether modules have been loaded from the API */
+  loaded: boolean;
+  /** Loading state */
+  loading: boolean;
+  /** Error if fetch failed */
+  error: string | null;
+  /** Check if a specific module is enabled */
+  isModuleEnabled: (key: ModuleKey) => boolean;
+  /** Refresh modules from the API */
+  refresh: () => Promise<void>;
+}
+
+const ModuleContext = createContext<ModuleState | null>(null);
+
+// Default: all enabled (optimistic — prevents flash of hidden content)
+const DEFAULT_MODULES: Record<string, boolean> = {
+  bookings: true,
+  vehicles: true,
+  absences: true,
+  payments: true,
+  webhooks: true,
+  notifications: true,
+  branding: true,
+  import: true,
+  qr_codes: true,
+  favorites: true,
+  swap_requests: true,
+  recurring_bookings: true,
+  zones: true,
+  credits: true,
+  metrics: true,
+  broadcasting: true,
+  admin_reports: true,
+  data_export: true,
+  setup_wizard: true,
+  gdpr: true,
+  push_notifications: true,
+  stripe: false,
+};
+
+export function ModuleProvider({ children }: { children: ReactNode }) {
+  const [modules, setModules] = useState<Record<string, boolean>>(DEFAULT_MODULES);
+  const [version, setVersion] = useState('');
+  const [loaded, setLoaded] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchModules = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/v1/modules');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      // Handle wrapped response: { success, data: { modules, version } }
+      const data = json?.data ?? json;
+      if (data?.modules) {
+        setModules(data.modules);
+        setVersion(data.version ?? '');
+        setLoaded(true);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load modules');
+      // Keep defaults on error — don't break the UI
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchModules();
+  }, [fetchModules]);
+
+  const isModuleEnabled = useCallback(
+    (key: ModuleKey) => modules[key] ?? false,
+    [modules],
+  );
+
+  return (
+    <ModuleContext.Provider
+      value={{ modules, version, loaded, loading, error, isModuleEnabled, refresh: fetchModules }}
+    >
+      {children}
+    </ModuleContext.Provider>
+  );
+}
+
+export function useModules() {
+  const ctx = useContext(ModuleContext);
+  if (!ctx) throw new Error('useModules must be used within ModuleProvider');
+  return ctx;
+}

--- a/parkhub-web/src/hooks/useModule.ts
+++ b/parkhub-web/src/hooks/useModule.ts
@@ -1,0 +1,33 @@
+import { useModules, type ModuleKey } from '../context/ModuleContext';
+
+/**
+ * Check if a module is enabled. Returns { enabled, loading, loaded }.
+ *
+ * Usage:
+ *   const { enabled } = useModule('bookings');
+ *   if (!enabled) return <ModuleDisabled name="Bookings" />;
+ */
+export function useModule(key: ModuleKey) {
+  const { isModuleEnabled, loading, loaded } = useModules();
+  return {
+    enabled: isModuleEnabled(key),
+    loading,
+    loaded,
+  };
+}
+
+/**
+ * Check multiple modules at once.
+ *
+ * Usage:
+ *   const { allEnabled, anyEnabled } = useModules(['bookings', 'recurring_bookings']);
+ */
+export function useModuleGroup(keys: ModuleKey[]) {
+  const { isModuleEnabled, loading, loaded } = useModules();
+  return {
+    allEnabled: keys.every(k => isModuleEnabled(k)),
+    anyEnabled: keys.some(k => isModuleEnabled(k)),
+    loading,
+    loaded,
+  };
+}

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -3,41 +3,29 @@
 /**
  * API v1 routes — compatible with the Rust backend's endpoint structure.
  * All routes are prefixed with /api/v1 (set in bootstrap/app.php).
+ *
+ * Module-specific routes are loaded from routes/modules/*.php
+ * based on config/modules.php toggle state.
  */
 
-use App\Http\Controllers\Api\AbsenceController;
 use App\Http\Controllers\Api\AdminAnnouncementController;
 use App\Http\Controllers\Api\AdminController;
-use App\Http\Controllers\Api\AdminCreditController;
-use App\Http\Controllers\Api\AdminReportController;
 use App\Http\Controllers\Api\AdminSettingsController;
 use App\Http\Controllers\Api\AuthController;
-use App\Http\Controllers\Api\BookingController;
-use App\Http\Controllers\Api\BookingInvoiceController;
 use App\Http\Controllers\Api\DemoController;
 use App\Http\Controllers\Api\HealthController;
 use App\Http\Controllers\Api\LotController;
-use App\Http\Controllers\Api\MiscController;
-use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\ModuleController;
 use App\Http\Controllers\Api\PublicController;
-use App\Http\Controllers\Api\PulseController;
-use App\Http\Controllers\Api\RecommendationController;
-use App\Http\Controllers\Api\RecurringBookingController;
-use App\Http\Controllers\Api\SetupController;
 use App\Http\Controllers\Api\SlotController;
 use App\Http\Controllers\Api\SystemController;
 use App\Http\Controllers\Api\TeamController;
 use App\Http\Controllers\Api\TranslationController;
 use App\Http\Controllers\Api\UserController;
-use App\Http\Controllers\Api\VehicleController;
 use App\Http\Controllers\Api\WaitlistController;
-use App\Http\Controllers\Api\ZoneController;
-use App\Models\Absence;
-use App\Models\Setting;
-use App\Models\User;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
+
+// ── Core routes (always available) ──────────────────────────────────────────
 
 // Auth — rate limited: 5 attempts per minute per IP to prevent brute force
 Route::middleware('throttle:auth')->group(function () {
@@ -45,57 +33,15 @@ Route::middleware('throttle:auth')->group(function () {
     Route::post('/auth/register', [AuthController::class, 'register']);
 });
 
-// Setup — status is always public; mutation endpoints are blocked once setup is completed
-Route::get('/setup/status', [SetupController::class, 'status']);
-Route::post('/setup', [SetupController::class, 'init']);
-Route::middleware('throttle:setup')->group(function () {
-    Route::post('/setup/change-password', function (Request $request) {
-        // Guard: reject if setup is already completed
-        if (Setting::get('setup_completed') === 'true') {
-            return response()->json(['success' => false, 'error' => ['code' => 'SETUP_COMPLETED', 'message' => 'Setup has already been completed']], 403);
-        }
-        $request->validate(['current_password' => 'required', 'new_password' => 'required|min:8']);
-        $admin = User::where('role', 'admin')->first();
-        if (! $admin || ! Hash::check($request->current_password, $admin->password)) {
-            return response()->json(['success' => false, 'error' => ['code' => 'INVALID_PASSWORD', 'message' => 'Current password is incorrect']], 401);
-        }
-        $admin->password = Hash::make($request->new_password);
-        $admin->save();
-        Setting::set('needs_password_change', 'false');
-        $token = $admin->createToken('auth-token');
-
-        return response()->json(['success' => true, 'data' => [
-            'user' => $admin,
-            'tokens' => ['access_token' => $token->plainTextToken, 'token_type' => 'Bearer', 'expires_at' => now()->addDays(7)->toISOString()],
-        ]]);
-    });
-    Route::post('/setup/complete', function (Request $request) {
-        // Guard: reject if setup is already completed
-        if (Setting::get('setup_completed') === 'true') {
-            return response()->json(['success' => false, 'error' => ['code' => 'SETUP_COMPLETED', 'message' => 'Setup has already been completed']], 403);
-        }
-        Setting::set('setup_completed', 'true');
-        if ($request->company_name) {
-            Setting::set('company_name', $request->company_name);
-        }
-        if ($request->use_case) {
-            Setting::set('use_case', $request->use_case);
-        }
-
-        return response()->json(['success' => true, 'data' => ['message' => 'Setup completed']]);
-    });
+// Auth (public) — rate limited: 3 password resets per 15 min per IP
+Route::middleware('throttle:password-reset')->group(function () {
+    Route::post('/auth/forgot-password', [AuthController::class, 'forgotPassword']);
+    Route::post('/auth/reset-password', [AuthController::class, 'resetPassword']);
 });
 
 // Public
 Route::get('/public/occupancy', [PublicController::class, 'occupancy']);
 Route::get('/public/display', [PublicController::class, 'display']);
-Route::get('/theme', [AdminSettingsController::class, 'getPublicTheme']);
-
-// VAPID public key for push subscriptions
-Route::get('/push/vapid-key', [PublicController::class, 'vapidKey']);
-
-// Branding
-Route::get('/branding', [PublicController::class, 'branding']);
 
 // Announcements (public)
 Route::get('/announcements/active', [PublicController::class, 'activeAnnouncementsWrapped']);
@@ -104,30 +50,44 @@ Route::get('/announcements/active', [PublicController::class, 'activeAnnouncemen
 Route::prefix('demo')->group(function () {
     Route::get('/status', [DemoController::class, 'status']);
     Route::get('/config', [DemoController::class, 'config']);
-    // POST endpoints rate-limited: 2 per minute per IP (heavy DB operations)
     Route::middleware('throttle:demo-action')->group(function () {
         Route::post('/vote', [DemoController::class, 'vote']);
         Route::post('/reset', [DemoController::class, 'reset']);
     });
 });
 
-// Protected
+// Health (no auth)
+Route::get('/health', [PublicController::class, 'healthCheck']);
+Route::get('/health/live', [HealthController::class, 'live']);
+Route::get('/health/ready', [HealthController::class, 'ready']);
+
+// System (public)
+Route::get('/system/version', [SystemController::class, 'version']);
+Route::get('/system/maintenance', [SystemController::class, 'maintenance']);
+
+// Translation overrides (public — frontend needs runtime i18n patching without login)
+Route::get('/translations/overrides', [TranslationController::class, 'overrides']);
+
+// Modules endpoint (public — frontend uses this to discover available features)
+Route::get('/modules', [ModuleController::class, 'index']);
+
+// ── Core protected routes ───────────────────────────────────────────────────
+
 Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
     // Auth (protected)
     Route::post('/auth/refresh', [AuthController::class, 'refresh']);
+    Route::patch('/users/me/password', [AuthController::class, 'changePassword']);
 
-    // Users — /me aliases for frontend compatibility (Rust edition uses /me)
+    // Users — /me aliases for frontend compatibility
     Route::get('/me', [AuthController::class, 'me']);
     Route::put('/me', [AuthController::class, 'updateMe']);
     Route::get('/users/me', [AuthController::class, 'me']);
     Route::put('/users/me', [AuthController::class, 'updateMe']);
-    Route::get('/users/me/export', [UserController::class, 'export']);
 
     // Feature flags — stub for frontend compatibility
     Route::get('/features', [PublicController::class, 'featureFlags']);
-    Route::delete('/users/me/delete', [AuthController::class, 'deleteAccount']);
 
-    // Lots
+    // Lots (core — always available)
     Route::get('/lots', [LotController::class, 'index']);
     Route::post('/lots', [LotController::class, 'store']);
     Route::get('/lots/{id}', [LotController::class, 'show']);
@@ -135,77 +95,34 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
     Route::delete('/lots/{id}', [LotController::class, 'destroy']);
     Route::get('/lots/{id}/slots', [LotController::class, 'slots']);
     Route::get('/lots/{id}/occupancy', [LotController::class, 'occupancy']);
-    Route::get('/lots/{id}/layout', [LotController::class, 'show']); // Layout is part of lot detail
+    Route::get('/lots/{id}/layout', [LotController::class, 'show']);
     Route::put('/lots/{id}/layout', [LotController::class, 'update']);
 
-    // Slots
+    // Slots (core)
     Route::post('/lots/{lotId}/slots', [SlotController::class, 'store']);
     Route::put('/lots/{lotId}/slots/{slotId}', [SlotController::class, 'update']);
     Route::delete('/lots/{lotId}/slots/{slotId}', [SlotController::class, 'destroy']);
 
-    // Zones
-    Route::get('/lots/{lotId}/zones', [ZoneController::class, 'index']);
-    Route::post('/lots/{lotId}/zones', [ZoneController::class, 'store']);
-
-    // Bookings
-    Route::get('/bookings/recommendations', [RecommendationController::class, 'index']);
-    Route::get('/bookings', [BookingController::class, 'index']);
-    Route::post('/bookings', [BookingController::class, 'store']);
-    Route::get('/bookings/{id}', [BookingController::class, 'show']);
-    Route::delete('/bookings/{id}', [BookingController::class, 'destroy']);
-    Route::post('/bookings/quick', [BookingController::class, 'quickBook']);
-    Route::post('/bookings/guest', [BookingController::class, 'guestBooking']);
-    Route::post('/bookings/swap', [BookingController::class, 'swap']);
-    Route::put('/bookings/{id}/notes', [BookingController::class, 'updateNotes']);
-
-    // Recurring
-    Route::get('/recurring-bookings', [RecurringBookingController::class, 'index']);
-    Route::post('/recurring-bookings', [RecurringBookingController::class, 'store']);
-    Route::put('/recurring-bookings/{id}', [RecurringBookingController::class, 'update']);
-    Route::delete('/recurring-bookings/{id}', [RecurringBookingController::class, 'destroy']);
-
-    // Absences (maps homeoffice + vacation to unified absences)
-    Route::get('/homeoffice', function (Request $request) {
-        $user = $request->user();
-
-        // Return HomeofficeSettings format expected by Rust frontend
-        return response()->json([
-            'pattern' => ['weekdays' => []],
-            'single_days' => Absence::where('user_id', $user->id)
-                ->where('absence_type', 'homeoffice')
-                ->get()
-                ->map(fn ($a) => ['id' => $a->id, 'date' => $a->start_date, 'reason' => $a->note]),
-            'parkingSlot' => null,
-        ]);
-    });
-    Route::post('/homeoffice/days', [AbsenceController::class, 'store']);
-    Route::delete('/homeoffice/days/{id}', [AbsenceController::class, 'destroy']);
-    Route::put('/homeoffice/pattern', [AbsenceController::class, 'update']);
-    Route::get('/vacation', [AbsenceController::class, 'index']);
-    Route::post('/vacation', [AbsenceController::class, 'store']);
-    Route::delete('/vacation/{id}', [AbsenceController::class, 'destroy']);
-    Route::get('/vacation/team', [TeamController::class, 'index']);
-    Route::get('/absences', [AbsenceController::class, 'index']);
-    Route::post('/absences', [AbsenceController::class, 'store']);
-    Route::put('/absences/{id}', [AbsenceController::class, 'update']);
-    Route::delete('/absences/{id}', [AbsenceController::class, 'destroy']);
-
-    // Vehicles
-    Route::get('/vehicles', [VehicleController::class, 'index']);
-    Route::post('/vehicles', [VehicleController::class, 'store']);
-    Route::put('/vehicles/{id}', [VehicleController::class, 'update']);
-    Route::delete('/vehicles/{id}', [VehicleController::class, 'destroy']);
-
     // Team
     Route::get('/team', [TeamController::class, 'index']);
+    Route::get('/team/today', [TeamController::class, 'today']);
 
-    // Admin — middleware enforces admin role at the routing layer (defense in depth)
+    // User preferences & stats
+    Route::get('/user/preferences', [UserController::class, 'preferences']);
+    Route::put('/user/preferences', [UserController::class, 'updatePreferences']);
+    Route::get('/user/stats', [UserController::class, 'stats']);
+
+    // Translation management
+    Route::get('/translations/proposals', [TranslationController::class, 'proposals']);
+    Route::get('/translations/proposals/{id}', [TranslationController::class, 'showProposal']);
+    Route::post('/translations/proposals', [TranslationController::class, 'createProposal']);
+    Route::post('/translations/proposals/{id}/vote', [TranslationController::class, 'vote']);
+    Route::put('/translations/proposals/{id}/review', [TranslationController::class, 'review']);
+
+    Route::get('/update/check', [PublicController::class, 'updateCheck']);
+
+    // Admin — core admin routes (always available)
     Route::middleware('admin')->prefix('admin')->group(function () {
-        // Reports & stats
-        Route::get('/stats', [AdminReportController::class, 'stats']);
-        Route::get('/heatmap', [AdminReportController::class, 'heatmap']);
-        Route::get('/users/export-csv', [AdminReportController::class, 'exportUsersCsv']);
-
         // Audit log
         Route::get('/audit-log', [AdminController::class, 'auditLog']);
 
@@ -213,17 +130,18 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
         Route::get('/settings', [AdminSettingsController::class, 'getSettings']);
         Route::put('/settings', [AdminSettingsController::class, 'updateSettings']);
         Route::get('/settings/use-case', [AdminSettingsController::class, 'getUseCase']);
+        Route::get('/settings/auto-release', [AdminSettingsController::class, 'getAutoReleaseSettings']);
+        Route::put('/settings/auto-release', [AdminSettingsController::class, 'updateAutoReleaseSettings']);
+        Route::get('/settings/email', [AdminSettingsController::class, 'getEmailSettings']);
+        Route::put('/settings/email', [AdminSettingsController::class, 'updateEmailSettings']);
+        Route::get('/settings/webhooks', [AdminSettingsController::class, 'getWebhookSettings']);
+        Route::put('/settings/webhooks', [AdminSettingsController::class, 'updateWebhookSettings']);
+        Route::post('/reset', [AdminSettingsController::class, 'resetDatabase']);
 
         // User management
         Route::get('/users', [AdminController::class, 'users']);
         Route::put('/users/{id}', [AdminController::class, 'updateUser']);
-        Route::post('/users/import', [AdminController::class, 'importUsers']);
-
-        // Bookings
-        Route::get('/bookings', [AdminController::class, 'bookings']);
-        Route::patch('/bookings/{id}/cancel', [AdminController::class, 'cancelBooking']);
-        Route::get('/guest-bookings', [AdminController::class, 'guestBookings']);
-        Route::patch('/guest-bookings/{id}/cancel', [AdminController::class, 'cancelGuestBooking']);
+        Route::delete('/users/{id}', [AdminController::class, 'deleteUser']);
 
         // Announcements
         Route::get('/announcements', [AdminAnnouncementController::class, 'announcements']);
@@ -233,187 +151,40 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
 
         Route::get('/updates/check', [PublicController::class, 'updateCheck']);
 
-        // Credits management
-        Route::put('/users/{id}/quota', [AdminCreditController::class, 'updateUserQuota']);
-        Route::post('/users/{id}/credits', [AdminCreditController::class, 'grantCredits']);
-        Route::get('/credits/transactions', [AdminCreditController::class, 'creditTransactions']);
-        Route::post('/credits/refill-all', [AdminCreditController::class, 'refillAllCredits']);
-
         // Feature flags — stub for frontend compatibility
         Route::get('/features', [PublicController::class, 'adminFeatureFlags']);
         Route::put('/features', [PublicController::class, 'adminFeatureFlags']);
 
-        // System pulse / monitoring
-        Route::get('/pulse', [PulseController::class, 'index']);
+        // Lot/slot admin
+        Route::patch('/slots/{id}', [AdminController::class, 'updateSlot']);
+        Route::delete('/lots/{id}', [AdminController::class, 'deleteLot']);
     });
 
-    // Notifications
-    Route::get('/notifications', [UserController::class, 'notifications']);
-    Route::put('/notifications/{id}/read', [UserController::class, 'markNotificationRead']);
-
-    // User preferences
-    Route::get('/user/preferences', [UserController::class, 'preferences']);
-    Route::put('/user/preferences', [UserController::class, 'updatePreferences']);
-    Route::get('/user/stats', [UserController::class, 'stats']);
-    Route::get('/user/credits', [UserController::class, 'credits']);
-    Route::get('/user/favorites', [UserController::class, 'favorites']);
-    Route::post('/user/favorites', [UserController::class, 'addFavorite']);
-    Route::delete('/user/favorites/{slotId}', [UserController::class, 'removeFavorite']);
-
-    // Calendar
-    Route::get('/calendar', [BookingController::class, 'index']);
-
-    // Push / Webhooks / QR
-    Route::post('/push/subscribe', [MiscController::class, 'pushSubscribe']);
-    Route::get('/webhooks', [MiscController::class, 'webhooks']);
-    Route::post('/webhooks', [MiscController::class, 'createWebhook']);
-    Route::put('/webhooks/{id}', [MiscController::class, 'updateWebhook']);
-    Route::delete('/webhooks/{id}', [MiscController::class, 'deleteWebhook']);
-    Route::post('/webhooks/{id}/test', [MiscController::class, 'testWebhook']);
-    Route::get('/update/check', [PublicController::class, 'updateCheck']);
-
-    // Translation management (overrides is public — see above)
-    Route::get('/translations/proposals', [TranslationController::class, 'proposals']);
-    Route::get('/translations/proposals/{id}', [TranslationController::class, 'showProposal']);
-    Route::post('/translations/proposals', [TranslationController::class, 'createProposal']);
-    Route::post('/translations/proposals/{id}/vote', [TranslationController::class, 'vote']);
-    Route::put('/translations/proposals/{id}/review', [TranslationController::class, 'review']);
-});
-
-// ── New feature-parity routes ──────────────────────────────────────────────
-
-// Health (no auth)
-Route::get('/health', [PublicController::class, 'healthCheck']);
-Route::get('/health/live', [HealthController::class, 'live']);
-Route::get('/health/ready', [HealthController::class, 'ready']);
-
-// Impressum — public (DDG § 5 requires it to be freely accessible)
-Route::get('/legal/impressum', [AdminSettingsController::class, 'publicImpress']);
-
-Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
-    // iCal export
-    Route::get('/user/calendar.ics', [UserController::class, 'calendarExport']);
-
-    // Invoice (HTML, printer-friendly — use browser "Print → Save as PDF")
-    Route::get('/bookings/{id}/invoice', [BookingInvoiceController::class, 'show']);
-
-    // GDPR data export
-    Route::get('/user/export', [UserController::class, 'exportData']);
-
-    // Vehicle photos
-    Route::post('/vehicles/{id}/photo', [VehicleController::class, 'uploadPhoto']);
-    Route::get('/vehicles/{id}/photo', [VehicleController::class, 'servePhoto']);
-
-    // City codes (no photo auth needed but put behind auth to avoid abuse)
-    Route::get('/vehicles/city-codes', [VehicleController::class, 'cityCodes']);
-
-    // Waitlist
+    // Waitlist (core)
     Route::get('/waitlist', [WaitlistController::class, 'index']);
     Route::post('/waitlist', [WaitlistController::class, 'store']);
     Route::delete('/waitlist/{id}', [WaitlistController::class, 'destroy']);
-
-    // Admin CSV export
-    Route::middleware('admin')->get('/admin/bookings/export', [AdminReportController::class, 'exportBookingsCsv']);
 });
 
-// ── Feature parity batch 2: system, auth, bookings, absences ──────────────
+// ── Module routes (conditionally loaded) ────────────────────────────────────
 
-// System (public)
-Route::get('/system/version', [SystemController::class, 'version']);
-Route::get('/system/maintenance', [SystemController::class, 'maintenance']);
-
-// Auth (public) — rate limited: 3 password resets per 15 min per IP
-Route::middleware('throttle:password-reset')->group(function () {
-    Route::post('/auth/forgot-password', [AuthController::class, 'forgotPassword']);
-    Route::post('/auth/reset-password', [AuthController::class, 'resetPassword']);
-});
-
-// Branding logo (public)
-Route::get('/branding/logo', [AdminSettingsController::class, 'serveBrandingLogo']);
-
-// Translation overrides (public — frontend needs runtime i18n patching without login)
-Route::get('/translations/overrides', [TranslationController::class, 'overrides']);
-
-Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
-
-    // Auth (protected)
-    Route::patch('/users/me/password', [AuthController::class, 'changePassword']);
-
-    // Bookings
-    Route::patch('/bookings/{id}', [BookingController::class, 'update']);
-    Route::post('/bookings/{id}/checkin', [BookingController::class, 'checkin']);
-    Route::post('/bookings/{id}/extend', [BookingController::class, 'extend']);
-    Route::get('/calendar/events', [BookingController::class, 'calendarEvents']);
-    Route::get('/swap-requests', [BookingController::class, 'swapRequests']);
-    Route::post('/bookings/{id}/swap-request', [BookingController::class, 'createSwapRequest']);
-    Route::put('/swap-requests/{id}', [BookingController::class, 'respondSwapRequest']);
-
-    // iCal import (absences + vacation)
-    Route::post('/absences/import', [AbsenceController::class, 'importIcal']);
-    Route::post('/vacation/import', [AbsenceController::class, 'importIcal']);
-
-    // Absence pattern + team
-    Route::get('/absences/pattern', [AbsenceController::class, 'getPattern']);
-    Route::post('/absences/pattern', [AbsenceController::class, 'setPattern']);
-    Route::get('/absences/team', [AbsenceController::class, 'teamAbsences']);
-    Route::get('/vacation/team', [AbsenceController::class, 'teamAbsences']);
-
-    // Team today
-    Route::get('/team/today', [TeamController::class, 'today']);
-
-    // Notifications: mark all read
-    Route::post('/notifications/read-all', [UserController::class, 'markAllNotificationsRead']);
-
-    // Push: unsubscribe
-    Route::delete('/push/unsubscribe', [UserController::class, 'pushUnsubscribe']);
-
-    // GDPR Art. 17 — Right to Erasure (anonymize, not hard-delete)
-    Route::post('/users/me/anonymize', [UserController::class, 'anonymizeAccount']);
-
-    // QR codes
-    Route::get('/lots/{id}/qr', [LotController::class, 'qrCode']);
-    Route::get('/lots/{lotId}/slots/{slotId}/qr', [LotController::class, 'slotQrCode']);
-
-    // Admin: branding, privacy, reports, charts, settings, reset
-    Route::middleware('admin')->prefix('admin')->group(function () {
-        // Settings (branding, privacy, impressum, auto-release, email, webhooks, reset)
-        Route::get('/branding', [AdminSettingsController::class, 'getBranding']);
-        Route::put('/branding', [AdminSettingsController::class, 'updateBranding']);
-        Route::post('/branding/logo', [AdminSettingsController::class, 'uploadBrandingLogo']);
-        Route::get('/privacy', [AdminSettingsController::class, 'getPrivacy']);
-        Route::put('/privacy', [AdminSettingsController::class, 'updatePrivacy']);
-        Route::get('/impressum', [AdminSettingsController::class, 'getImpress']);
-        Route::put('/impressum', [AdminSettingsController::class, 'updateImpress']);
-        Route::post('/reset', [AdminSettingsController::class, 'resetDatabase']);
-        Route::get('/settings/auto-release', [AdminSettingsController::class, 'getAutoReleaseSettings']);
-        Route::put('/settings/auto-release', [AdminSettingsController::class, 'updateAutoReleaseSettings']);
-        Route::get('/settings/email', [AdminSettingsController::class, 'getEmailSettings']);
-        Route::put('/settings/email', [AdminSettingsController::class, 'updateEmailSettings']);
-        Route::get('/settings/webhooks', [AdminSettingsController::class, 'getWebhookSettings']);
-        Route::put('/settings/webhooks', [AdminSettingsController::class, 'updateWebhookSettings']);
-
-        // Reports
-        Route::get('/reports', [AdminReportController::class, 'reports']);
-        Route::get('/dashboard/charts', [AdminReportController::class, 'dashboardCharts']);
-
-        // User/lot/slot management
-        Route::patch('/slots/{id}', [AdminController::class, 'updateSlot']);
-        Route::delete('/lots/{id}', [AdminController::class, 'deleteLot']);
-        Route::delete('/users/{id}', [AdminController::class, 'deleteUser']);
-
-        // System pulse / monitoring
-        Route::get('/pulse', [PulseController::class, 'index']);
-    });
-});
-
-// ── Stripe Payments ────────────────────────────────────────────────────────
-
-// Stripe webhook (no auth — Stripe signs the payload)
-Route::post('/payments/webhook', [PaymentController::class, 'webhook']);
-
-Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
-    // Stripe Payments (stub — Rust API parity)
-    Route::post('/payments/create-intent', [PaymentController::class, 'createIntent']);
-    Route::post('/payments/confirm', [PaymentController::class, 'confirm']);
-    Route::get('/payments/{id}/status', [PaymentController::class, 'status']);
-});
+module_routes('bookings', 'bookings.php');
+module_routes('vehicles', 'vehicles.php');
+module_routes('absences', 'absences.php');
+module_routes('payments', 'payments.php');
+module_routes('webhooks', 'webhooks.php');
+module_routes('notifications', 'notifications.php');
+module_routes('branding', 'branding.php');
+module_routes('import', 'import.php');
+module_routes('qr_codes', 'qr_codes.php');
+module_routes('favorites', 'favorites.php');
+module_routes('swap_requests', 'swap_requests.php');
+module_routes('recurring_bookings', 'recurring_bookings.php');
+module_routes('zones', 'zones.php');
+module_routes('credits', 'credits.php');
+module_routes('metrics', 'metrics.php');
+module_routes('admin_reports', 'admin_reports.php');
+module_routes('data_export', 'data_export.php');
+module_routes('setup_wizard', 'setup_wizard.php');
+module_routes('gdpr', 'gdpr.php');
+module_routes('push_notifications', 'push_notifications.php');

--- a/routes/modules/absences.php
+++ b/routes/modules/absences.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Absences module routes (api/v1).
+ * Loaded only when MODULE_ABSENCES=true.
+ */
+
+use App\Http\Controllers\Api\AbsenceController;
+use App\Models\Absence;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:absences', 'auth:sanctum', 'throttle:api'])->group(function () {
+    // Homeoffice (absence aliases for Rust frontend compat)
+    Route::get('/homeoffice', function (Request $request) {
+        $user = $request->user();
+
+        return response()->json([
+            'pattern' => ['weekdays' => []],
+            'single_days' => Absence::where('user_id', $user->id)
+                ->where('absence_type', 'homeoffice')
+                ->get()
+                ->map(fn ($a) => ['id' => $a->id, 'date' => $a->start_date, 'reason' => $a->note]),
+            'parkingSlot' => null,
+        ]);
+    });
+    Route::post('/homeoffice/days', [AbsenceController::class, 'store']);
+    Route::delete('/homeoffice/days/{id}', [AbsenceController::class, 'destroy']);
+    Route::put('/homeoffice/pattern', [AbsenceController::class, 'update']);
+    Route::get('/vacation', [AbsenceController::class, 'index']);
+    Route::post('/vacation', [AbsenceController::class, 'store']);
+    Route::delete('/vacation/{id}', [AbsenceController::class, 'destroy']);
+    Route::get('/vacation/team', [AbsenceController::class, 'teamAbsences']);
+    Route::get('/absences', [AbsenceController::class, 'index']);
+    Route::post('/absences', [AbsenceController::class, 'store']);
+    Route::put('/absences/{id}', [AbsenceController::class, 'update']);
+    Route::delete('/absences/{id}', [AbsenceController::class, 'destroy']);
+    Route::post('/absences/import', [AbsenceController::class, 'importIcal']);
+    Route::post('/vacation/import', [AbsenceController::class, 'importIcal']);
+    Route::get('/absences/pattern', [AbsenceController::class, 'getPattern']);
+    Route::post('/absences/pattern', [AbsenceController::class, 'setPattern']);
+    Route::get('/absences/team', [AbsenceController::class, 'teamAbsences']);
+});

--- a/routes/modules/admin_reports.php
+++ b/routes/modules/admin_reports.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Admin Reports module routes (api/v1).
+ * Loaded only when MODULE_ADMIN_REPORTS=true.
+ */
+
+use App\Http\Controllers\Api\AdminReportController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:admin_reports', 'auth:sanctum', 'throttle:api', 'admin'])->prefix('admin')->group(function () {
+    Route::get('/stats', [AdminReportController::class, 'stats']);
+    Route::get('/heatmap', [AdminReportController::class, 'heatmap']);
+    Route::get('/users/export-csv', [AdminReportController::class, 'exportUsersCsv']);
+    Route::get('/reports', [AdminReportController::class, 'reports']);
+    Route::get('/dashboard/charts', [AdminReportController::class, 'dashboardCharts']);
+});

--- a/routes/modules/bookings.php
+++ b/routes/modules/bookings.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Bookings module routes (api/v1).
+ * Loaded only when MODULE_BOOKINGS=true.
+ */
+
+use App\Http\Controllers\Api\AdminController;
+use App\Http\Controllers\Api\AdminReportController;
+use App\Http\Controllers\Api\BookingController;
+use App\Http\Controllers\Api\BookingInvoiceController;
+use App\Http\Controllers\Api\RecommendationController;
+use Illuminate\Support\Facades\Route;
+
+// Protected booking routes
+Route::middleware(['module:bookings', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/bookings/recommendations', [RecommendationController::class, 'index']);
+    Route::get('/bookings', [BookingController::class, 'index']);
+    Route::post('/bookings', [BookingController::class, 'store']);
+    Route::get('/bookings/{id}', [BookingController::class, 'show']);
+    Route::delete('/bookings/{id}', [BookingController::class, 'destroy']);
+    Route::post('/bookings/quick', [BookingController::class, 'quickBook']);
+    Route::post('/bookings/guest', [BookingController::class, 'guestBooking']);
+    Route::put('/bookings/{id}/notes', [BookingController::class, 'updateNotes']);
+    Route::patch('/bookings/{id}', [BookingController::class, 'update']);
+    Route::post('/bookings/{id}/checkin', [BookingController::class, 'checkin']);
+    Route::post('/bookings/{id}/extend', [BookingController::class, 'extend']);
+    Route::get('/calendar', [BookingController::class, 'index']);
+    Route::get('/calendar/events', [BookingController::class, 'calendarEvents']);
+
+    // Invoice
+    Route::get('/bookings/{id}/invoice', [BookingInvoiceController::class, 'show']);
+
+    // Admin bookings
+    Route::middleware('admin')->prefix('admin')->group(function () {
+        Route::get('/bookings', [AdminController::class, 'bookings']);
+        Route::patch('/bookings/{id}/cancel', [AdminController::class, 'cancelBooking']);
+        Route::get('/guest-bookings', [AdminController::class, 'guestBookings']);
+        Route::patch('/guest-bookings/{id}/cancel', [AdminController::class, 'cancelGuestBooking']);
+        Route::get('/bookings/export', [AdminReportController::class, 'exportBookingsCsv']);
+    });
+});

--- a/routes/modules/branding.php
+++ b/routes/modules/branding.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Branding module routes (api/v1).
+ * Loaded only when MODULE_BRANDING=true.
+ */
+
+use App\Http\Controllers\Api\AdminSettingsController;
+use App\Http\Controllers\Api\PublicController;
+use Illuminate\Support\Facades\Route;
+
+// Public branding routes
+Route::middleware('module:branding')->group(function () {
+    Route::get('/branding', [PublicController::class, 'branding']);
+    Route::get('/branding/logo', [AdminSettingsController::class, 'serveBrandingLogo']);
+    Route::get('/theme', [AdminSettingsController::class, 'getPublicTheme']);
+});
+
+// Admin branding management
+Route::middleware(['module:branding', 'auth:sanctum', 'throttle:api', 'admin'])->prefix('admin')->group(function () {
+    Route::get('/branding', [AdminSettingsController::class, 'getBranding']);
+    Route::put('/branding', [AdminSettingsController::class, 'updateBranding']);
+    Route::post('/branding/logo', [AdminSettingsController::class, 'uploadBrandingLogo']);
+});

--- a/routes/modules/credits.php
+++ b/routes/modules/credits.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Credits module routes (api/v1).
+ * Loaded only when MODULE_CREDITS=true.
+ */
+
+use App\Http\Controllers\Api\AdminCreditController;
+use App\Http\Controllers\Api\UserController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:credits', 'auth:sanctum', 'throttle:api'])->group(function () {
+    // User credits
+    Route::get('/user/credits', [UserController::class, 'credits']);
+
+    // Admin credits management
+    Route::middleware('admin')->prefix('admin')->group(function () {
+        Route::put('/users/{id}/quota', [AdminCreditController::class, 'updateUserQuota']);
+        Route::post('/users/{id}/credits', [AdminCreditController::class, 'grantCredits']);
+        Route::get('/credits/transactions', [AdminCreditController::class, 'creditTransactions']);
+        Route::post('/credits/refill-all', [AdminCreditController::class, 'refillAllCredits']);
+    });
+});

--- a/routes/modules/data_export.php
+++ b/routes/modules/data_export.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Data Export module routes (api/v1).
+ * Loaded only when MODULE_DATA_EXPORT=true.
+ */
+
+use App\Http\Controllers\Api\UserController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:data_export', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/users/me/export', [UserController::class, 'export']);
+    Route::get('/user/export', [UserController::class, 'exportData']);
+    Route::get('/user/calendar.ics', [UserController::class, 'calendarExport']);
+});

--- a/routes/modules/favorites.php
+++ b/routes/modules/favorites.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Favorites module routes (api/v1).
+ * Loaded only when MODULE_FAVORITES=true.
+ */
+
+use App\Http\Controllers\Api\UserController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:favorites', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/user/favorites', [UserController::class, 'favorites']);
+    Route::post('/user/favorites', [UserController::class, 'addFavorite']);
+    Route::delete('/user/favorites/{slotId}', [UserController::class, 'removeFavorite']);
+});

--- a/routes/modules/gdpr.php
+++ b/routes/modules/gdpr.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * GDPR module routes (api/v1).
+ * Loaded only when MODULE_GDPR=true.
+ */
+
+use App\Http\Controllers\Api\AdminSettingsController;
+use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\UserController;
+use Illuminate\Support\Facades\Route;
+
+// Public privacy/impressum
+Route::middleware('module:gdpr')->group(function () {
+    Route::get('/legal/impressum', [AdminSettingsController::class, 'publicImpress']);
+});
+
+Route::middleware(['module:gdpr', 'auth:sanctum', 'throttle:api'])->group(function () {
+    // Account deletion
+    Route::delete('/users/me/delete', [AuthController::class, 'deleteAccount']);
+
+    // GDPR Art. 17 — Right to Erasure
+    Route::post('/users/me/anonymize', [UserController::class, 'anonymizeAccount']);
+
+    // Admin privacy settings
+    Route::middleware('admin')->prefix('admin')->group(function () {
+        Route::get('/privacy', [AdminSettingsController::class, 'getPrivacy']);
+        Route::put('/privacy', [AdminSettingsController::class, 'updatePrivacy']);
+        Route::get('/impressum', [AdminSettingsController::class, 'getImpress']);
+        Route::put('/impressum', [AdminSettingsController::class, 'updateImpress']);
+    });
+});

--- a/routes/modules/import.php
+++ b/routes/modules/import.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Import module routes (api/v1).
+ * Loaded only when MODULE_IMPORT=true.
+ */
+
+use App\Http\Controllers\Api\AdminController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:import', 'auth:sanctum', 'throttle:api', 'admin'])->prefix('admin')->group(function () {
+    Route::post('/users/import', [AdminController::class, 'importUsers']);
+});

--- a/routes/modules/metrics.php
+++ b/routes/modules/metrics.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Metrics module routes (api/v1).
+ * Loaded only when MODULE_METRICS=true.
+ */
+
+use App\Http\Controllers\Api\PulseController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:metrics', 'auth:sanctum', 'throttle:api', 'admin'])->prefix('admin')->group(function () {
+    Route::get('/pulse', [PulseController::class, 'index']);
+});

--- a/routes/modules/notifications.php
+++ b/routes/modules/notifications.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Notifications module routes (api/v1).
+ * Loaded only when MODULE_NOTIFICATIONS=true.
+ */
+
+use App\Http\Controllers\Api\UserController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:notifications', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/notifications', [UserController::class, 'notifications']);
+    Route::put('/notifications/{id}/read', [UserController::class, 'markNotificationRead']);
+    Route::post('/notifications/read-all', [UserController::class, 'markAllNotificationsRead']);
+});

--- a/routes/modules/payments.php
+++ b/routes/modules/payments.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Payments module routes (api/v1).
+ * Loaded only when MODULE_PAYMENTS=true.
+ */
+
+use App\Http\Controllers\Api\PaymentController;
+use Illuminate\Support\Facades\Route;
+
+// Stripe webhook (no auth — Stripe signs the payload)
+Route::middleware('module:payments')->group(function () {
+    Route::post('/payments/webhook', [PaymentController::class, 'webhook']);
+});
+
+Route::middleware(['module:payments', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::post('/payments/create-intent', [PaymentController::class, 'createIntent']);
+    Route::post('/payments/confirm', [PaymentController::class, 'confirm']);
+    Route::get('/payments/{id}/status', [PaymentController::class, 'status']);
+});

--- a/routes/modules/push_notifications.php
+++ b/routes/modules/push_notifications.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Push Notifications module routes (api/v1).
+ * Loaded only when MODULE_PUSH_NOTIFICATIONS=true.
+ */
+
+use App\Http\Controllers\Api\MiscController;
+use App\Http\Controllers\Api\PublicController;
+use App\Http\Controllers\Api\UserController;
+use Illuminate\Support\Facades\Route;
+
+// VAPID public key (no auth)
+Route::middleware('module:push_notifications')->group(function () {
+    Route::get('/push/vapid-key', [PublicController::class, 'vapidKey']);
+});
+
+Route::middleware(['module:push_notifications', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::post('/push/subscribe', [MiscController::class, 'pushSubscribe']);
+    Route::delete('/push/unsubscribe', [UserController::class, 'pushUnsubscribe']);
+});

--- a/routes/modules/qr_codes.php
+++ b/routes/modules/qr_codes.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * QR Codes module routes (api/v1).
+ * Loaded only when MODULE_QR_CODES=true.
+ */
+
+use App\Http\Controllers\Api\LotController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:qr_codes', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/lots/{id}/qr', [LotController::class, 'qrCode']);
+    Route::get('/lots/{lotId}/slots/{slotId}/qr', [LotController::class, 'slotQrCode']);
+});

--- a/routes/modules/recurring_bookings.php
+++ b/routes/modules/recurring_bookings.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Recurring Bookings module routes (api/v1).
+ * Loaded only when MODULE_RECURRING_BOOKINGS=true.
+ * Depends on: bookings module.
+ */
+
+use App\Http\Controllers\Api\RecurringBookingController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:recurring_bookings', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/recurring-bookings', [RecurringBookingController::class, 'index']);
+    Route::post('/recurring-bookings', [RecurringBookingController::class, 'store']);
+    Route::put('/recurring-bookings/{id}', [RecurringBookingController::class, 'update']);
+    Route::delete('/recurring-bookings/{id}', [RecurringBookingController::class, 'destroy']);
+});

--- a/routes/modules/setup_wizard.php
+++ b/routes/modules/setup_wizard.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Setup Wizard module routes (api/v1).
+ * Loaded only when MODULE_SETUP_WIZARD=true.
+ */
+
+use App\Http\Controllers\Api\SetupController;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('module:setup_wizard')->group(function () {
+    Route::get('/setup/status', [SetupController::class, 'status']);
+    Route::post('/setup', [SetupController::class, 'init']);
+    Route::middleware('throttle:setup')->group(function () {
+        Route::post('/setup/change-password', function (Request $request) {
+            if (Setting::get('setup_completed') === 'true') {
+                return response()->json(['success' => false, 'error' => ['code' => 'SETUP_COMPLETED', 'message' => 'Setup has already been completed']], 403);
+            }
+            $request->validate(['current_password' => 'required', 'new_password' => 'required|min:8']);
+            $admin = User::where('role', 'admin')->first();
+            if (! $admin || ! Hash::check($request->current_password, $admin->password)) {
+                return response()->json(['success' => false, 'error' => ['code' => 'INVALID_PASSWORD', 'message' => 'Current password is incorrect']], 401);
+            }
+            $admin->password = Hash::make($request->new_password);
+            $admin->save();
+            Setting::set('needs_password_change', 'false');
+            $token = $admin->createToken('auth-token');
+
+            return response()->json(['success' => true, 'data' => [
+                'user' => $admin,
+                'tokens' => ['access_token' => $token->plainTextToken, 'token_type' => 'Bearer', 'expires_at' => now()->addDays(7)->toISOString()],
+            ]]);
+        });
+        Route::post('/setup/complete', function (Request $request) {
+            if (Setting::get('setup_completed') === 'true') {
+                return response()->json(['success' => false, 'error' => ['code' => 'SETUP_COMPLETED', 'message' => 'Setup has already been completed']], 403);
+            }
+            Setting::set('setup_completed', 'true');
+            if ($request->company_name) {
+                Setting::set('company_name', $request->company_name);
+            }
+            if ($request->use_case) {
+                Setting::set('use_case', $request->use_case);
+            }
+
+            return response()->json(['success' => true, 'data' => ['message' => 'Setup completed']]);
+        });
+    });
+});

--- a/routes/modules/stripe.php
+++ b/routes/modules/stripe.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Stripe module routes (api/v1).
+ * Loaded only when MODULE_STRIPE=true (disabled by default).
+ * Depends on: payments module.
+ *
+ * This is separate from the payments module because Stripe requires
+ * API keys and is not needed for all deployments.
+ */
+
+// Stripe-specific routes are handled by the payments module.
+// This file exists as a flag — when MODULE_STRIPE is enabled,
+// the PaymentController uses real Stripe SDK calls instead of stubs.

--- a/routes/modules/swap_requests.php
+++ b/routes/modules/swap_requests.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Swap Requests module routes (api/v1).
+ * Loaded only when MODULE_SWAP_REQUESTS=true.
+ * Depends on: bookings module.
+ */
+
+use App\Http\Controllers\Api\BookingController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:swap_requests', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::post('/bookings/swap', [BookingController::class, 'swap']);
+    Route::get('/swap-requests', [BookingController::class, 'swapRequests']);
+    Route::post('/bookings/{id}/swap-request', [BookingController::class, 'createSwapRequest']);
+    Route::put('/swap-requests/{id}', [BookingController::class, 'respondSwapRequest']);
+});

--- a/routes/modules/vehicles.php
+++ b/routes/modules/vehicles.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Vehicles module routes (api/v1).
+ * Loaded only when MODULE_VEHICLES=true.
+ */
+
+use App\Http\Controllers\Api\VehicleController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:vehicles', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/vehicles', [VehicleController::class, 'index']);
+    Route::post('/vehicles', [VehicleController::class, 'store']);
+    Route::put('/vehicles/{id}', [VehicleController::class, 'update']);
+    Route::delete('/vehicles/{id}', [VehicleController::class, 'destroy']);
+    Route::post('/vehicles/{id}/photo', [VehicleController::class, 'uploadPhoto']);
+    Route::get('/vehicles/{id}/photo', [VehicleController::class, 'servePhoto']);
+    Route::get('/vehicles/city-codes', [VehicleController::class, 'cityCodes']);
+});

--- a/routes/modules/webhooks.php
+++ b/routes/modules/webhooks.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Webhooks module routes (api/v1).
+ * Loaded only when MODULE_WEBHOOKS=true.
+ */
+
+use App\Http\Controllers\Api\MiscController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:webhooks', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/webhooks', [MiscController::class, 'webhooks']);
+    Route::post('/webhooks', [MiscController::class, 'createWebhook']);
+    Route::put('/webhooks/{id}', [MiscController::class, 'updateWebhook']);
+    Route::delete('/webhooks/{id}', [MiscController::class, 'deleteWebhook']);
+    Route::post('/webhooks/{id}/test', [MiscController::class, 'testWebhook']);
+});

--- a/routes/modules/zones.php
+++ b/routes/modules/zones.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Zones module routes (api/v1).
+ * Loaded only when MODULE_ZONES=true.
+ */
+
+use App\Http\Controllers\Api\ZoneController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:zones', 'auth:sanctum', 'throttle:api'])->group(function () {
+    Route::get('/lots/{lotId}/zones', [ZoneController::class, 'index']);
+    Route::post('/lots/{lotId}/zones', [ZoneController::class, 'store']);
+});

--- a/tests/Feature/ModuleSystemTest.php
+++ b/tests/Feature/ModuleSystemTest.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Providers\ModuleServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ModuleSystemTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Modules endpoint ────────────────────────────────────────────────
+
+    public function test_modules_endpoint_returns_all_modules(): void
+    {
+        $response = $this->getJson('/api/v1/modules');
+
+        $response->assertOk();
+        $data = $response->json('data') ?? $response->json();
+
+        // Unwrap if wrapped
+        $modules = $data['modules'] ?? $data;
+        $this->assertArrayHasKey('bookings', $modules);
+        $this->assertArrayHasKey('vehicles', $modules);
+        $this->assertArrayHasKey('absences', $modules);
+        $this->assertArrayHasKey('payments', $modules);
+        $this->assertArrayHasKey('webhooks', $modules);
+        $this->assertArrayHasKey('notifications', $modules);
+        $this->assertArrayHasKey('branding', $modules);
+        $this->assertArrayHasKey('import', $modules);
+        $this->assertArrayHasKey('qr_codes', $modules);
+        $this->assertArrayHasKey('favorites', $modules);
+        $this->assertArrayHasKey('swap_requests', $modules);
+        $this->assertArrayHasKey('recurring_bookings', $modules);
+        $this->assertArrayHasKey('zones', $modules);
+        $this->assertArrayHasKey('credits', $modules);
+        $this->assertArrayHasKey('metrics', $modules);
+        $this->assertArrayHasKey('broadcasting', $modules);
+        $this->assertArrayHasKey('admin_reports', $modules);
+        $this->assertArrayHasKey('data_export', $modules);
+        $this->assertArrayHasKey('setup_wizard', $modules);
+        $this->assertArrayHasKey('gdpr', $modules);
+        $this->assertArrayHasKey('push_notifications', $modules);
+        $this->assertArrayHasKey('stripe', $modules);
+    }
+
+    public function test_modules_endpoint_shows_correct_defaults(): void
+    {
+        $response = $this->getJson('/api/v1/modules');
+        $data = $response->json('data') ?? $response->json();
+        $modules = $data['modules'] ?? $data;
+
+        $this->assertTrue($modules['bookings']);
+        $this->assertTrue($modules['vehicles']);
+        $this->assertTrue($modules['absences']);
+        $this->assertFalse($modules['stripe']);
+    }
+
+    public function test_modules_endpoint_reflects_config_changes(): void
+    {
+        config(['modules.bookings' => false]);
+
+        $response = $this->getJson('/api/v1/modules');
+        $data = $response->json('data') ?? $response->json();
+        $modules = $data['modules'] ?? $data;
+
+        $this->assertFalse($modules['bookings']);
+    }
+
+    public function test_modules_endpoint_includes_version(): void
+    {
+        $response = $this->getJson('/api/v1/modules');
+        $data = $response->json('data') ?? $response->json();
+        $version = $data['version'] ?? null;
+
+        $this->assertNotEmpty($version);
+    }
+
+    // ── Disabled modules return MODULE_DISABLED (404) ───────────────────
+
+    public function test_disabled_bookings_module_returns_404(): void
+    {
+        config(['modules.bookings' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/bookings');
+
+        $response->assertNotFound();
+    }
+
+    public function test_enabled_bookings_module_works(): void
+    {
+        config(['modules.bookings' => true]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/bookings');
+
+        $response->assertOk();
+    }
+
+    public function test_disabled_vehicles_module_returns_404(): void
+    {
+        config(['modules.vehicles' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/vehicles');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_recurring_bookings_module_returns_404(): void
+    {
+        config(['modules.recurring_bookings' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/recurring-bookings');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_zones_module_returns_404(): void
+    {
+        config(['modules.zones' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/lots/1/zones');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_favorites_module_returns_404(): void
+    {
+        config(['modules.favorites' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/user/favorites');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_notifications_module_returns_404(): void
+    {
+        config(['modules.notifications' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/notifications');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_webhooks_module_returns_404(): void
+    {
+        config(['modules.webhooks' => false]);
+
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/webhooks');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_credits_module_returns_404(): void
+    {
+        config(['modules.credits' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/user/credits');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_absences_module_returns_404(): void
+    {
+        config(['modules.absences' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/absences');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_push_notifications_module_returns_404(): void
+    {
+        config(['modules.push_notifications' => false]);
+
+        $response = $this->getJson('/api/v1/push/vapid-key');
+
+        $response->assertNotFound();
+    }
+
+    public function test_disabled_module_returns_module_disabled_error(): void
+    {
+        config(['modules.bookings' => false]);
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/v1/bookings');
+
+        $response->assertNotFound();
+        $json = $response->json();
+        // Check for MODULE_DISABLED in the error (may be wrapped)
+        $error = $json['error'] ?? ($json['data'] ?? null);
+        $this->assertNotNull($error);
+    }
+
+    // ── Core routes always work ─────────────────────────────────────────
+
+    public function test_core_routes_work_regardless_of_module_state(): void
+    {
+        config([
+            'modules.bookings' => false,
+            'modules.vehicles' => false,
+            'modules.absences' => false,
+        ]);
+
+        $this->getJson('/api/v1/health')->assertOk();
+        $this->getJson('/api/v1/system/version')->assertOk();
+        $this->getJson('/api/v1/modules')->assertOk();
+    }
+
+    public function test_lots_always_available(): void
+    {
+        config(['modules.bookings' => false, 'modules.vehicles' => false]);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->getJson('/api/v1/lots')
+            ->assertOk();
+    }
+
+    public function test_team_always_available(): void
+    {
+        config(['modules.absences' => false]);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->getJson('/api/v1/team')
+            ->assertOk();
+    }
+
+    public function test_auth_always_available(): void
+    {
+        config(['modules.bookings' => false]);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->getJson('/api/v1/me')
+            ->assertOk();
+    }
+
+    // ── Helper/service provider ─────────────────────────────────────────
+
+    public function test_module_enabled_helper(): void
+    {
+        config(['modules.bookings' => true]);
+        $this->assertTrue(module_enabled('bookings'));
+
+        config(['modules.bookings' => false]);
+        $this->assertFalse(module_enabled('bookings'));
+    }
+
+    public function test_module_enabled_returns_false_for_unknown(): void
+    {
+        $this->assertFalse(module_enabled('nonexistent_module'));
+    }
+
+    public function test_module_service_provider_all(): void
+    {
+        $all = ModuleServiceProvider::all();
+
+        $this->assertIsArray($all);
+        $this->assertArrayHasKey('bookings', $all);
+        $this->assertArrayHasKey('stripe', $all);
+        $this->assertIsBool($all['bookings']);
+    }
+
+    public function test_module_service_provider_enabled(): void
+    {
+        config(['modules.bookings' => true]);
+        $this->assertTrue(ModuleServiceProvider::enabled('bookings'));
+
+        config(['modules.bookings' => false]);
+        $this->assertFalse(ModuleServiceProvider::enabled('bookings'));
+    }
+
+    // ── Stripe disabled by default ──────────────────────────────────────
+
+    public function test_stripe_disabled_by_default(): void
+    {
+        $this->assertFalse(config('modules.stripe'));
+    }
+
+    // ── Multiple modules can be toggled independently ───────────────────
+
+    public function test_multiple_modules_toggled_independently(): void
+    {
+        config([
+            'modules.bookings' => false,
+            'modules.vehicles' => true,
+        ]);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->getJson('/api/v1/bookings')
+            ->assertNotFound();
+
+        $this->actingAs($user)
+            ->getJson('/api/v1/vehicles')
+            ->assertOk();
+    }
+
+    public function test_all_22_modules_in_config(): void
+    {
+        $modules = config('modules');
+
+        $this->assertCount(22, $modules);
+    }
+}


### PR DESCRIPTION
## Summary

- **22 independently toggleable modules** via `MODULE_*` env vars in `config/modules.php`
- Dual protection: routes not loaded at boot when disabled + `CheckModule` middleware for runtime guards
- `GET /api/v1/modules` endpoint returns all module states + app version
- Core routes (auth, lots, slots, team, health) always available regardless of module state
- Frontend `ModuleContext` + `useModule` hook for UI-level module awareness
- All 613 PHP tests pass (27 new), all 405 frontend tests pass (4 new)

## Modules

| Module | Default | Env Var |
|--------|---------|---------|
| bookings | enabled | `MODULE_BOOKINGS` |
| vehicles | enabled | `MODULE_VEHICLES` |
| absences | enabled | `MODULE_ABSENCES` |
| payments | enabled | `MODULE_PAYMENTS` |
| webhooks | enabled | `MODULE_WEBHOOKS` |
| notifications | enabled | `MODULE_NOTIFICATIONS` |
| branding | enabled | `MODULE_BRANDING` |
| import | enabled | `MODULE_IMPORT` |
| qr_codes | enabled | `MODULE_QR_CODES` |
| favorites | enabled | `MODULE_FAVORITES` |
| swap_requests | enabled | `MODULE_SWAP_REQUESTS` |
| recurring_bookings | enabled | `MODULE_RECURRING_BOOKINGS` |
| zones | enabled | `MODULE_ZONES` |
| credits | enabled | `MODULE_CREDITS` |
| metrics | enabled | `MODULE_METRICS` |
| broadcasting | enabled | `MODULE_BROADCASTING` |
| admin_reports | enabled | `MODULE_ADMIN_REPORTS` |
| data_export | enabled | `MODULE_DATA_EXPORT` |
| setup_wizard | enabled | `MODULE_SETUP_WIZARD` |
| gdpr | enabled | `MODULE_GDPR` |
| push_notifications | enabled | `MODULE_PUSH_NOTIFICATIONS` |
| stripe | **disabled** | `MODULE_STRIPE` |

## Architecture

- `config/modules.php` — module definitions with env var bindings
- `app/Http/Middleware/CheckModule.php` — runtime route guard
- `app/Providers/ModuleServiceProvider.php` — module registry
- `app/helpers.php` — `module_enabled()` and `module_routes()` helpers
- `routes/modules/*.php` — 16 modular route files split from api_v1.php
- `app/Http/Controllers/Api/ModuleController.php` — modules API endpoint
- `parkhub-web/src/context/ModuleContext.tsx` — React context for module state
- `parkhub-web/src/hooks/useModule.ts` — convenience hooks

## Test Plan

- [x] Disabled modules return 404 with MODULE_DISABLED error
- [x] Core routes (auth, lots, health) work regardless of module state
- [x] Modules endpoint returns all 22 modules with correct defaults
- [x] Stripe disabled by default
- [x] module_enabled() helper works for known and unknown modules
- [x] Frontend ModuleContext loads, handles errors, falls back to defaults
- [x] All 613 existing PHP tests pass (no regressions)
- [x] All 405 existing frontend tests pass