### PR TITLE
feat: discovery endpoint, backup/restore, CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to ParkHub
+
+## Development Setup
+
+### Prerequisites
+- PHP 8.4+
+- Composer 2.x
+- Node.js 20+ and npm
+- SQLite (default) or MySQL 8+
+
+### Quick Start
+```bash
+git clone https://github.com/nash87/parkhub-php.git
+cd parkhub-php
+composer setup
+```
+
+This will:
+1. Install PHP dependencies
+2. Copy `.env.example` to `.env`
+3. Generate an application key
+4. Run database migrations
+5. Install Node.js dependencies
+6. Build frontend assets
+
+### Running Locally
+```bash
+composer dev
+```
+
+This starts the PHP dev server, queue worker, log viewer, and Vite dev server concurrently.
+
+### Running Tests
+```bash
+php artisan test              # All tests
+php artisan test tests/Unit   # Unit tests only
+php artisan test tests/Feature # Feature tests only
+```
+
+### Code Style
+ParkHub uses [Laravel Pint](https://laravel.com/docs/pint) for code formatting:
+```bash
+./vendor/bin/pint           # Auto-fix
+./vendor/bin/pint --test    # Check only
+```
+
+### Static Analysis
+```bash
+./vendor/bin/phpstan analyse
+```
+
+## Pull Request Guidelines
+
+1. Create a feature branch from `main`
+2. Write tests for new functionality
+3. Ensure all tests pass: `php artisan test`
+4. Ensure code style passes: `./vendor/bin/pint --test`
+5. Write a descriptive commit message
+6. Open a PR against `main`
+
+## Project Structure
+
+```
+app/
+  Console/Commands/   # Artisan commands
+  Http/Controllers/   # API controllers
+  Http/Middleware/     # Request middleware
+  Http/Requests/      # Form request validation
+  Http/Resources/     # API resource transformers
+  Models/             # Eloquent models
+  Jobs/               # Queue jobs
+  Mail/               # Mail templates
+config/               # Configuration files
+database/             # Migrations and seeders
+routes/
+  api.php             # Main API routes
+  api_v1.php          # V1 API routes
+  modules/            # Per-module route files
+tests/
+  Feature/            # Integration tests
+  Unit/               # Unit tests
+parkhub-web/          # React SPA frontend
+```
+
+## Module System
+
+ParkHub uses a module toggle system. Each module can be enabled/disabled via environment variables (`MODULE_BOOKINGS=true`, `MODULE_VEHICLES=false`, etc.). Module routes are loaded conditionally from `routes/modules/`.
+
+## License
+
+MIT

--- a/app/Http/Controllers/Api/AdminSettingsController.php
+++ b/app/Http/Controllers/Api/AdminSettingsController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\UpdateSettingsRequest;
 use App\Models\Absence;
 use App\Models\AuditLog;
 use App\Models\Booking;
+use App\Models\ParkingLot;
 use App\Models\ParkingSlot;
 use App\Models\Setting;
 use App\Models\User;
@@ -358,6 +359,57 @@ class AdminSettingsController extends Controller
         ]);
 
         return response()->json(['message' => 'Database reset. All user data deleted.']);
+    }
+
+    /**
+     * GET /api/v1/admin/backup
+     * Export all settings, users, lots, slots, and bookings as JSON.
+     */
+    public function exportBackup(Request $request): JsonResponse
+    {
+        $data = [
+            'exported_at' => now()->toISOString(),
+            'version' => SystemController::appVersion(),
+            'settings' => Setting::all()->pluck('value', 'key'),
+            'users' => User::all()->makeHidden(['password', 'remember_token']),
+            'lots' => ParkingLot::with('slots')->get(),
+            'bookings' => Booking::limit(10000)->get(),
+        ];
+
+        return response()->json([
+            'success' => true,
+            'data' => $data,
+        ]);
+    }
+
+    /**
+     * POST /api/v1/admin/restore
+     * Restore settings from a backup JSON payload.
+     */
+    public function importBackup(Request $request): JsonResponse
+    {
+        $request->validate([
+            'settings' => 'required|array',
+        ]);
+
+        $imported = 0;
+        foreach ($request->settings as $key => $value) {
+            Setting::set($key, $value);
+            $imported++;
+        }
+
+        AuditLog::log([
+            'user_id' => $request->user()->id,
+            'username' => $request->user()->username,
+            'action' => 'settings_restored',
+            'details' => ['settings_count' => $imported],
+            'ip_address' => $request->ip(),
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data' => ['settings_imported' => $imported],
+        ]);
     }
 
     private static function useCaseTheme(string $key): array

--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -169,4 +169,39 @@ class PublicController extends Controller
             'meta' => null,
         ]);
     }
+
+    /**
+     * GET /api/v1/discover
+     * Handshake/discovery endpoint — returns API version, capabilities, and available modules.
+     */
+    public function discover(): JsonResponse
+    {
+        $modules = collect(config('modules', []))
+            ->filter(fn ($enabled) => $enabled)
+            ->keys()
+            ->values();
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'name' => Setting::get('company_name', 'ParkHub'),
+                'version' => SystemController::appVersion(),
+                'api_version' => 'v1',
+                'modules' => $modules,
+                'capabilities' => [
+                    'auth' => 'sanctum',
+                    'realtime' => config('broadcasting.default') !== 'log',
+                    'push_notifications' => ! empty(Setting::get('vapid_public_key')),
+                    'demo_mode' => (bool) config('parkhub.demo_mode'),
+                ],
+                'endpoints' => [
+                    'auth' => '/api/v1/auth/login',
+                    'health' => '/api/v1/health',
+                    'docs' => '/docs/api',
+                ],
+            ],
+            'error' => null,
+            'meta' => null,
+        ]);
+    }
 }

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -71,6 +71,9 @@ Route::get('/translations/overrides', [TranslationController::class, 'overrides'
 // Modules endpoint (public — frontend uses this to discover available features)
 Route::get('/modules', [ModuleController::class, 'index']);
 
+// Discovery / handshake endpoint (public)
+Route::get('/discover', [PublicController::class, 'discover']);
+
 // ── Core protected routes ───────────────────────────────────────────────────
 
 Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
@@ -137,6 +140,10 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
         Route::get('/settings/webhooks', [AdminSettingsController::class, 'getWebhookSettings']);
         Route::put('/settings/webhooks', [AdminSettingsController::class, 'updateWebhookSettings']);
         Route::post('/reset', [AdminSettingsController::class, 'resetDatabase']);
+
+        // Backup / restore
+        Route::get('/backup', [AdminSettingsController::class, 'exportBackup']);
+        Route::post('/restore', [AdminSettingsController::class, 'importBackup']);
 
         // User management
         Route::get('/users', [AdminController::class, 'users']);


### PR DESCRIPTION
Fixes #33, #34, #104, #105

- GET /api/v1/discover handshake endpoint with API version, modules, capabilities
- Theme endpoint already exists at /api/v1/theme
- Admin backup/restore endpoints for settings export/import
- CONTRIBUTING.md with development setup guide

All 631 tests pass.