### PR TITLE
feat: port OAuth/social login from parkhub-rust

### DIFF
--- a/app/Http/Controllers/Api/OAuthController.php
+++ b/app/Http/Controllers/Api/OAuthController.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * OAuth / Social Login controller.
+ *
+ * Supports Google and GitHub providers. Each provider is only available
+ * when the corresponding OAUTH_*_CLIENT_ID env vars are set.
+ *
+ * Flow:
+ *   1. GET /api/v1/auth/oauth/{provider}       → redirect to consent screen
+ *   2. GET /api/v1/auth/oauth/{provider}/callback → exchange code, create/link user, redirect with token
+ *   3. GET /api/v1/auth/oauth/providers         → list available providers (no secrets)
+ */
+class OAuthController extends Controller
+{
+    /**
+     * Return which OAuth providers are configured (no secrets exposed).
+     */
+    public function providers(): JsonResponse
+    {
+        return response()->json([
+            'google' => $this->isProviderConfigured('google'),
+            'github' => $this->isProviderConfigured('github'),
+        ]);
+    }
+
+    /**
+     * Redirect to Google OAuth consent screen.
+     */
+    public function googleRedirect(): RedirectResponse
+    {
+        $this->ensureProviderConfigured('google');
+
+        $params = http_build_query([
+            'client_id' => config('services.google.client_id'),
+            'redirect_uri' => $this->callbackUrl('google'),
+            'response_type' => 'code',
+            'scope' => 'openid email profile',
+            'access_type' => 'offline',
+            'state' => $this->generateState(),
+        ]);
+
+        return redirect("https://accounts.google.com/o/oauth2/v2/auth?{$params}");
+    }
+
+    /**
+     * Handle Google OAuth callback.
+     */
+    public function googleCallback(Request $request): RedirectResponse
+    {
+        $this->ensureProviderConfigured('google');
+        $this->validateCallback($request);
+
+        $code = $request->query('code');
+
+        // Exchange code for tokens
+        $tokenResponse = $this->httpPost('https://oauth2.googleapis.com/token', [
+            'code' => $code,
+            'client_id' => config('services.google.client_id'),
+            'client_secret' => config('services.google.client_secret'),
+            'redirect_uri' => $this->callbackUrl('google'),
+            'grant_type' => 'authorization_code',
+        ]);
+
+        if (! isset($tokenResponse['access_token'])) {
+            return $this->errorRedirect('OAuth token exchange failed');
+        }
+
+        // Fetch user info
+        $userInfo = $this->httpGet('https://www.googleapis.com/oauth2/v2/userinfo', $tokenResponse['access_token']);
+
+        if (! isset($userInfo['email'])) {
+            return $this->errorRedirect('Could not retrieve email from Google');
+        }
+
+        return $this->handleOAuthUser('google', $userInfo['id'] ?? $userInfo['email'], [
+            'email' => $userInfo['email'],
+            'name' => $userInfo['name'] ?? $userInfo['email'],
+            'picture' => $userInfo['picture'] ?? null,
+        ], $request);
+    }
+
+    /**
+     * Redirect to GitHub OAuth consent screen.
+     */
+    public function githubRedirect(): RedirectResponse
+    {
+        $this->ensureProviderConfigured('github');
+
+        $params = http_build_query([
+            'client_id' => config('services.github.client_id'),
+            'redirect_uri' => $this->callbackUrl('github'),
+            'scope' => 'user:email',
+            'state' => $this->generateState(),
+        ]);
+
+        return redirect("https://github.com/login/oauth/authorize?{$params}");
+    }
+
+    /**
+     * Handle GitHub OAuth callback.
+     */
+    public function githubCallback(Request $request): RedirectResponse
+    {
+        $this->ensureProviderConfigured('github');
+        $this->validateCallback($request);
+
+        $code = $request->query('code');
+
+        // Exchange code for access token
+        $tokenResponse = $this->httpPost('https://github.com/login/oauth/access_token', [
+            'client_id' => config('services.github.client_id'),
+            'client_secret' => config('services.github.client_secret'),
+            'code' => $code,
+            'redirect_uri' => $this->callbackUrl('github'),
+        ], ['Accept' => 'application/json']);
+
+        if (! isset($tokenResponse['access_token'])) {
+            return $this->errorRedirect('OAuth token exchange failed');
+        }
+
+        // Fetch user info
+        $userInfo = $this->httpGet('https://api.github.com/user', $tokenResponse['access_token']);
+
+        // GitHub may not return email in profile — fetch from emails endpoint
+        $email = $userInfo['email'] ?? null;
+        if (! $email) {
+            $emails = $this->httpGet('https://api.github.com/user/emails', $tokenResponse['access_token']);
+            if (is_array($emails)) {
+                foreach ($emails as $e) {
+                    if (! empty($e['primary']) && ! empty($e['verified'])) {
+                        $email = $e['email'];
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (! $email) {
+            return $this->errorRedirect('Could not retrieve email from GitHub');
+        }
+
+        return $this->handleOAuthUser('github', (string) ($userInfo['id'] ?? $email), [
+            'email' => $email,
+            'name' => $userInfo['name'] ?? $userInfo['login'] ?? $email,
+            'picture' => $userInfo['avatar_url'] ?? null,
+        ], $request);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private function isProviderConfigured(string $provider): bool
+    {
+        return match ($provider) {
+            'google' => ! empty(config('services.google.client_id')) && ! empty(config('services.google.client_secret')),
+            'github' => ! empty(config('services.github.client_id')) && ! empty(config('services.github.client_secret')),
+            default => false,
+        };
+    }
+
+    private function ensureProviderConfigured(string $provider): void
+    {
+        if (! $this->isProviderConfigured($provider)) {
+            abort(404, "OAuth provider '{$provider}' is not configured");
+        }
+    }
+
+    private function callbackUrl(string $provider): string
+    {
+        return rtrim(config('app.url'), '/')."/api/v1/auth/oauth/{$provider}/callback";
+    }
+
+    private function generateState(): string
+    {
+        $state = Str::random(40);
+        session(['oauth_state' => $state]);
+
+        return $state;
+    }
+
+    private function validateCallback(Request $request): void
+    {
+        if ($request->has('error')) {
+            abort(400, 'OAuth authorization denied: '.($request->query('error_description') ?? $request->query('error')));
+        }
+    }
+
+    /**
+     * Find or create user from OAuth profile, generate token, redirect to frontend.
+     */
+    private function handleOAuthUser(string $provider, string $providerId, array $profile, Request $request): RedirectResponse
+    {
+        $user = User::where('email', $profile['email'])->first();
+
+        if ($user) {
+            // Existing user — update last login
+            $user->update(['last_login' => now()]);
+            if (! empty($profile['picture']) && ! $user->picture) {
+                $user->update(['picture' => $profile['picture']]);
+            }
+        } else {
+            // New user — create account
+            $username = Str::slug($profile['name'] ?? 'user', '_').'_'.Str::random(4);
+            $user = User::create([
+                'username' => $username,
+                'email' => $profile['email'],
+                'password' => Hash::make(Str::random(32)), // random password — user uses OAuth
+                'name' => $profile['name'],
+                'picture' => $profile['picture'],
+                'is_active' => true,
+                'preferences' => ['language' => 'en', 'theme' => 'system', 'notifications_enabled' => true],
+            ]);
+            $user->role = 'user';
+            $user->save();
+        }
+
+        if (! $user->is_active) {
+            return $this->errorRedirect('Account is disabled');
+        }
+
+        $token = $user->createToken('oauth-'.$provider);
+
+        AuditLog::log([
+            'user_id' => $user->id,
+            'username' => $user->username,
+            'action' => 'oauth_login',
+            'details' => ['provider' => $provider],
+            'ip_address' => $request->ip(),
+        ]);
+
+        // Redirect to frontend with token
+        $frontendUrl = rtrim(config('app.url'), '/');
+
+        return redirect("{$frontendUrl}/oauth/callback?token={$token->plainTextToken}");
+    }
+
+    private function errorRedirect(string $message): RedirectResponse
+    {
+        $frontendUrl = rtrim(config('app.url'), '/');
+
+        return redirect("{$frontendUrl}/login?oauth_error=".urlencode($message));
+    }
+
+    /**
+     * HTTP POST helper.
+     */
+    private function httpPost(string $url, array $data, array $extraHeaders = []): array
+    {
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => http_build_query($data),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_HTTPHEADER => array_merge([
+                'Accept: application/json',
+                'Content-Type: application/x-www-form-urlencoded',
+            ], array_map(fn ($k, $v) => "{$k}: {$v}", array_keys($extraHeaders), array_values($extraHeaders))),
+        ]);
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        return json_decode($response ?: '{}', true) ?: [];
+    }
+
+    /**
+     * HTTP GET helper with Bearer token.
+     */
+    private function httpGet(string $url, string $token): array
+    {
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_HTTPHEADER => [
+                'Accept: application/json',
+                "Authorization: Bearer {$token}",
+                'User-Agent: ParkHub-PHP',
+            ],
+        ]);
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        return json_decode($response ?: '{}', true) ?: [];
+    }
+}

--- a/config/modules.php
+++ b/config/modules.php
@@ -34,4 +34,5 @@ return [
     'push_notifications' => env('MODULE_PUSH_NOTIFICATIONS', true),
     'stripe' => env('MODULE_STRIPE', false), // disabled by default — requires Stripe keys
     'themes' => env('MODULE_THEMES', true),
+    'oauth' => env('MODULE_OAUTH', false), // disabled by default — requires OAuth credentials
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,14 @@ return [
         ],
     ],
 
+    'google' => [
+        'client_id' => env('OAUTH_GOOGLE_CLIENT_ID'),
+        'client_secret' => env('OAUTH_GOOGLE_CLIENT_SECRET'),
+    ],
+
+    'github' => [
+        'client_id' => env('OAUTH_GITHUB_CLIENT_ID'),
+        'client_secret' => env('OAUTH_GITHUB_CLIENT_SECRET'),
+    ],
+
 ];

--- a/parkhub-web/src/components/OAuthButtons.test.tsx
+++ b/parkhub-web/src/components/OAuthButtons.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'auth.continueWithGoogle': 'Continue with Google',
+        'auth.continueWithGitHub': 'Continue with GitHub',
+        'auth.orContinueWith': 'or',
+      };
+      return map[key] || key;
+    },
+  }),
+}));
+
+import { OAuthButtons } from './OAuthButtons';
+
+describe('OAuthButtons', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders both buttons when both providers are available', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+      expect(screen.getByTestId('oauth-github')).toBeDefined();
+    });
+
+    expect(screen.getByText('Continue with Google')).toBeDefined();
+    expect(screen.getByText('Continue with GitHub')).toBeDefined();
+  });
+
+  it('renders only Google button when only Google is configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: false } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+    });
+
+    expect(screen.queryByTestId('oauth-github')).toBeNull();
+  });
+
+  it('renders only GitHub button when only GitHub is configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: false, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-github')).toBeDefined();
+    });
+
+    expect(screen.queryByTestId('oauth-google')).toBeNull();
+  });
+
+  it('renders nothing when no providers are configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: false, github: false } }),
+    }) as any;
+
+    const { container } = render(<OAuthButtons />);
+
+    // Wait for fetch to resolve
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    // Should render nothing
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when fetch fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error')) as any;
+
+    const { container } = render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders correct OAuth redirect URLs', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+    });
+
+    const googleLink = screen.getByTestId('oauth-google');
+    const githubLink = screen.getByTestId('oauth-github');
+
+    expect(googleLink.getAttribute('href')).toBe('/api/v1/auth/oauth/google');
+    expect(githubLink.getAttribute('href')).toBe('/api/v1/auth/oauth/github');
+  });
+
+  it('shows divider text between OAuth buttons and form', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: false } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByText('or')).toBeDefined();
+    });
+  });
+});

--- a/parkhub-web/src/components/OAuthButtons.tsx
+++ b/parkhub-web/src/components/OAuthButtons.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface OAuthProviders {
+  google: boolean;
+  github: boolean;
+}
+
+/** Fetch which OAuth providers are configured from the backend. */
+async function fetchProviders(): Promise<OAuthProviders> {
+  try {
+    const base = (import.meta as Record<string, any>).env?.VITE_API_URL || '';
+    const res = await fetch(`${base}/api/v1/auth/oauth/providers`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return { google: false, github: false };
+    const json = await res.json();
+    return json?.data || { google: false, github: false };
+  } catch {
+    return { google: false, github: false };
+  }
+}
+
+/** Google icon SVG (brand colors) */
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.77.42 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+/** GitHub icon SVG */
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.49.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
+    </svg>
+  );
+}
+
+/**
+ * OAuth / Social Login buttons.
+ *
+ * Only renders buttons for providers that are actually configured on the backend.
+ * If no providers are configured, renders nothing.
+ */
+export function OAuthButtons() {
+  const { t } = useTranslation();
+  const [providers, setProviders] = useState<OAuthProviders | null>(null);
+
+  useEffect(() => {
+    fetchProviders().then(setProviders);
+  }, []);
+
+  // Don't render anything if providers haven't loaded or none are configured
+  if (!providers || (!providers.google && !providers.github)) {
+    return null;
+  }
+
+  const base = (import.meta as Record<string, any>).env?.VITE_API_URL || '';
+
+  return (
+    <div className="space-y-3">
+      {providers.google && (
+        <a
+          href={`${base}/api/v1/auth/oauth/google`}
+          className="flex items-center justify-center gap-3 w-full py-2.5 px-4 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-700 dark:text-surface-200 font-medium text-sm hover:bg-surface-50 dark:hover:bg-surface-750 transition-colors shadow-sm"
+          data-testid="oauth-google"
+        >
+          <GoogleIcon />
+          {t('auth.continueWithGoogle')}
+        </a>
+      )}
+
+      {providers.github && (
+        <a
+          href={`${base}/api/v1/auth/oauth/github`}
+          className="flex items-center justify-center gap-3 w-full py-2.5 px-4 rounded-lg bg-surface-900 dark:bg-surface-100 text-white dark:text-surface-900 font-medium text-sm hover:bg-surface-800 dark:hover:bg-surface-200 transition-colors shadow-sm"
+          data-testid="oauth-github"
+        >
+          <GitHubIcon />
+          {t('auth.continueWithGitHub')}
+        </a>
+      )}
+
+      <div className="flex items-center gap-3 my-1">
+        <div className="flex-1 h-px bg-surface-200 dark:bg-surface-700" />
+        <span className="text-xs text-surface-400 dark:text-surface-500 uppercase tracking-wider">{t('auth.orContinueWith')}</span>
+        <div className="flex-1 h-px bg-surface-200 dark:bg-surface-700" />
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/i18n/locales/de.ts
+++ b/parkhub-web/src/i18n/locales/de.ts
@@ -47,6 +47,9 @@ export default {
       ruleLower: 'Kleinbuchstabe',
       ruleUpper: 'Großbuchstabe',
       ruleDigit: 'Zahl',
+      continueWithGoogle: 'Weiter mit Google',
+      continueWithGitHub: 'Weiter mit GitHub',
+      orContinueWith: 'oder',
     },
     nav: {
       dashboard: 'Dashboard',
@@ -483,6 +486,7 @@ export default {
         team_view: { name: 'Team-Ansicht', desc: 'Sehen wer im Buro oder remote arbeitet', help: 'Zeigt Team-Prasenz basierend auf Abwesenheiten und Buchungsdaten.' },
         booking_types: { name: 'Buchungstypen', desc: 'Ein- und mehrtägige sowie wiederkehrende Buchungen', help: 'Verschiedene Buchungstypen uber einfache Reservierungen hinaus.' },
         invoices: { name: 'Rechnungen', desc: 'PDF-Rechnungen fur Buchungen erstellen', help: 'Automatisch Rechnungen fur abgeschlossene Buchungen generieren.' },
+        oauth: { name: 'OAuth / Social Login', desc: 'Mit Google oder GitHub anmelden', help: 'Social-Login-Buttons auf Login- und Registrierungsseiten. Erfordert OAuth-Zugangsdaten.' },
         self_registration: { name: 'Selbstregistrierung', desc: 'Benutzer konnen Konten ohne Admin-Genehmigung erstellen', help: 'Neue Benutzer konnen sich selbst registrieren.' },
         generative_bg: { name: 'Generativer Hintergrund', desc: 'Animierte Hintergrunde auf offentlichen Seiten', help: 'Dezente animierte Muster auf Login- und Willkommensseiten.' },
         micro_animations: { name: 'Mikro-Animationen', desc: 'Sanfte Ubergange und Hover-Effekte', help: 'Spring-Physik-Animationen und gestaffelte Listen.' },

--- a/parkhub-web/src/i18n/locales/en.ts
+++ b/parkhub-web/src/i18n/locales/en.ts
@@ -47,6 +47,9 @@ export default {
       ruleLower: 'Lowercase',
       ruleUpper: 'Uppercase',
       ruleDigit: 'Number',
+      continueWithGoogle: 'Continue with Google',
+      continueWithGitHub: 'Continue with GitHub',
+      orContinueWith: 'or',
     },
     nav: {
       dashboard: 'Dashboard',
@@ -483,6 +486,7 @@ export default {
         team_view: { name: 'Team View', desc: 'See who is in the office or working remotely', help: 'Shows team presence overview based on absence entries and booking data.' },
         booking_types: { name: 'Booking Types', desc: 'Support single-day, multi-day, and recurring bookings', help: 'Enable different booking types beyond simple single-slot reservations.' },
         invoices: { name: 'Invoices', desc: 'Generate PDF invoices for bookings', help: 'Automatically generate and download invoices for completed bookings.' },
+        oauth: { name: 'OAuth / Social Login', desc: 'Sign in with Google or GitHub', help: 'Enable social login buttons on the login and registration pages. Requires OAuth credentials.' },
         self_registration: { name: 'Self Registration', desc: 'Allow users to create accounts without admin approval', help: 'New users can register themselves. Disable for invite-only setups.' },
         generative_bg: { name: 'Generative Background', desc: 'Animated generative art backgrounds on public pages', help: 'Adds subtle animated patterns to login, welcome, and onboarding screens.' },
         micro_animations: { name: 'Micro Animations', desc: 'Smooth transitions and hover effects throughout the UI', help: 'Enables spring physics animations, staggered lists, and hover feedback.' },

--- a/parkhub-web/src/views/Login.tsx
+++ b/parkhub-web/src/views/Login.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { CarSimple, Eye, EyeSlash, SpinnerGap, ArrowLeft } from '@phosphor-icons/react';
 import { useAuth } from '../context/AuthContext';
 import { FormField, FormInput } from '../components/ui/FormField';
+import { OAuthButtons } from '../components/OAuthButtons';
 // @ts-ignore — Vite resolves JSON imports at build time
 import { version as APP_VERSION } from '../../package.json';
 
@@ -129,6 +130,9 @@ export function LoginPage() {
           <p className="text-surface-500 dark:text-surface-400 text-sm mb-8">
             {t('auth.loginSubtitle')}
           </p>
+
+          {/* OAuth social login buttons */}
+          <OAuthButtons />
 
           {/* Demo hint */}
           <button

--- a/parkhub-web/src/views/Register.tsx
+++ b/parkhub-web/src/views/Register.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { CarSimple, SpinnerGap, ArrowLeft, Check, X } from '@phosphor-icons/react';
 import { api } from '../api/client';
 import { FormField, FormInput } from '../components/ui/FormField';
+import { OAuthButtons } from '../components/OAuthButtons';
 
 const registerSchema = z.object({
   name: z.string().min(1, 'Required'),
@@ -89,6 +90,9 @@ export function RegisterPage() {
 
         <h1 className="text-2xl font-bold text-surface-900 dark:text-white mb-1">{t('auth.register')}</h1>
         <p className="text-surface-500 dark:text-surface-400 text-sm mb-8">{t('auth.registerSubtitle')}</p>
+
+        {/* OAuth social login buttons */}
+        <OAuthButtons />
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-5" noValidate>
           <FormField label={t('auth.name')} htmlFor="reg-name" error={errors.name} required>

--- a/resources/js/src/components/OAuthButtons.test.tsx
+++ b/resources/js/src/components/OAuthButtons.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'auth.continueWithGoogle': 'Continue with Google',
+        'auth.continueWithGitHub': 'Continue with GitHub',
+        'auth.orContinueWith': 'or',
+      };
+      return map[key] || key;
+    },
+  }),
+}));
+
+import { OAuthButtons } from './OAuthButtons';
+
+describe('OAuthButtons', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders both buttons when both providers are available', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+      expect(screen.getByTestId('oauth-github')).toBeDefined();
+    });
+
+    expect(screen.getByText('Continue with Google')).toBeDefined();
+    expect(screen.getByText('Continue with GitHub')).toBeDefined();
+  });
+
+  it('renders only Google button when only Google is configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: false } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+    });
+
+    expect(screen.queryByTestId('oauth-github')).toBeNull();
+  });
+
+  it('renders only GitHub button when only GitHub is configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: false, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-github')).toBeDefined();
+    });
+
+    expect(screen.queryByTestId('oauth-google')).toBeNull();
+  });
+
+  it('renders nothing when no providers are configured', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: false, github: false } }),
+    }) as any;
+
+    const { container } = render(<OAuthButtons />);
+
+    // Wait for fetch to resolve
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    // Should render nothing
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when fetch fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error')) as any;
+
+    const { container } = render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders correct OAuth redirect URLs', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: true } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('oauth-google')).toBeDefined();
+    });
+
+    const googleLink = screen.getByTestId('oauth-google');
+    const githubLink = screen.getByTestId('oauth-github');
+
+    expect(googleLink.getAttribute('href')).toBe('/api/v1/auth/oauth/google');
+    expect(githubLink.getAttribute('href')).toBe('/api/v1/auth/oauth/github');
+  });
+
+  it('shows divider text between OAuth buttons and form', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { google: true, github: false } }),
+    }) as any;
+
+    render(<OAuthButtons />);
+
+    await waitFor(() => {
+      expect(screen.getByText('or')).toBeDefined();
+    });
+  });
+});

--- a/resources/js/src/components/OAuthButtons.tsx
+++ b/resources/js/src/components/OAuthButtons.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface OAuthProviders {
+  google: boolean;
+  github: boolean;
+}
+
+/** Fetch which OAuth providers are configured from the backend. */
+async function fetchProviders(): Promise<OAuthProviders> {
+  try {
+    const base = (import.meta as Record<string, any>).env?.VITE_API_URL || '';
+    const res = await fetch(`${base}/api/v1/auth/oauth/providers`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return { google: false, github: false };
+    const json = await res.json();
+    return json?.data || { google: false, github: false };
+  } catch {
+    return { google: false, github: false };
+  }
+}
+
+/** Google icon SVG (brand colors) */
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.77.42 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+/** GitHub icon SVG */
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.49.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
+    </svg>
+  );
+}
+
+/**
+ * OAuth / Social Login buttons.
+ *
+ * Only renders buttons for providers that are actually configured on the backend.
+ * If no providers are configured, renders nothing.
+ */
+export function OAuthButtons() {
+  const { t } = useTranslation();
+  const [providers, setProviders] = useState<OAuthProviders | null>(null);
+
+  useEffect(() => {
+    fetchProviders().then(setProviders);
+  }, []);
+
+  // Don't render anything if providers haven't loaded or none are configured
+  if (!providers || (!providers.google && !providers.github)) {
+    return null;
+  }
+
+  const base = (import.meta as Record<string, any>).env?.VITE_API_URL || '';
+
+  return (
+    <div className="space-y-3">
+      {providers.google && (
+        <a
+          href={`${base}/api/v1/auth/oauth/google`}
+          className="flex items-center justify-center gap-3 w-full py-2.5 px-4 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-surface-700 dark:text-surface-200 font-medium text-sm hover:bg-surface-50 dark:hover:bg-surface-750 transition-colors shadow-sm"
+          data-testid="oauth-google"
+        >
+          <GoogleIcon />
+          {t('auth.continueWithGoogle')}
+        </a>
+      )}
+
+      {providers.github && (
+        <a
+          href={`${base}/api/v1/auth/oauth/github`}
+          className="flex items-center justify-center gap-3 w-full py-2.5 px-4 rounded-lg bg-surface-900 dark:bg-surface-100 text-white dark:text-surface-900 font-medium text-sm hover:bg-surface-800 dark:hover:bg-surface-200 transition-colors shadow-sm"
+          data-testid="oauth-github"
+        >
+          <GitHubIcon />
+          {t('auth.continueWithGitHub')}
+        </a>
+      )}
+
+      <div className="flex items-center gap-3 my-1">
+        <div className="flex-1 h-px bg-surface-200 dark:bg-surface-700" />
+        <span className="text-xs text-surface-400 dark:text-surface-500 uppercase tracking-wider">{t('auth.orContinueWith')}</span>
+        <div className="flex-1 h-px bg-surface-200 dark:bg-surface-700" />
+      </div>
+    </div>
+  );
+}

--- a/resources/js/src/i18n/locales/de.ts
+++ b/resources/js/src/i18n/locales/de.ts
@@ -47,6 +47,9 @@ export default {
       ruleLower: 'Kleinbuchstabe',
       ruleUpper: 'Großbuchstabe',
       ruleDigit: 'Zahl',
+      continueWithGoogle: 'Weiter mit Google',
+      continueWithGitHub: 'Weiter mit GitHub',
+      orContinueWith: 'oder',
     },
     nav: {
       dashboard: 'Dashboard',

--- a/resources/js/src/i18n/locales/en.ts
+++ b/resources/js/src/i18n/locales/en.ts
@@ -47,6 +47,9 @@ export default {
       ruleLower: 'Lowercase',
       ruleUpper: 'Uppercase',
       ruleDigit: 'Number',
+      continueWithGoogle: 'Continue with Google',
+      continueWithGitHub: 'Continue with GitHub',
+      orContinueWith: 'or',
     },
     nav: {
       dashboard: 'Dashboard',

--- a/resources/js/src/views/Login.tsx
+++ b/resources/js/src/views/Login.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { CarSimple, Eye, EyeSlash, SpinnerGap, ArrowLeft } from '@phosphor-icons/react';
 import { useAuth } from '../context/AuthContext';
 import { FormField, FormInput } from '../components/ui/FormField';
+import { OAuthButtons } from '../components/OAuthButtons';
 // @ts-ignore — Vite resolves JSON imports at build time
 import { version as APP_VERSION } from '../../package.json';
 
@@ -107,6 +108,9 @@ export function LoginPage() {
           <p className="text-surface-500 dark:text-surface-400 text-sm mb-8">
             {t('auth.loginSubtitle')}
           </p>
+
+          {/* OAuth social login buttons */}
+          <OAuthButtons />
 
           {/* Demo hint — click to auto-fill credentials */}
           <button

--- a/resources/js/src/views/Register.tsx
+++ b/resources/js/src/views/Register.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { CarSimple, SpinnerGap, ArrowLeft, Check, X } from '@phosphor-icons/react';
 import { api } from '../api/client';
 import { FormField, FormInput } from '../components/ui/FormField';
+import { OAuthButtons } from '../components/OAuthButtons';
 
 const registerSchema = z.object({
   name: z.string().min(1, 'Required'),
@@ -89,6 +90,9 @@ export function RegisterPage() {
 
         <h1 className="text-2xl font-bold text-surface-900 dark:text-white mb-1">{t('auth.register')}</h1>
         <p className="text-surface-500 dark:text-surface-400 text-sm mb-8">{t('auth.registerSubtitle')}</p>
+
+        {/* OAuth social login buttons */}
+        <OAuthButtons />
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-5" noValidate>
           <FormField label={t('auth.name')} htmlFor="reg-name" error={errors.name} required>

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -228,3 +228,6 @@ module_routes('setup_wizard', 'setup_wizard.php');
 module_routes('gdpr', 'gdpr.php');
 module_routes('push_notifications', 'push_notifications.php');
 module_routes('themes', 'themes.php');
+
+// OAuth — always load routes (module disabled by default, middleware gates access)
+require base_path('routes/modules/oauth.php');

--- a/routes/modules/oauth.php
+++ b/routes/modules/oauth.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * OAuth module routes (api/v1).
+ * Loaded only when MODULE_OAUTH=true (disabled by default — requires OAuth credentials).
+ *
+ * Provides social login via Google and GitHub.
+ */
+
+use App\Http\Controllers\Api\OAuthController;
+use Illuminate\Support\Facades\Route;
+
+// Public OAuth routes (no auth required — these initiate and complete the OAuth flow)
+Route::middleware(['module:oauth', 'throttle:auth'])->group(function () {
+    Route::get('/auth/oauth/providers', [OAuthController::class, 'providers']);
+    Route::get('/auth/oauth/google', [OAuthController::class, 'googleRedirect']);
+    Route::get('/auth/oauth/google/callback', [OAuthController::class, 'googleCallback']);
+    Route::get('/auth/oauth/github', [OAuthController::class, 'githubRedirect']);
+    Route::get('/auth/oauth/github/callback', [OAuthController::class, 'githubCallback']);
+});

--- a/tests/Feature/ModuleSystemExtendedTest.php
+++ b/tests/Feature/ModuleSystemExtendedTest.php
@@ -130,7 +130,7 @@ class ModuleSystemExtendedTest extends TestCase
     public function test_module_service_provider_all_returns_correct_count(): void
     {
         $all = ModuleServiceProvider::all();
-        $this->assertCount(23, $all);
+        $this->assertCount(24, $all);
     }
 
     public function test_modules_endpoint_is_always_public(): void

--- a/tests/Feature/ModuleSystemTest.php
+++ b/tests/Feature/ModuleSystemTest.php
@@ -335,10 +335,10 @@ class ModuleSystemTest extends TestCase
             ->assertOk();
     }
 
-    public function test_all_23_modules_in_config(): void
+    public function test_all_24_modules_in_config(): void
     {
         $modules = config('modules');
 
-        $this->assertCount(23, $modules);
+        $this->assertCount(24, $modules);
     }
 }

--- a/tests/Feature/OAuthTest.php
+++ b/tests/Feature/OAuthTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_providers_endpoint_returns_configured_providers(): void
+    {
+        // With no OAuth env vars set, both should be false
+        config(['services.google.client_id' => null, 'services.google.client_secret' => null]);
+        config(['services.github.client_id' => null, 'services.github.client_secret' => null]);
+        config(['modules.oauth' => true]);
+
+        $response = $this->getJson('/api/v1/auth/oauth/providers');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertFalse($data['google']);
+        $this->assertFalse($data['github']);
+    }
+
+    public function test_providers_endpoint_shows_google_when_configured(): void
+    {
+        config([
+            'services.google.client_id' => 'test-client-id',
+            'services.google.client_secret' => 'test-client-secret',
+            'services.github.client_id' => null,
+            'services.github.client_secret' => null,
+            'modules.oauth' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/auth/oauth/providers');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertTrue($data['google']);
+        $this->assertFalse($data['github']);
+    }
+
+    public function test_providers_endpoint_shows_github_when_configured(): void
+    {
+        config([
+            'services.google.client_id' => null,
+            'services.google.client_secret' => null,
+            'services.github.client_id' => 'test-client-id',
+            'services.github.client_secret' => 'test-client-secret',
+            'modules.oauth' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/auth/oauth/providers');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertFalse($data['google']);
+        $this->assertTrue($data['github']);
+    }
+
+    public function test_google_redirect_returns_redirect_when_configured(): void
+    {
+        config([
+            'services.google.client_id' => 'test-google-id',
+            'services.google.client_secret' => 'test-google-secret',
+            'modules.oauth' => true,
+        ]);
+
+        $response = $this->get('/api/v1/auth/oauth/google');
+
+        $response->assertStatus(302);
+        $this->assertStringContains('accounts.google.com', $response->headers->get('Location'));
+    }
+
+    public function test_github_redirect_returns_redirect_when_configured(): void
+    {
+        config([
+            'services.github.client_id' => 'test-github-id',
+            'services.github.client_secret' => 'test-github-secret',
+            'modules.oauth' => true,
+        ]);
+
+        $response = $this->get('/api/v1/auth/oauth/github');
+
+        $response->assertStatus(302);
+        $this->assertStringContains('github.com/login/oauth', $response->headers->get('Location'));
+    }
+
+    public function test_google_redirect_404_when_not_configured(): void
+    {
+        config([
+            'services.google.client_id' => null,
+            'services.google.client_secret' => null,
+            'modules.oauth' => true,
+        ]);
+
+        $response = $this->get('/api/v1/auth/oauth/google');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_github_redirect_404_when_not_configured(): void
+    {
+        config([
+            'services.github.client_id' => null,
+            'services.github.client_secret' => null,
+            'modules.oauth' => true,
+        ]);
+
+        $response = $this->get('/api/v1/auth/oauth/github');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_google_callback_with_error_param_aborts(): void
+    {
+        config([
+            'services.google.client_id' => 'test-id',
+            'services.google.client_secret' => 'test-secret',
+            'modules.oauth' => true,
+        ]);
+
+        $response = $this->get('/api/v1/auth/oauth/google/callback?error=access_denied&error_description=User+denied');
+
+        $response->assertStatus(400);
+    }
+
+    public function test_github_callback_with_error_param_aborts(): void
+    {
+        config([
+            'services.github.client_id' => 'test-id',
+            'services.github.client_secret' => 'test-secret',
+            'modules.oauth' => true,
+        ]);
+
+        $response = $this->get('/api/v1/auth/oauth/github/callback?error=access_denied');
+
+        $response->assertStatus(400);
+    }
+
+    /**
+     * Helper: assertStringContains for URL checks.
+     */
+    private function assertStringContains(string $needle, ?string $haystack): void
+    {
+        $this->assertNotNull($haystack, "Expected non-null string containing '{$needle}'");
+        $this->assertTrue(
+            str_contains($haystack, $needle),
+            "Expected '{$haystack}' to contain '{$needle}'"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add Google and GitHub OAuth/social login as a toggleable module (`MODULE_OAUTH`)
- Backend: `OAuthController` with providers, redirect, and callback endpoints
- Frontend: `OAuthButtons` component on Login and Register pages
- i18n strings (en/de) for social login buttons

## Changes
- **New**: `app/Http/Controllers/Api/OAuthController.php` - full OAuth flow
- **New**: `routes/modules/oauth.php` - module route file
- **New**: `OAuthButtons.tsx` + test (copied from parkhub-rust)
- **Modified**: Login.tsx, Register.tsx - added OAuthButtons component
- **Modified**: config/modules.php, config/services.php - OAuth config
- **Modified**: en.ts, de.ts - i18n strings

## Test plan
- [x] 9 PHP tests pass (providers, redirects, error handling)
- [x] 7 frontend tests pass (OAuthButtons component)
- [x] Full suite: 878 PHP tests pass, 0 regressions