### PR TITLE
fix(security): P1 critical — rate limiting, webhook verification, metrics

### DIFF
--- a/app/Http/Controllers/Api/MetricsController.php
+++ b/app/Http/Controllers/Api/MetricsController.php
@@ -94,12 +94,21 @@ class MetricsController extends Controller
         $lines[] = '';
 
         // ── parkhub_lot_occupancy_percent (per lot) ────────────────────────
-        $lots = ParkingLot::all(['id', 'name', 'total_slots', 'available_slots']);
+        // Compute occupancy dynamically from active bookings instead of stale available_slots column
+        $lots = ParkingLot::all(['id', 'name', 'total_slots']);
+        $now = now();
+        $activeByLot = Booking::whereIn('status', ['confirmed', 'active'])
+            ->where('start_time', '<=', $now)
+            ->where('end_time', '>=', $now)
+            ->selectRaw('lot_id, COUNT(*) as active_count')
+            ->groupBy('lot_id')
+            ->pluck('active_count', 'lot_id');
+
         $lines[] = '# HELP parkhub_lot_occupancy_percent Occupancy percentage per parking lot';
         $lines[] = '# TYPE parkhub_lot_occupancy_percent gauge';
         foreach ($lots as $lot) {
             $total = (int) $lot->total_slots;
-            $occupied = $total - (int) $lot->available_slots;
+            $occupied = (int) ($activeByLot[$lot->id] ?? 0);
             $pct = $total > 0 ? round(($occupied / $total) * 100, 2) : 0;
             $safeName = preg_replace('/[^a-zA-Z0-9_]/', '_', $lot->name);
             $lines[] = "parkhub_lot_occupancy_percent{lot_id=\"{$lot->id}\",lot_name=\"{$safeName}\"} {$pct}";

--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -44,6 +44,7 @@ class PaymentController extends Controller
     /**
      * POST /api/v1/payments/confirm
      * Confirms a payment intent stub.
+     * Returns proper status based on whether payment_method was provided.
      */
     public function confirm(Request $request): JsonResponse
     {
@@ -52,12 +53,15 @@ class PaymentController extends Controller
             'payment_method' => 'nullable|string',
         ]);
 
+        // Without a payment method, the intent cannot succeed
+        $status = $request->filled('payment_method') ? 'succeeded' : 'requires_payment_method';
+
         return response()->json([
             'success' => true,
             'data' => [
                 'id' => $request->payment_intent_id,
-                'status' => 'succeeded',
-                'amount_received' => null,
+                'status' => $status,
+                'amount_received' => $status === 'succeeded' ? null : 0,
             ],
             'error' => null,
             'meta' => null,
@@ -67,6 +71,7 @@ class PaymentController extends Controller
     /**
      * GET /api/v1/payments/{id}/status
      * Returns the status of a payment intent.
+     * Stub returns 'requires_confirmation' since no real payment processor is configured.
      */
     public function status(Request $request, string $id): JsonResponse
     {
@@ -74,7 +79,7 @@ class PaymentController extends Controller
             'success' => true,
             'data' => [
                 'id' => $id,
-                'status' => 'succeeded',
+                'status' => 'requires_confirmation',
                 'amount' => null,
                 'currency' => 'eur',
             ],
@@ -85,13 +90,24 @@ class PaymentController extends Controller
 
     /**
      * POST /api/v1/payments/webhook
-     * Handles Stripe webhook events (stub - logs and returns 200).
+     * Handles Stripe webhook events with signature verification.
      */
     public function webhook(Request $request): JsonResponse
     {
-        // In production: verify Stripe-Signature header
-        // $payload = $request->getContent();
-        // $sigHeader = $request->header('Stripe-Signature');
+        $webhookSecret = config('services.stripe.webhook_secret');
+
+        if ($webhookSecret) {
+            $payload = $request->getContent();
+            $sigHeader = $request->header('Stripe-Signature', '');
+
+            if (! $this->verifyStripeSignature($payload, $sigHeader, $webhookSecret)) {
+                Log::warning('Stripe webhook signature verification failed', [
+                    'ip' => $request->ip(),
+                ]);
+
+                return response()->json(['error' => 'Invalid signature'], 403);
+            }
+        }
 
         Log::info('Stripe webhook received', [
             'type' => $request->input('type'),
@@ -99,5 +115,37 @@ class PaymentController extends Controller
         ]);
 
         return response()->json(['received' => true]);
+    }
+
+    /**
+     * Verify Stripe webhook signature (v1 scheme).
+     */
+    private function verifyStripeSignature(string $payload, string $sigHeader, string $secret): bool
+    {
+        if (empty($sigHeader)) {
+            return false;
+        }
+
+        $parts = collect(explode(',', $sigHeader))->mapWithKeys(function ($part) {
+            $pair = explode('=', trim($part), 2);
+
+            return count($pair) === 2 ? [$pair[0] => $pair[1]] : [];
+        });
+
+        $timestamp = $parts->get('t');
+        $signature = $parts->get('v1');
+
+        if (! $timestamp || ! $signature) {
+            return false;
+        }
+
+        // Reject timestamps older than 5 minutes to prevent replay attacks
+        if (abs(time() - (int) $timestamp) > 300) {
+            return false;
+        }
+
+        $expectedSignature = hash_hmac('sha256', "{$timestamp}.{$payload}", $secret);
+
+        return hash_equals($expectedSignature, $signature);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -55,6 +55,11 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute(3)->by($request->ip());
         });
 
+        // Payment endpoints: 10 per minute per user (prevent abuse)
+        RateLimiter::for('payments', function (Request $request) {
+            return Limit::perMinute(10)->by($request->user()?->id ?: $request->ip());
+        });
+
         // Authenticated API: 120 per minute per user (or IP if unauthenticated)
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(120)->by($request->user()?->id ?: $request->ip());

--- a/routes/modules/payments.php
+++ b/routes/modules/payments.php
@@ -13,7 +13,7 @@ Route::middleware('module:payments')->group(function () {
     Route::post('/payments/webhook', [PaymentController::class, 'webhook']);
 });
 
-Route::middleware(['module:payments', 'auth:sanctum', 'throttle:api'])->group(function () {
+Route::middleware(['module:payments', 'auth:sanctum', 'throttle:payments'])->group(function () {
     Route::post('/payments/create-intent', [PaymentController::class, 'createIntent']);
     Route::post('/payments/confirm', [PaymentController::class, 'confirm']);
     Route::get('/payments/{id}/status', [PaymentController::class, 'status']);


### PR DESCRIPTION
Fixes #89, #77, #82, #39

- Rate-limit payment endpoints (10 req/min per user)
- Stripe webhook signature verification with replay attack protection
- PaymentController stubs return proper status instead of always 'succeeded'
- MetricsController computes lot occupancy dynamically from active bookings

All 613 tests pass.