### PR TITLE
fix(auth): replace localStorage JWT with httpOnly cookie auth

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -19,9 +19,46 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Cookie;
 
 class AuthController extends Controller
 {
+    /**
+     * Build an httpOnly cookie containing the Sanctum token.
+     */
+    private function authCookie(string $token): Cookie
+    {
+        $secure = app()->environment('production');
+
+        return new Cookie(
+            name: 'parkhub_token',
+            value: $token,
+            expire: now()->addDays(7),
+            path: '/',
+            secure: $secure,
+            httpOnly: true,
+            sameSite: 'lax',
+        );
+    }
+
+    /**
+     * Build a cookie that clears the auth cookie.
+     */
+    private function forgetAuthCookie(): Cookie
+    {
+        $secure = app()->environment('production');
+
+        return new Cookie(
+            name: 'parkhub_token',
+            value: '',
+            expire: now()->subMinute(),
+            path: '/',
+            secure: $secure,
+            httpOnly: true,
+            sameSite: 'lax',
+        );
+    }
+
     public function login(LoginRequest $request): JsonResponse
     {
 
@@ -86,7 +123,7 @@ class AuthController extends Controller
                 'token_type' => 'Bearer',
                 'expires_at' => now()->addDays(7)->toISOString(),
             ],
-        ]);
+        ])->withCookie($this->authCookie($token->plainTextToken));
     }
 
     public function register(RegisterRequest $request): JsonResponse
@@ -127,7 +164,7 @@ class AuthController extends Controller
                 'token_type' => 'Bearer',
                 'expires_at' => now()->addDays(7)->toISOString(),
             ],
-        ], 201);
+        ], 201)->withCookie($this->authCookie($token->plainTextToken));
     }
 
     public function refresh(Request $request): JsonResponse
@@ -142,7 +179,35 @@ class AuthController extends Controller
                 'token_type' => 'Bearer',
                 'expires_at' => now()->addDays(7)->toISOString(),
             ],
-        ]);
+        ])->withCookie($this->authCookie($token->plainTextToken));
+    }
+
+    /**
+     * Logout — revoke current token, clear httpOnly cookie.
+     */
+    public function logout(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        if ($user) {
+            // Revoke the token that was used for this request.
+            // currentAccessToken() returns the PersonalAccessToken model
+            // when authenticated via Sanctum Bearer token.
+            $token = $user->currentAccessToken();
+            if ($token && method_exists($token, 'delete')) {
+                $token->delete();
+            }
+
+            AuditLog::log([
+                'user_id' => $user->id,
+                'username' => $user->username,
+                'action' => 'logout',
+                'ip_address' => $request->ip(),
+            ]);
+        }
+
+        return response()->json(['message' => 'Logged out'])
+            ->withCookie($this->forgetAuthCookie());
     }
 
     public function me(Request $request): JsonResponse
@@ -343,6 +408,6 @@ class AuthController extends Controller
                 'token_type' => 'Bearer',
                 'expires_at' => now()->addDays(7)->toISOString(),
             ],
-        ]);
+        ])->withCookie($this->authCookie($token->plainTextToken));
     }
 }

--- a/app/Http/Middleware/AuthenticateFromCookie.php
+++ b/app/Http/Middleware/AuthenticateFromCookie.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Authenticate API requests from the httpOnly parkhub_token cookie.
+ *
+ * Precedence:
+ *   1. Authorization: Bearer header  (standard Sanctum flow, untouched)
+ *   2. parkhub_token cookie          (requires X-Requested-With header for CSRF)
+ *
+ * This middleware runs *before* auth:sanctum so it can inject the
+ * Bearer header into the request, letting Sanctum handle the rest.
+ */
+class AuthenticateFromCookie
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        // If a Bearer header is already present, let Sanctum handle it directly.
+        if ($request->bearerToken()) {
+            return $next($request);
+        }
+
+        $cookieToken = $request->cookie('parkhub_token');
+
+        if (! $cookieToken) {
+            return $next($request);
+        }
+
+        // CSRF protection: cookie-based auth requires this header to prove
+        // the request originates from our SPA, not a cross-site form.
+        if ($request->header('X-Requested-With') !== 'XMLHttpRequest') {
+            return response()->json([
+                'error' => 'CSRF_REQUIRED',
+                'message' => 'Cookie-based authentication requires the X-Requested-With: XMLHttpRequest header.',
+            ], 403);
+        }
+
+        // Validate the token exists in the database before injecting it.
+        $accessToken = PersonalAccessToken::findToken($cookieToken);
+
+        if (! $accessToken) {
+            return $next($request);
+        }
+
+        // Inject the cookie token as a Bearer header so Sanctum picks it up.
+        $request->headers->set('Authorization', 'Bearer '.$cookieToken);
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\ApiResponseWrapper;
+use App\Http\Middleware\AuthenticateFromCookie;
 use App\Http\Middleware\CheckModule;
 use App\Http\Middleware\ForceJsonResponse;
 use App\Http\Middleware\RequireAdmin;
@@ -30,11 +31,16 @@ return Application::configure(basePath: dirname(__DIR__))
         // Security headers on every response (web + API)
         $middleware->append(SecurityHeaders::class);
 
+        // Exclude parkhub_token from encryption so our AuthenticateFromCookie
+        // middleware can read the raw Sanctum token value from the cookie.
+        $middleware->encryptCookies(except: ['parkhub_token']);
+
         $middleware->validateCsrfTokens(except: [
             'api/*',
         ]);
         $middleware->api(prepend: [
             ForceJsonResponse::class,
+            AuthenticateFromCookie::class,
             ApiResponseWrapper::class,
         ]);
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -49,5 +49,5 @@ return [
 
     'max_age' => 86400,
 
-    'supports_credentials' => false,
+    'supports_credentials' => true,
 ];

--- a/parkhub-web/src/api/client.test.ts
+++ b/parkhub-web/src/api/client.test.ts
@@ -2,26 +2,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // We can't directly import `request` since it's not exported — but we can test
 // the behaviour through the public `api` object which calls `request` internally.
-// We need to mock fetch and localStorage.
-
-// Mock import.meta.env before importing the module
-vi.stubGlobal('localStorage', {
-  store: {} as Record<string, string>,
-  getItem(key: string) { return this.store[key] ?? null; },
-  setItem(key: string, val: string) { this.store[key] = val; },
-  removeItem(key: string) { delete this.store[key]; },
-  clear() { this.store = {}; },
-});
+// We need to mock fetch.
 
 // We need to import after mocks are set up
-const { api } = await import('./client');
+const { api, setInMemoryToken, getInMemoryToken } = await import('./client');
 
 describe('API client', () => {
   const originalFetch = globalThis.fetch;
   const originalLocation = window.location;
 
   beforeEach(() => {
-    localStorage.clear();
+    setInMemoryToken(null);
     // Mock window.location
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -38,7 +29,7 @@ describe('API client', () => {
     vi.restoreAllMocks();
   });
 
-  it('sends JSON headers by default', async () => {
+  it('sends JSON headers and credentials by default', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -52,10 +43,12 @@ describe('API client', () => {
     expect(url).toBe('/api/v1/lots');
     expect(opts.headers['Content-Type']).toBe('application/json');
     expect(opts.headers['Accept']).toBe('application/json');
+    expect(opts.headers['X-Requested-With']).toBe('XMLHttpRequest');
+    expect(opts.credentials).toBe('include');
   });
 
-  it('includes Authorization header when token is present', async () => {
-    localStorage.setItem('parkhub_token', 'test-jwt-token');
+  it('includes Authorization header when in-memory token is present', async () => {
+    setInMemoryToken('test-jwt-token');
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -69,7 +62,7 @@ describe('API client', () => {
     expect(opts.headers['Authorization']).toBe('Bearer test-jwt-token');
   });
 
-  it('omits Authorization header when no token', async () => {
+  it('omits Authorization header when no in-memory token', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -97,8 +90,8 @@ describe('API client', () => {
     expect(JSON.parse(opts.body)).toEqual({ username: 'admin', password: 'demo' });
   });
 
-  it('handles 401 by clearing token and redirecting to /login', async () => {
-    localStorage.setItem('parkhub_token', 'expired-token');
+  it('handles 401 by clearing in-memory token and redirecting to /login', async () => {
+    setInMemoryToken('expired-token');
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
@@ -110,7 +103,7 @@ describe('API client', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('UNAUTHORIZED');
-    expect(localStorage.getItem('parkhub_token')).toBeNull();
+    expect(getInMemoryToken()).toBeNull();
     expect(window.location.href).toBe('/login');
   });
 
@@ -319,5 +312,30 @@ describe('API client', () => {
     expect(result.success).toBe(true);
     const [, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(JSON.parse(opts.body).user_ids).toEqual(['id1']);
+  });
+
+  // ── Logout ──
+
+  it('calls logout endpoint', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ success: true, data: null }),
+    });
+    const result = await api.logout();
+    expect(result.success).toBe(true);
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/v1/auth/logout');
+    expect(opts.method).toBe('POST');
+    expect(opts.credentials).toBe('include');
+  });
+
+  // ── In-memory token management ──
+
+  it('setInMemoryToken/getInMemoryToken roundtrip', () => {
+    expect(getInMemoryToken()).toBeNull();
+    setInMemoryToken('test-123');
+    expect(getInMemoryToken()).toBe('test-123');
+    setInMemoryToken(null);
+    expect(getInMemoryToken()).toBeNull();
   });
 });

--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -6,20 +6,38 @@ export interface ApiResponse<T> {
   error?: { code: string; message: string };
 }
 
+// In-memory token storage (XSS-safe: not in localStorage).
+// Used as fallback when httpOnly cookie is not available (API/mobile clients).
+let _inMemoryToken: string | null = null;
+
+export function setInMemoryToken(token: string | null) {
+  _inMemoryToken = token;
+}
+
+export function getInMemoryToken(): string | null {
+  return _inMemoryToken;
+}
+
 async function request<T>(path: string, opts: RequestInit = {}): Promise<ApiResponse<T>> {
-  const token = localStorage.getItem('parkhub_token');
+  const token = _inMemoryToken;
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json',
+    // CSRF protection: required by backend for cookie-based auth
+    'X-Requested-With': 'XMLHttpRequest',
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
     ...(opts.headers as Record<string, string> || {}),
   };
 
   try {
-    const res = await fetch(`${BASE_URL}${path}`, { ...opts, headers });
+    const res = await fetch(`${BASE_URL}${path}`, {
+      ...opts,
+      headers,
+      credentials: 'include',  // Send httpOnly cookies automatically
+    });
 
     if (res.status === 401) {
-      localStorage.removeItem('parkhub_token');
+      _inMemoryToken = null;
       window.location.href = '/login';
       return { success: false, data: null, error: { code: 'UNAUTHORIZED', message: 'Session expired' } };
     }
@@ -45,11 +63,12 @@ async function request<T>(path: string, opts: RequestInit = {}): Promise<ApiResp
 }
 
 async function requestBlob(path: string): Promise<Blob> {
-  const token = localStorage.getItem('parkhub_token');
+  const token = _inMemoryToken;
   const headers: Record<string, string> = {
+    'X-Requested-With': 'XMLHttpRequest',
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
   };
-  const res = await fetch(`${BASE_URL}${path}`, { headers });
+  const res = await fetch(`${BASE_URL}${path}`, { headers, credentials: 'include' });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.blob();
 }
@@ -69,6 +88,8 @@ export const api = {
 
   resetPassword: (token: string, password: string) =>
     request('/api/v1/auth/reset-password', { method: 'POST', body: JSON.stringify({ token, password }) }),
+
+  logout: () => request('/api/v1/auth/logout', { method: 'POST' }),
 
   me: () => request<User>('/api/v1/users/me'),
 
@@ -122,10 +143,14 @@ export const api = {
   importAbsenceIcal: async (file: File) => {
     const fd = new FormData();
     fd.append('file', file);
-    const token = localStorage.getItem('parkhub_token');
+    const token = _inMemoryToken;
     const res = await fetch(`${BASE_URL}/api/v1/absences/import`, {
       method: 'POST', body: fd,
-      headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+      credentials: 'include',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
     });
     return res.json();
   },

--- a/parkhub-web/src/components/ExportButton.test.tsx
+++ b/parkhub-web/src/components/ExportButton.test.tsx
@@ -4,7 +4,15 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ExportButton, type ExportType } from './ExportButton';
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_: string, f: string) => f }) }));
-beforeEach(() => { vi.restoreAllMocks(); localStorage.clear(); });
+
+const { mockGetInMemoryToken } = vi.hoisted(() => ({
+  mockGetInMemoryToken: vi.fn(() => null as string | null),
+}));
+vi.mock('../api/client', () => ({
+  getInMemoryToken: mockGetInMemoryToken,
+}));
+
+beforeEach(() => { vi.restoreAllMocks(); mockGetInMemoryToken.mockReturnValue(null); });
 
 describe('ExportButton', () => {
   it('renders toggle', () => { render(<ExportButton />); expect(screen.getByTestId('export-toggle')).toBeDefined(); });
@@ -40,7 +48,7 @@ describe('ExportButton', () => {
 
 describe('ExportButton download', () => {
   it('fetches with auth', async () => {
-    localStorage.setItem('parkhub_token', 'tok');
+    mockGetInMemoryToken.mockReturnValue('tok');
     const fm = vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(new Blob([''])) });
     vi.stubGlobal('fetch', fm);
     vi.stubGlobal('URL', { ...URL, createObjectURL: vi.fn().mockReturnValue('b:x'), revokeObjectURL: vi.fn() });
@@ -48,6 +56,7 @@ describe('ExportButton download', () => {
     await waitFor(() => expect(fm).toHaveBeenCalledTimes(1));
     expect(fm.mock.calls[0][0]).toContain('/api/v1/admin/export/bookings');
     expect(fm.mock.calls[0][1].headers.Authorization).toBe('Bearer tok');
+    expect(fm.mock.calls[0][1].credentials).toBe('include');
   });
   it('correct URL per type', async () => {
     const fm = vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(new Blob([''])) });
@@ -65,11 +74,14 @@ describe('ExportButton download', () => {
     render(<ExportButton />); fireEvent.click(screen.getByTestId('export-toggle')); fireEvent.click(screen.getByTestId('export-users'));
     await waitFor(() => expect(spy).toHaveBeenCalled()); spy.mockRestore();
   });
-  it('no token', async () => {
+  it('no token still sends CSRF header and credentials', async () => {
     const fm = vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(new Blob([''])) });
     vi.stubGlobal('fetch', fm); vi.stubGlobal('URL', { ...URL, createObjectURL: vi.fn().mockReturnValue('b:x'), revokeObjectURL: vi.fn() });
     render(<ExportButton />); fireEvent.click(screen.getByTestId('export-toggle')); fireEvent.click(screen.getByTestId('export-revenue'));
-    await waitFor(() => expect(fm).toHaveBeenCalledTimes(1)); expect(fm.mock.calls[0][1].headers).toEqual({});
+    await waitFor(() => expect(fm).toHaveBeenCalledTimes(1));
+    expect(fm.mock.calls[0][1].headers['X-Requested-With']).toBe('XMLHttpRequest');
+    expect(fm.mock.calls[0][1].headers.Authorization).toBeUndefined();
+    expect(fm.mock.calls[0][1].credentials).toBe('include');
   });
   it('custom baseUrl', async () => {
     const fm = vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(new Blob([''])) });

--- a/parkhub-web/src/components/ExportButton.tsx
+++ b/parkhub-web/src/components/ExportButton.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getInMemoryToken } from '../api/client';
 
 export type ExportType = 'bookings' | 'users' | 'revenue';
 export interface ExportButtonProps { baseUrl?: string; }
@@ -27,9 +28,15 @@ export function ExportButton({ baseUrl = '' }: ExportButtonProps) {
   const handleExport = useCallback(async (type: ExportType) => {
     setLoading(type);
     try {
-      const token = localStorage.getItem('parkhub_token');
+      const token = getInMemoryToken();
       const url = buildExportUrl(baseUrl, type, from, to);
-      const res = await fetch(url, { headers: token ? { Authorization: `Bearer ${token}` } : {} });
+      const res = await fetch(url, {
+        credentials: 'include',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      });
       if (!res.ok) { const text = await res.text(); throw new Error(text || `HTTP ${res.status}`); }
       const blob = await res.blob();
       const blobUrl = URL.createObjectURL(blob);

--- a/parkhub-web/src/components/ParkingPass.tsx
+++ b/parkhub-web/src/components/ParkingPass.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, DownloadSimple, Printer } from '@phosphor-icons/react';
 import type { Booking } from '../api/client';
+import { getInMemoryToken } from '../api/client';
 import { format } from 'date-fns';
 
 interface ParkingPassProps {
@@ -15,10 +16,14 @@ export function ParkingPass({ booking, onClose }: ParkingPassProps) {
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    const token = localStorage.getItem('parkhub_token');
+    const token = getInMemoryToken();
     const BASE_URL = import.meta.env?.VITE_API_URL || '';
     fetch(`${BASE_URL}/api/v1/bookings/${booking.id}/qr`, {
-      headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+      credentials: 'include',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
     })
       .then(res => {
         if (!res.ok) throw new Error('Failed to load pass');

--- a/parkhub-web/src/context/AuthContext.test.tsx
+++ b/parkhub-web/src/context/AuthContext.test.tsx
@@ -3,31 +3,22 @@ import React from 'react';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-// ── Mock localStorage ──
-const localStorageMock = (() => {
-  let store: Record<string, string> = {};
-  return {
-    getItem: vi.fn((key: string) => store[key] ?? null),
-    setItem: vi.fn((key: string, val: string) => { store[key] = val; }),
-    removeItem: vi.fn((key: string) => { delete store[key]; }),
-    clear: vi.fn(() => { store = {}; }),
-    get _store() { return store; },
-  };
-})();
-Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
-
 // ── Mock API ──
 // vi.mock is hoisted, so we use vi.hoisted to define mock fns that the factory can reference.
-const { mockLogin, mockMe } = vi.hoisted(() => ({
+const { mockLogin, mockMe, mockLogout, mockSetInMemoryToken } = vi.hoisted(() => ({
   mockLogin: vi.fn(),
   mockMe: vi.fn(),
+  mockLogout: vi.fn(),
+  mockSetInMemoryToken: vi.fn(),
 }));
 
 vi.mock('../api/client', () => ({
   api: {
     login: mockLogin,
     me: mockMe,
+    logout: mockLogout,
   },
+  setInMemoryToken: mockSetInMemoryToken,
 }));
 
 import { AuthProvider, useAuth } from './AuthContext';
@@ -47,8 +38,8 @@ function AuthConsumer() {
 
 describe('AuthContext', () => {
   beforeEach(() => {
-    localStorageMock.clear();
     vi.clearAllMocks();
+    mockLogout.mockResolvedValue({ success: true, data: null });
   });
 
   afterEach(() => {
@@ -66,7 +57,7 @@ describe('AuthContext', () => {
     spy.mockRestore();
   });
 
-  it('starts with loading=true and resolves to false when no token', async () => {
+  it('starts with loading=true and resolves to false when no cookie/token', async () => {
     mockMe.mockResolvedValue({ success: false, data: null });
 
     render(
@@ -75,7 +66,7 @@ describe('AuthContext', () => {
       </AuthProvider>,
     );
 
-    // Initially loading
+    // Resolves to loading=false after cookie auth attempt
     await waitFor(() => {
       expect(screen.getByTestId('loading').textContent).toBe('false');
     });
@@ -83,8 +74,7 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('user').textContent).toBe('null');
   });
 
-  it('fetches user on mount when token exists in localStorage', async () => {
-    localStorageMock.setItem('parkhub_token', 'existing-token');
+  it('fetches user on mount via httpOnly cookie', async () => {
     mockMe.mockResolvedValue({
       success: true,
       data: { id: '1', username: 'alice', email: 'alice@test.com', name: 'Alice', role: 'user' },
@@ -102,7 +92,7 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('loading').textContent).toBe('false');
   });
 
-  it('login stores token and sets user on success', async () => {
+  it('login stores token in memory and sets user on success', async () => {
     const user = userEvent.setup();
     mockLogin.mockResolvedValue({
       success: true,
@@ -130,7 +120,7 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('user').textContent).toBe('bob');
     });
 
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('parkhub_token', 'new-jwt-token');
+    expect(mockSetInMemoryToken).toHaveBeenCalledWith('new-jwt-token');
   });
 
   it('login returns error on failure', async () => {
@@ -169,9 +159,8 @@ describe('AuthContext', () => {
     });
   });
 
-  it('logout clears token from localStorage and resets user', async () => {
+  it('logout calls server, clears in-memory token, and resets user', async () => {
     const user = userEvent.setup();
-    localStorageMock.setItem('parkhub_token', 'existing-token');
     mockMe.mockResolvedValue({
       success: true,
       data: { id: '1', username: 'alice', email: 'alice@test.com', name: 'Alice', role: 'user' },
@@ -189,12 +178,14 @@ describe('AuthContext', () => {
 
     await user.click(screen.getByTestId('logout-btn'));
 
-    expect(screen.getByTestId('user').textContent).toBe('null');
-    expect(localStorageMock.removeItem).toHaveBeenCalledWith('parkhub_token');
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('null');
+    });
+    expect(mockLogout).toHaveBeenCalledOnce();
+    expect(mockSetInMemoryToken).toHaveBeenCalledWith(null);
   });
 
-  it('clears token when me() returns 401/failure on mount', async () => {
-    localStorageMock.setItem('parkhub_token', 'expired-token');
+  it('shows no user when me() returns failure on mount (expired cookie)', async () => {
     mockMe.mockResolvedValue({ success: false, data: null });
 
     render(
@@ -208,7 +199,6 @@ describe('AuthContext', () => {
     });
 
     expect(screen.getByTestId('user').textContent).toBe('null');
-    expect(localStorageMock.removeItem).toHaveBeenCalledWith('parkhub_token');
   });
 
   it('login returns generic error when API gives no message', async () => {

--- a/parkhub-web/src/context/AuthContext.tsx
+++ b/parkhub-web/src/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import { api, type User } from '../api/client';
+import { api, type User, setInMemoryToken } from '../api/client';
 
 interface AuthState {
   user: User | null;
@@ -16,21 +16,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const token = localStorage.getItem('parkhub_token');
-    if (token) {
-      api.me().then(res => {
-        if (res.success && res.data) setUser(res.data);
-        else localStorage.removeItem('parkhub_token');
-      }).finally(() => setLoading(false));
-    } else {
-      setLoading(false);
-    }
+    // On page load, try to authenticate via the httpOnly cookie.
+    // The cookie is sent automatically with credentials: 'include',
+    // so we just call /api/v1/users/me and see if it works.
+    api.me().then(res => {
+      if (res.success && res.data) setUser(res.data);
+    }).finally(() => setLoading(false));
   }, []);
 
   async function login(username: string, password: string) {
     const res = await api.login(username, password);
     if (res.success && res.data?.tokens?.access_token) {
-      localStorage.setItem('parkhub_token', res.data.tokens.access_token);
+      // Store token in memory as fallback (not localStorage -- XSS safe).
+      // The httpOnly cookie is the primary auth mechanism for the browser.
+      setInMemoryToken(res.data.tokens.access_token);
       const me = await api.me();
       if (me.success && me.data) {
         setUser(me.data);
@@ -40,8 +39,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return { success: false, error: res.error?.message || 'Login failed' };
   }
 
-  function logout() {
-    localStorage.removeItem('parkhub_token');
+  async function logout() {
+    // Call the server to clear the cookie and invalidate the session
+    await api.logout();
+    setInMemoryToken(null);
     setUser(null);
   }
 

--- a/parkhub-web/src/context/ThemeContext.tsx
+++ b/parkhub-web/src/context/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState, useCallback, useSyncExternalStore, type ReactNode } from 'react';
+import { getInMemoryToken } from '../api/client';
 
 // ── Light/Dark Mode ──
 
@@ -177,18 +178,18 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     if (!DESIGN_THEMES.some(t => t.id === id)) return;
     setDesignThemeState(id);
     localStorage.setItem('parkhub_design_theme', id);
-    // Sync to server if user is logged in
-    const token = localStorage.getItem('parkhub_token');
-    if (token) {
-      fetch('/api/v1/preferences/theme', {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ design_theme: id }),
-      }).catch(() => {});
-    }
+    // Sync to server if user is logged in (uses cookie or in-memory token)
+    const token = getInMemoryToken();
+    fetch('/api/v1/preferences/theme', {
+      method: 'PUT',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ design_theme: id }),
+    }).catch(() => {});
   }, []);
 
   const currentDesignTheme = DESIGN_THEMES.find(t => t.id === designTheme) || DESIGN_THEMES[0];

--- a/parkhub-web/src/i18n/index.ts
+++ b/parkhub-web/src/i18n/index.ts
@@ -42,12 +42,14 @@ i18n
 export async function loadTranslationOverrides(): Promise<void> {
   try {
     const base = (import.meta as Record<string, any>).env?.VITE_API_URL || '';
-    const token = typeof localStorage !== 'undefined' ? localStorage.getItem('parkhub_token') : null;
+    const { getInMemoryToken } = await import('../api/client');
+    const token = getInMemoryToken();
     const headers: Record<string, string> = {
       Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     };
-    const res = await fetch(`${base}/api/v1/translations/overrides`, { headers });
+    const res = await fetch(`${base}/api/v1/translations/overrides`, { headers, credentials: 'include' });
     if (!res.ok) return;
     const json = await res.json();
     const overrides: { language: string; key: string; value: string }[] =

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,6 +55,7 @@ Route::get('/legal/impressum', [PublicController::class, 'legalImpressum']);
 // Protected routes
 Route::middleware('auth:sanctum')->group(function () {
     // Auth
+    Route::post('/auth/logout', [AuthController::class, 'logout']);
     Route::post('/refresh', [AuthController::class, 'refresh']);
     Route::get('/me', [AuthController::class, 'me']);
     Route::put('/me', [AuthController::class, 'updateMe']);

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -83,6 +83,7 @@ Route::get('/discover', [PublicController::class, 'discover']);
 
 Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
     // Auth (protected)
+    Route::post('/auth/logout', [AuthController::class, 'logout']);
     Route::post('/auth/refresh', [AuthController::class, 'refresh']);
     Route::patch('/users/me/password', [AuthController::class, 'changePassword']);
 

--- a/tests/Feature/HttpOnlyCookieAuthTest.php
+++ b/tests/Feature/HttpOnlyCookieAuthTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HttpOnlyCookieAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_sets_httponly_cookie(): void
+    {
+        User::factory()->create([
+            'username' => 'cookieuser',
+            'password' => bcrypt('password123'),
+        ]);
+
+        $response = $this->postJson('/api/v1/auth/login', [
+            'username' => 'cookieuser',
+            'password' => 'password123',
+        ]);
+
+        $response->assertStatus(200);
+
+        // Verify the cookie is set
+        $cookie = collect($response->headers->getCookies())->first(
+            fn ($c) => $c->getName() === 'parkhub_token'
+        );
+
+        $this->assertNotNull($cookie, 'parkhub_token cookie should be set');
+        $this->assertTrue($cookie->isHttpOnly(), 'Cookie should be httpOnly');
+        $this->assertSame('lax', $cookie->getSameSite(), 'Cookie should be SameSite=Lax');
+        $this->assertSame('/', $cookie->getPath(), 'Cookie path should be /');
+
+        // Token in cookie should match the one in the JSON response
+        $json = $response->json();
+        $this->assertSame(
+            $json['data']['tokens']['access_token'],
+            $cookie->getValue(),
+            'Cookie token should match response token'
+        );
+    }
+
+    public function test_register_sets_httponly_cookie(): void
+    {
+        $response = $this->postJson('/api/v1/auth/register', [
+            'username' => 'newuser',
+            'email' => 'new@example.com',
+            'password' => 'Password123',
+            'password_confirmation' => 'Password123',
+            'name' => 'New User',
+        ]);
+
+        $response->assertStatus(201);
+
+        $cookie = collect($response->headers->getCookies())->first(
+            fn ($c) => $c->getName() === 'parkhub_token'
+        );
+
+        $this->assertNotNull($cookie, 'parkhub_token cookie should be set on register');
+        $this->assertTrue($cookie->isHttpOnly());
+    }
+
+    public function test_cookie_auth_works_with_csrf_header(): void
+    {
+        $user = User::factory()->create([
+            'username' => 'cookieauth',
+            'password' => bcrypt('password123'),
+        ]);
+
+        $token = $user->createToken('test')->plainTextToken;
+
+        // Simulate cookie-based auth with X-Requested-With header.
+        // Use withUnencryptedCookie because parkhub_token is excluded from encryption,
+        // and withCredentials() so JSON requests include cookies.
+        $response = $this->withCredentials()
+            ->withUnencryptedCookie('parkhub_token', $token)
+            ->withHeader('X-Requested-With', 'XMLHttpRequest')
+            ->getJson('/api/v1/users/me');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.username', 'cookieauth');
+    }
+
+    public function test_cookie_auth_rejected_without_csrf_header(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        // Cookie present but no X-Requested-With header -> CSRF rejection
+        $response = $this->withCredentials()
+            ->withUnencryptedCookie('parkhub_token', $token)
+            ->getJson('/api/v1/users/me');
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error', 'CSRF_REQUIRED');
+    }
+
+    public function test_bearer_header_takes_precedence_over_cookie(): void
+    {
+        $user1 = User::factory()->create(['username' => 'user_header']);
+        $user2 = User::factory()->create(['username' => 'user_cookie']);
+
+        $headerToken = $user1->createToken('header-token')->plainTextToken;
+        $cookieToken = $user2->createToken('cookie-token')->plainTextToken;
+
+        // Both header and cookie present — header should win
+        $response = $this->withCredentials()
+            ->withHeader('Authorization', 'Bearer '.$headerToken)
+            ->withUnencryptedCookie('parkhub_token', $cookieToken)
+            ->withHeader('X-Requested-With', 'XMLHttpRequest')
+            ->getJson('/api/v1/users/me');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.username', 'user_header');
+    }
+
+    public function test_logout_clears_cookie_and_revokes_token(): void
+    {
+        $user = User::factory()->create([
+            'username' => 'logoutuser',
+            'password' => bcrypt('password123'),
+        ]);
+
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson('/api/v1/auth/logout');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.message', 'Logged out');
+
+        // Cookie should be cleared (expired)
+        $cookie = collect($response->headers->getCookies())->first(
+            fn ($c) => $c->getName() === 'parkhub_token'
+        );
+
+        $this->assertNotNull($cookie, 'Logout should set a clearing cookie');
+        $this->assertTrue(
+            $cookie->getExpiresTime() < time(),
+            'Cookie should be expired to clear it'
+        );
+
+        // Token should be revoked — verify it no longer exists in the DB
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+        ]);
+    }
+
+    public function test_refresh_sets_new_cookie(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson('/api/v1/auth/refresh');
+
+        $response->assertStatus(200);
+
+        $cookie = collect($response->headers->getCookies())->first(
+            fn ($c) => $c->getName() === 'parkhub_token'
+        );
+
+        $this->assertNotNull($cookie, 'Refresh should set new cookie');
+        $this->assertTrue($cookie->isHttpOnly());
+
+        // New token should match
+        $json = $response->json();
+        $this->assertSame(
+            $json['data']['tokens']['access_token'],
+            $cookie->getValue()
+        );
+    }
+
+    public function test_invalid_cookie_token_falls_through_to_401(): void
+    {
+        $response = $this->withCredentials()
+            ->withUnencryptedCookie('parkhub_token', 'invalid-token-value')
+            ->withHeader('X-Requested-With', 'XMLHttpRequest')
+            ->getJson('/api/v1/users/me');
+
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Summary
- Port httpOnly cookie auth from parkhub-rust PR #180 to the Laravel/PHP backend
- Replace all `localStorage` JWT storage in the frontend with in-memory token + httpOnly cookies
- Add `AuthenticateFromCookie` middleware that checks both Bearer header and `parkhub_token` cookie (header takes precedence)
- CSRF protection via required `X-Requested-With: XMLHttpRequest` header on cookie-authenticated requests
- Add `POST /api/v1/auth/logout` endpoint that revokes the token and clears the cookie

## Changes

### Backend (Laravel)
- **AuthController**: Set httpOnly cookie on login/register/refresh/changePassword responses; add logout endpoint
- **AuthenticateFromCookie middleware**: Reads `parkhub_token` cookie, validates CSRF header, injects Bearer token for Sanctum
- **bootstrap/app.php**: Register middleware, exclude `parkhub_token` from cookie encryption
- **config/cors.php**: Enable `supports_credentials`
- **routes**: Add `/auth/logout` to both `api.php` and `api_v1.php`

### Frontend (React/TypeScript)
- **client.ts**: In-memory token storage, `credentials: 'include'`, `X-Requested-With` header, `api.logout()` endpoint
- **AuthContext.tsx**: Cookie-based session restore on mount, server-side logout
- **ThemeContext.tsx, ParkingPass.tsx, ExportButton.tsx, i18n/index.ts**: Replace all `localStorage.getItem('parkhub_token')` with `getInMemoryToken()`

### Tests
- 8 PHP feature tests: cookie set on login/register, cookie auth with CSRF, CSRF rejection, header precedence, logout clears cookie, refresh sets new cookie, invalid token 401
- Frontend tests synced from parkhub-rust (433 tests pass)

## Test plan
- [x] `php artisan test --filter=HttpOnlyCookieAuthTest` -- 8/8 pass
- [x] `php artisan test` -- 868/869 pass (1 pre-existing module count failure)
- [x] `npx vitest run` (parkhub-web) -- 433/433 pass
- [x] `vendor/bin/pint --test` -- clean