### PR TITLE
test: add 18 unit tests for Setting, Zone, Webhook, Absence models

### DIFF
--- a/tests/Unit/Models/AbsenceModelTest.php
+++ b/tests/Unit/Models/AbsenceModelTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Absence;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AbsenceModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_absence_has_fillable_attributes(): void
+    {
+        $absence = new Absence;
+        $fillable = $absence->getFillable();
+        $this->assertContains('user_id', $fillable);
+        $this->assertContains('absence_type', $fillable);
+        $this->assertContains('start_date', $fillable);
+        $this->assertContains('end_date', $fillable);
+    }
+
+    public function test_absence_belongs_to_user(): void
+    {
+        $absence = new Absence;
+        $this->assertInstanceOf(BelongsTo::class, $absence->user());
+    }
+
+    public function test_absence_uses_uuid(): void
+    {
+        $user = User::factory()->create();
+        $absence = Absence::create([
+            'user_id' => $user->id,
+            'absence_type' => 'homeoffice',
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addDays(1)->toDateString(),
+        ]);
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $absence->id);
+    }
+
+    public function test_absence_creation(): void
+    {
+        $user = User::factory()->create();
+        $absence = Absence::create([
+            'user_id' => $user->id,
+            'absence_type' => 'vacation',
+            'start_date' => '2026-07-01',
+            'end_date' => '2026-07-14',
+            'note' => 'Summer holiday',
+        ]);
+
+        $this->assertDatabaseHas('absences', [
+            'user_id' => $user->id,
+            'absence_type' => 'vacation',
+        ]);
+    }
+}

--- a/tests/Unit/Models/SettingModelTest.php
+++ b/tests/Unit/Models/SettingModelTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SettingModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_set_and_get_value(): void
+    {
+        Setting::set('test_key', 'test_value');
+        $this->assertEquals('test_value', Setting::get('test_key'));
+    }
+
+    public function test_get_returns_default_when_not_set(): void
+    {
+        $this->assertEquals('fallback', Setting::get('nonexistent_key', 'fallback'));
+    }
+
+    public function test_set_overwrites_existing_value(): void
+    {
+        Setting::set('overwrite_key', 'old');
+        Setting::set('overwrite_key', 'new');
+        $this->assertEquals('new', Setting::get('overwrite_key'));
+    }
+
+    public function test_fillable_attributes(): void
+    {
+        $setting = new Setting;
+        $this->assertContains('key', $setting->getFillable());
+        $this->assertContains('value', $setting->getFillable());
+    }
+
+    public function test_get_returns_null_default(): void
+    {
+        $this->assertNull(Setting::get('missing_key'));
+    }
+}

--- a/tests/Unit/Models/WebhookModelTest.php
+++ b/tests/Unit/Models/WebhookModelTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Webhook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebhookModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_webhook_has_fillable_attributes(): void
+    {
+        $webhook = new Webhook;
+        $fillable = $webhook->getFillable();
+        $this->assertContains('url', $fillable);
+        $this->assertContains('events', $fillable);
+        $this->assertContains('secret', $fillable);
+        $this->assertContains('active', $fillable);
+    }
+
+    public function test_webhook_events_cast_to_array(): void
+    {
+        $webhook = Webhook::create([
+            'url' => 'https://example.com/webhook',
+            'events' => ['booking.created', 'booking.cancelled'],
+            'active' => true,
+        ]);
+
+        $this->assertIsArray($webhook->events);
+        $this->assertContains('booking.created', $webhook->events);
+    }
+
+    public function test_webhook_active_defaults(): void
+    {
+        $webhook = Webhook::create([
+            'url' => 'https://example.com/hook',
+            'events' => [],
+        ]);
+
+        $this->assertNotNull($webhook->id);
+    }
+
+    public function test_webhook_uses_uuid(): void
+    {
+        $webhook = Webhook::create([
+            'url' => 'https://example.com/hook',
+            'events' => ['booking.created'],
+            'active' => true,
+        ]);
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $webhook->id);
+    }
+}

--- a/tests/Unit/Models/ZoneModelTest.php
+++ b/tests/Unit/Models/ZoneModelTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\ParkingLot;
+use App\Models\Zone;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ZoneModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_zone_has_fillable_attributes(): void
+    {
+        $zone = new Zone;
+        $fillable = $zone->getFillable();
+        $this->assertContains('lot_id', $fillable);
+        $this->assertContains('name', $fillable);
+        $this->assertContains('color', $fillable);
+        $this->assertContains('description', $fillable);
+    }
+
+    public function test_zone_uses_uuid(): void
+    {
+        $lot = ParkingLot::create(['name' => 'Test Lot', 'total_slots' => 5]);
+        $zone = Zone::create(['lot_id' => $lot->id, 'name' => 'Test Zone']);
+        $this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $zone->id);
+    }
+
+    public function test_zone_belongs_to_lot(): void
+    {
+        $zone = new Zone;
+        $this->assertInstanceOf(BelongsTo::class, $zone->lot());
+    }
+
+    public function test_zone_has_many_slots(): void
+    {
+        $zone = new Zone;
+        $this->assertInstanceOf(HasMany::class, $zone->slots());
+    }
+
+    public function test_zone_creation(): void
+    {
+        $lot = ParkingLot::create(['name' => 'Test Lot', 'total_slots' => 10]);
+        $zone = Zone::create([
+            'lot_id' => $lot->id,
+            'name' => 'VIP Zone',
+            'color' => '#FFD700',
+            'description' => 'Premium parking',
+        ]);
+
+        $this->assertDatabaseHas('zones', [
+            'name' => 'VIP Zone',
+            'color' => '#FFD700',
+        ]);
+        $this->assertEquals($lot->id, $zone->lot->id);
+    }
+}


### PR DESCRIPTION
Fixes #49

- 18 new unit tests across 4 model test files
- Setting: get/set, defaults, overwrite
- Zone: fillable, UUID, relations, creation
- Webhook: fillable, events cast, UUID
- Absence: fillable, relations, UUID, creation

Total: 631 tests (up from 613).