### PR TITLE
feat: port PDF invoice improvements from parkhub-rust

### DIFF
--- a/app/Http/Controllers/Api/BookingInvoiceController.php
+++ b/app/Http/Controllers/Api/BookingInvoiceController.php
@@ -96,7 +96,8 @@ class BookingInvoiceController extends Controller
         $dateNow = date('d.m.Y');
 
         $shortId = strtoupper(substr(str_replace('-', '', $booking->id), 0, 8));
-        $invoiceNo = 'INV-'.date('Ym').'-'.$shortId;
+        $year = $booking->created_at ? $booking->created_at->format('Y') : date('Y');
+        $invoiceNo = 'INV-'.$year.'-'.$shortId;
 
         return compact(
             'company', 'vatId', 'street', 'zipCity', 'email',

--- a/config/modules.php
+++ b/config/modules.php
@@ -35,4 +35,5 @@ return [
     'stripe' => env('MODULE_STRIPE', false), // disabled by default — requires Stripe keys
     'themes' => env('MODULE_THEMES', true),
     'oauth' => env('MODULE_OAUTH', false), // disabled by default — requires OAuth credentials
+    'invoices' => env('MODULE_INVOICES', true),
 ];

--- a/parkhub-web/src/i18n/locales/de.ts
+++ b/parkhub-web/src/i18n/locales/de.ts
@@ -117,6 +117,7 @@ export default {
       startsIn: 'Beginnt {{time}}',
       endsIn: 'Endet {{time}}',
       invoice: 'Rechnung',
+      downloadInvoice: 'Rechnung',
       loading: 'Buchungen werden geladen...',
       insufficientCredits: 'Nicht genug Credits zum Buchen',
     },

--- a/parkhub-web/src/i18n/locales/en.ts
+++ b/parkhub-web/src/i18n/locales/en.ts
@@ -117,6 +117,7 @@ export default {
       startsIn: 'Starts {{time}}',
       endsIn: 'Ends {{time}}',
       invoice: 'Invoice',
+      downloadInvoice: 'Invoice',
       loading: 'Loading bookings...',
       insufficientCredits: 'Not enough credits to book',
     },

--- a/parkhub-web/src/views/Bookings.tsx
+++ b/parkhub-web/src/views/Bookings.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import {
   CalendarBlank, Clock, Car, X, SpinnerGap,
   ArrowClockwise, Warning, MapPin, CalendarPlus, Timer,
-  MagnifyingGlass, Funnel, QrCode,
+  MagnifyingGlass, Funnel, QrCode, FilePdf,
 } from '@phosphor-icons/react';
 import type { TFunction } from 'react-i18next';
 import { api, type Booking, type Vehicle } from '../api/client';
@@ -269,6 +269,16 @@ function BookingCard({ booking, now, vehicles, onCancel, cancelling, onShowPass,
               <QrCode weight="bold" className="w-4 h-4" /> {t('pass.showPass')}
             </button>
           )}
+          <a
+            href={`${(import.meta as Record<string, any>).env?.VITE_API_URL || ''}/api/v1/bookings/${booking.id}/invoice/pdf`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn-sm btn-ghost text-surface-600 hover:bg-surface-50 dark:hover:bg-surface-800"
+            aria-label={`${t('bookings.downloadInvoice')} ${booking.lot_name}`}
+            data-testid={`invoice-${booking.id}`}
+          >
+            <FilePdf weight="bold" className="w-4 h-4" /> {t('bookings.downloadInvoice')}
+          </a>
           {isActiveOrConfirmed && (
             <button
               onClick={() => onCancel(booking.id)}

--- a/resources/js/src/i18n/locales/de.ts
+++ b/resources/js/src/i18n/locales/de.ts
@@ -117,6 +117,7 @@ export default {
       startsIn: 'Beginnt {{time}}',
       endsIn: 'Endet {{time}}',
       invoice: 'Rechnung',
+      downloadInvoice: 'Rechnung',
       loading: 'Buchungen werden geladen...',
       insufficientCredits: 'Nicht genug Credits zum Buchen',
     },

--- a/resources/js/src/i18n/locales/en.ts
+++ b/resources/js/src/i18n/locales/en.ts
@@ -117,6 +117,7 @@ export default {
       startsIn: 'Starts {{time}}',
       endsIn: 'Ends {{time}}',
       invoice: 'Invoice',
+      downloadInvoice: 'Invoice',
       loading: 'Loading bookings...',
       insufficientCredits: 'Not enough credits to book',
     },

--- a/resources/js/src/views/Bookings.tsx
+++ b/resources/js/src/views/Bookings.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import {
   CalendarBlank, Clock, Car, X, SpinnerGap,
   ArrowClockwise, Warning, MapPin, CalendarPlus, Timer,
-  MagnifyingGlass, Funnel, QrCode,
+  MagnifyingGlass, Funnel, QrCode, FilePdf,
 } from '@phosphor-icons/react';
 import type { TFunction } from 'react-i18next';
 import { api, type Booking, type Vehicle } from '../api/client';
@@ -269,6 +269,16 @@ function BookingCard({ booking, now, vehicles, onCancel, cancelling, onShowPass,
               <QrCode weight="bold" className="w-4 h-4" /> {t('pass.showPass')}
             </button>
           )}
+          <a
+            href={`${(import.meta as Record<string, any>).env?.VITE_API_URL || ''}/api/v1/bookings/${booking.id}/invoice/pdf`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn-sm btn-ghost text-surface-600 hover:bg-surface-50 dark:hover:bg-surface-800"
+            aria-label={`${t('bookings.downloadInvoice')} ${booking.lot_name}`}
+            data-testid={`invoice-${booking.id}`}
+          >
+            <FilePdf weight="bold" className="w-4 h-4" /> {t('bookings.downloadInvoice')}
+          </a>
           {isActiveOrConfirmed && (
             <button
               onClick={() => onCancel(booking.id)}

--- a/routes/modules/bookings.php
+++ b/routes/modules/bookings.php
@@ -28,9 +28,10 @@ Route::middleware(['module:bookings', 'auth:sanctum', 'throttle:api'])->group(fu
     Route::get('/calendar', [BookingController::class, 'index']);
     Route::get('/calendar/events', [BookingController::class, 'calendarEvents']);
 
-    // Invoice
+    // Invoice (both dot and slash notation for Rust API compatibility)
     Route::get('/bookings/{id}/invoice', [BookingInvoiceController::class, 'show']);
     Route::get('/bookings/{id}/invoice.pdf', [BookingInvoiceController::class, 'pdf']);
+    Route::get('/bookings/{id}/invoice/pdf', [BookingInvoiceController::class, 'pdf']);
 
     // iCal feed
     Route::get('/bookings/ical', [BookingController::class, 'ical']);

--- a/tests/Feature/InvoicePdfTest.php
+++ b/tests/Feature/InvoicePdfTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InvoicePdfTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createBookingForUser(User $user): Booking
+    {
+        $lot = ParkingLot::create([
+            'name' => 'Test Lot',
+            'total_slots' => 10,
+            'available_slots' => 10,
+            'status' => 'open',
+        ]);
+        $slot = ParkingSlot::create([
+            'lot_id' => $lot->id,
+            'slot_number' => 'A1',
+            'status' => 'available',
+        ]);
+
+        return Booking::create([
+            'user_id' => $user->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'lot_name' => $lot->name,
+            'slot_number' => $slot->slot_number,
+            'start_time' => now()->subHour(),
+            'end_time' => now()->addHours(3),
+            'status' => 'confirmed',
+            'booking_type' => 'single',
+        ]);
+    }
+
+    public function test_invoice_pdf_slash_endpoint_returns_pdf(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+        $booking = $this->createBookingForUser($user);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->get("/api/v1/bookings/{$booking->id}/invoice/pdf");
+
+        $response->assertStatus(200);
+        $this->assertStringContainsString(
+            'pdf',
+            strtolower($response->headers->get('Content-Type') ?? '')
+        );
+    }
+
+    public function test_invoice_dot_pdf_endpoint_returns_pdf(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+        $booking = $this->createBookingForUser($user);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->get("/api/v1/bookings/{$booking->id}/invoice.pdf");
+
+        $response->assertStatus(200);
+        $this->assertStringContainsString(
+            'pdf',
+            strtolower($response->headers->get('Content-Type') ?? '')
+        );
+    }
+
+    public function test_invoice_number_format_matches_inv_year_hex(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+        $booking = $this->createBookingForUser($user);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->get("/api/v1/bookings/{$booking->id}/invoice");
+
+        $response->assertStatus(200);
+        $content = $response->getContent();
+
+        // Invoice number: INV-{YEAR}-{HEX8}
+        $year = date('Y');
+        $shortId = strtoupper(substr(str_replace('-', '', $booking->id), 0, 8));
+        $expectedInvoiceNo = "INV-{$year}-{$shortId}";
+        $this->assertStringContainsString($expectedInvoiceNo, $content);
+    }
+
+    public function test_invoice_requires_authentication(): void
+    {
+        $user = User::factory()->create();
+        $booking = $this->createBookingForUser($user);
+
+        $response = $this->getJson("/api/v1/bookings/{$booking->id}/invoice/pdf");
+
+        $response->assertStatus(401);
+    }
+
+    public function test_invoice_not_accessible_by_other_user(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $booking = $this->createBookingForUser($owner);
+        $token = $other->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->get("/api/v1/bookings/{$booking->id}/invoice/pdf");
+
+        // Should 404 because query scopes to user_id
+        $response->assertStatus(404);
+    }
+
+    public function test_invoice_for_nonexistent_booking_returns_404(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->get('/api/v1/bookings/00000000-0000-0000-0000-000000000000/invoice/pdf');
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/ModuleSystemExtendedTest.php
+++ b/tests/Feature/ModuleSystemExtendedTest.php
@@ -130,7 +130,7 @@ class ModuleSystemExtendedTest extends TestCase
     public function test_module_service_provider_all_returns_correct_count(): void
     {
         $all = ModuleServiceProvider::all();
-        $this->assertCount(24, $all);
+        $this->assertCount(25, $all);
     }
 
     public function test_modules_endpoint_is_always_public(): void

--- a/tests/Feature/ModuleSystemTest.php
+++ b/tests/Feature/ModuleSystemTest.php
@@ -335,10 +335,10 @@ class ModuleSystemTest extends TestCase
             ->assertOk();
     }
 
-    public function test_all_24_modules_in_config(): void
+    public function test_all_25_modules_in_config(): void
     {
         $modules = config('modules');
 
-        $this->assertCount(24, $modules);
+        $this->assertCount(25, $modules);
     }
 }


### PR DESCRIPTION
## Summary
- Add Rust-compatible `/invoice/pdf` route alongside existing `/invoice.pdf`
- Update invoice number format to `INV-{YEAR}-{HEX8}` (matches Rust backend)
- Add `MODULE_INVOICES=true` module toggle
- Add PDF download button to Bookings.tsx (FilePdf icon)
- Add `downloadInvoice` i18n strings (en/de)

## Changes
- **Modified**: `BookingInvoiceController.php` - invoice number format update
- **Modified**: `routes/modules/bookings.php` - new `/invoice/pdf` route
- **Modified**: `config/modules.php` - add invoices module
- **Modified**: `Bookings.tsx` - download invoice button
- **New**: `tests/Feature/InvoicePdfTest.php` - 6 tests

## Test plan
- [x] 6 new PHP tests pass (PDF endpoint, format, auth, access)
- [x] Full suite: 884 PHP tests pass, 0 regressions