### PR TITLE
perf: chunked credit refill, batched metrics, cached webhooks

### DIFF
--- a/app/Http/Controllers/Api/AdminCreditController.php
+++ b/app/Http/Controllers/Api/AdminCreditController.php
@@ -103,24 +103,29 @@ class AdminCreditController extends Controller
         ]);
 
         $amount = $validated['amount'] ?? null;
-        $users = User::where('role', 'user')->where('is_active', true)->get();
+        $adminId = $request->user()->id;
         $count = 0;
 
-        foreach ($users as $user) {
-            $refillAmount = $amount ?? $user->credits_monthly_quota;
-            $user->update([
-                'credits_balance' => $refillAmount,
-                'credits_last_refilled' => now(),
-            ]);
-            CreditTransaction::create([
-                'user_id' => $user->id,
-                'amount' => $refillAmount,
-                'type' => 'monthly_refill',
-                'description' => 'Monthly credit refill',
-                'granted_by' => $request->user()->id,
-            ]);
-            $count++;
-        }
+        // Process in chunks of 100 to avoid loading all users into memory
+        User::where('role', 'user')
+            ->where('is_active', true)
+            ->chunkById(100, function ($users) use ($amount, $adminId, &$count) {
+                foreach ($users as $user) {
+                    $refillAmount = $amount ?? $user->credits_monthly_quota;
+                    $user->update([
+                        'credits_balance' => $refillAmount,
+                        'credits_last_refilled' => now(),
+                    ]);
+                    CreditTransaction::create([
+                        'user_id' => $user->id,
+                        'amount' => $refillAmount,
+                        'type' => 'monthly_refill',
+                        'description' => 'Monthly credit refill',
+                        'granted_by' => $adminId,
+                    ]);
+                    $count++;
+                }
+            });
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/Api/BookingController.php
+++ b/app/Http/Controllers/Api/BookingController.php
@@ -26,6 +26,7 @@ use App\Models\Webhook;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -260,8 +261,9 @@ class BookingController extends Controller
         // Send booking confirmation email via job queue
         SendBookingConfirmationJob::dispatch($booking->id, $request->user()->id);
 
-        // Dispatch webhook events
-        foreach (Webhook::where('active', true)->get() as $webhook) {
+        // Dispatch webhook events (cached for 60s to avoid per-booking queries)
+        $activeWebhooks = Cache::remember('active_webhooks', 60, fn () => Webhook::where('active', true)->get());
+        foreach ($activeWebhooks as $webhook) {
             if (in_array('booking.created', $webhook->events ?? [])) {
                 SendWebhookJob::dispatch($webhook->id, 'booking.created', [
                     'booking_id' => $booking->id,
@@ -325,8 +327,9 @@ class BookingController extends Controller
         // Notify waitlist users that a slot has become available in this lot
         $this->notifyWaitlist($booking->lot_id, $booking->slot_id);
 
-        // Dispatch webhook events
-        foreach (Webhook::where('active', true)->get() as $webhook) {
+        // Dispatch webhook events (cached for 60s to avoid per-booking queries)
+        $activeWebhooks = Cache::remember('active_webhooks', 60, fn () => Webhook::where('active', true)->get());
+        foreach ($activeWebhooks as $webhook) {
             if (in_array('booking.cancelled', $webhook->events ?? [])) {
                 SendWebhookJob::dispatch($webhook->id, 'booking.cancelled', [
                     'booking_id' => $booking->id,

--- a/app/Http/Controllers/Api/MetricsController.php
+++ b/app/Http/Controllers/Api/MetricsController.php
@@ -35,20 +35,39 @@ class MetricsController extends Controller
     private function buildMetrics(): array
     {
         $lines = [];
+        $now = now();
+
+        // ── Batch scalar counts in fewer queries ────────────────────────────
+        $usersTotal = User::count();
+        $lotsTotal = ParkingLot::count();
+
+        // Single query for booking counts by status
+        $bookingsByStatus = Booking::select('status', DB::raw('count(*) as total'))
+            ->groupBy('status')
+            ->pluck('total', 'status')
+            ->all();
+
+        // Active bookings in current time window
+        $activeBookings = Booking::whereIn('status', ['confirmed', 'active'])
+            ->where('start_time', '<=', $now)
+            ->where('end_time', '>=', $now)
+            ->count();
+
+        // Single query for slot counts by status
+        $slotsByStatus = ParkingSlot::select('status', DB::raw('count(*) as total'))
+            ->groupBy('status')
+            ->pluck('total', 'status');
+        $slotsTotal = $slotsByStatus->sum();
+        $slotsAvailable = (int) ($slotsByStatus['available'] ?? 0);
+        $slotsActive = (int) ($slotsByStatus['active'] ?? 0);
 
         // ── parkhub_users_total ────────────────────────────────────────────
-        $usersTotal = User::count();
         $lines[] = '# HELP parkhub_users_total Total registered users';
         $lines[] = '# TYPE parkhub_users_total gauge';
         $lines[] = "parkhub_users_total {$usersTotal}";
         $lines[] = '';
 
         // ── parkhub_bookings_total (by status) ────────────────────────────
-        $bookingsByStatus = Booking::select('status', DB::raw('count(*) as total'))
-            ->groupBy('status')
-            ->pluck('total', 'status')
-            ->all();
-
         $lines[] = '# HELP parkhub_bookings_total Total bookings by status';
         $lines[] = '# TYPE parkhub_bookings_total gauge';
         foreach ($bookingsByStatus as $status => $count) {
@@ -57,26 +76,16 @@ class MetricsController extends Controller
         $lines[] = '';
 
         // ── parkhub_bookings_active ────────────────────────────────────────
-        $activeBookings = Booking::whereIn('status', ['confirmed', 'active'])
-            ->where('start_time', '<=', now())
-            ->where('end_time', '>=', now())
-            ->count();
         $lines[] = '# HELP parkhub_bookings_active Number of currently active/confirmed bookings in window';
         $lines[] = '# TYPE parkhub_bookings_active gauge';
         $lines[] = "parkhub_bookings_active {$activeBookings}";
         $lines[] = '';
 
         // ── parkhub_lots_total ─────────────────────────────────────────────
-        $lotsTotal = ParkingLot::count();
         $lines[] = '# HELP parkhub_lots_total Total parking lots';
         $lines[] = '# TYPE parkhub_lots_total gauge';
         $lines[] = "parkhub_lots_total {$lotsTotal}";
         $lines[] = '';
-
-        // ── parkhub_slots_total / parkhub_slots_available ─────────────────
-        $slotsTotal = ParkingSlot::count();
-        $slotsAvailable = ParkingSlot::where('status', 'available')->count();
-        $slotsActive = ParkingSlot::where('status', 'active')->count();
 
         $lines[] = '# HELP parkhub_slots_total Total parking slots';
         $lines[] = '# TYPE parkhub_slots_total gauge';
@@ -96,7 +105,6 @@ class MetricsController extends Controller
         // ── parkhub_lot_occupancy_percent (per lot) ────────────────────────
         // Compute occupancy dynamically from active bookings instead of stale available_slots column
         $lots = ParkingLot::all(['id', 'name', 'total_slots']);
-        $now = now();
         $activeByLot = Booking::whereIn('status', ['confirmed', 'active'])
             ->where('start_time', '<=', $now)
             ->where('end_time', '>=', $now)


### PR DESCRIPTION
Fixes #99, #100, #101

- Chunked user processing in refillAllCredits (100 at a time)
- Batched slot status counts into single GROUP BY query
- Cache active webhooks for 60s to eliminate per-booking queries

All 613 tests pass.