### PR TITLE
feat: lobby display / kiosk mode (closes #170)

### DIFF
--- a/app/Http/Controllers/Api/LobbyDisplayController.php
+++ b/app/Http/Controllers/Api/LobbyDisplayController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\Zone;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class LobbyDisplayController extends Controller
+{
+    /**
+     * GET /api/v1/lots/{id}/display
+     *
+     * Public endpoint (no auth) — returns real-time occupancy data
+     * formatted for full-screen lobby/kiosk monitors.
+     */
+    public function show(string $id): JsonResponse
+    {
+        $lot = ParkingLot::withCount('slots')->find($id);
+
+        if (! $lot) {
+            return response()->json([
+                'success' => false,
+                'data' => null,
+                'error' => ['code' => 'NOT_FOUND', 'message' => 'Parking lot not found'],
+                'meta' => null,
+            ], 404);
+        }
+
+        $now = now();
+        $totalSlots = $lot->slots_count;
+
+        // Count currently occupied slots for this lot
+        $occupiedCount = Booking::where('lot_id', $lot->id)
+            ->whereIn('status', ['confirmed', 'active'])
+            ->where('start_time', '<=', $now)
+            ->where('end_time', '>=', $now)
+            ->count();
+
+        $availableSlots = max(0, $totalSlots - $occupiedCount);
+        $occupancyPercent = $totalSlots > 0
+            ? round(($occupiedCount / $totalSlots) * 100, 1)
+            : 0;
+
+        // Determine color status based on occupancy
+        $colorStatus = match (true) {
+            $occupancyPercent >= 90 => 'red',
+            $occupancyPercent >= 60 => 'yellow',
+            default => 'green',
+        };
+
+        // Build floor breakdown from zones
+        $floors = $this->buildFloorBreakdown($lot->id, $now);
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'lot_id' => $lot->id,
+                'lot_name' => $lot->name,
+                'total_slots' => $totalSlots,
+                'available_slots' => $availableSlots,
+                'occupancy_percent' => $occupancyPercent,
+                'color_status' => $colorStatus,
+                'floors' => $floors,
+                'timestamp' => $now->toIso8601String(),
+            ],
+            'error' => null,
+            'meta' => null,
+        ]);
+    }
+
+    /**
+     * Build per-zone (floor) occupancy breakdown.
+     */
+    private function buildFloorBreakdown(string $lotId, \DateTimeInterface $now): array
+    {
+        $zones = Zone::where('lot_id', $lotId)
+            ->withCount('slots')
+            ->get();
+
+        if ($zones->isEmpty()) {
+            return [];
+        }
+
+        // Count occupied slots per zone in a single query
+        $occupiedByZone = DB::table('bookings')
+            ->join('parking_slots', 'bookings.slot_id', '=', 'parking_slots.id')
+            ->where('bookings.lot_id', $lotId)
+            ->whereIn('bookings.status', ['confirmed', 'active'])
+            ->where('bookings.start_time', '<=', $now)
+            ->where('bookings.end_time', '>=', $now)
+            ->whereNotNull('parking_slots.zone_id')
+            ->select('parking_slots.zone_id', DB::raw('COUNT(*) as occupied'))
+            ->groupBy('parking_slots.zone_id')
+            ->pluck('occupied', 'zone_id');
+
+        return $zones->map(function ($zone, $index) use ($occupiedByZone) {
+            $total = $zone->slots_count;
+            $occupied = $occupiedByZone->get($zone->id, 0);
+            $available = max(0, $total - $occupied);
+            $percent = $total > 0 ? round(($occupied / $total) * 100, 1) : 0;
+
+            return [
+                'floor_name' => $zone->name,
+                'floor_number' => $index + 1,
+                'total_slots' => $total,
+                'available_slots' => $available,
+                'occupancy_percent' => $percent,
+            ];
+        })->values()->all();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -68,6 +68,11 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute(10)->by($request->user()?->id ?: $request->ip());
         });
 
+        // Lobby display: 10 per minute per IP (public kiosk polling)
+        RateLimiter::for('lobby-display', function (Request $request) {
+            return Limit::perMinute(10)->by($request->ip());
+        });
+
         // Authenticated API: 120 per minute per user (or IP if unauthenticated)
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(120)->by($request->user()?->id ?: $request->ip());

--- a/config/modules.php
+++ b/config/modules.php
@@ -39,4 +39,5 @@ return [
     'dynamic_pricing' => env('MODULE_DYNAMIC_PRICING', true),
     'operating_hours' => env('MODULE_OPERATING_HOURS', true),
     'realtime' => env('MODULE_REALTIME', true),
+    'lobby_display' => env('MODULE_LOBBY_DISPLAY', true),
 ];

--- a/parkhub-web/src/App.tsx
+++ b/parkhub-web/src/App.tsx
@@ -25,6 +25,7 @@ const LoginPage = lazy(() => import('./views/Login'), 'LoginPage');
 const RegisterPage = lazy(() => import('./views/Register'), 'RegisterPage');
 const ForgotPasswordPage = lazy(() => import('./views/ForgotPassword'), 'ForgotPasswordPage');
 const UseCaseSelectorPage = lazy(() => import('./views/UseCaseSelector'), 'UseCaseSelectorPage');
+const LobbyDisplayPage = lazy(() => import('./views/LobbyDisplay'), 'LobbyDisplayPage');
 const NotFoundPage = lazy(() => import('./views/NotFound'), 'NotFoundPage');
 
 // Main app pages
@@ -111,6 +112,7 @@ function AnimatedRoutes() {
         <Route path="/register" element={<SuspenseRoute><RegisterPage /></SuspenseRoute>} />
         <Route path="/forgot-password" element={<SuspenseRoute><ForgotPasswordPage /></SuspenseRoute>} />
         <Route path="/choose" element={<SuspenseRoute><UseCaseSelectorPage /></SuspenseRoute>} />
+        <Route path="/lobby/:lotId" element={<SuspenseRoute><LobbyDisplayPage /></SuspenseRoute>} />
         <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
           <Route index element={<SuspenseRoute><DashboardPage /></SuspenseRoute>} />
           <Route path="book" element={<SuspenseRoute><BookPage /></SuspenseRoute>} />

--- a/parkhub-web/src/i18n/locales/de.ts
+++ b/parkhub-web/src/i18n/locales/de.ts
@@ -871,5 +871,14 @@ export default {
       genericError: 'Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut.',
       retry: 'Erneut versuchen',
     },
+    lobby: {
+      available: 'Verfugbar',
+      total: 'Gesamt',
+      floor: 'Etage',
+      lastUpdated: 'Zuletzt aktualisiert',
+      occupancy: 'Auslastung',
+      error: 'Parkplatz nicht gefunden',
+      networkError: 'Netzwerkfehler',
+    },
   },
 };

--- a/parkhub-web/src/i18n/locales/en.ts
+++ b/parkhub-web/src/i18n/locales/en.ts
@@ -871,5 +871,14 @@ export default {
       genericError: 'Something went wrong. Please try again.',
       retry: 'Try Again',
     },
+    lobby: {
+      available: 'Available',
+      total: 'Total',
+      floor: 'Floor',
+      lastUpdated: 'Last updated',
+      occupancy: 'Occupancy',
+      error: 'Lot not found',
+      networkError: 'Network error',
+    },
   },
 };

--- a/parkhub-web/src/views/LobbyDisplay.test.tsx
+++ b/parkhub-web/src/views/LobbyDisplay.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+
+// ── Mocks ──
+
+const mockUseParams = vi.fn().mockReturnValue({ lotId: 'lot-1' });
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => mockUseParams(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => {
+      const map: Record<string, string> = {
+        'lobby.available': 'Available',
+        'lobby.total': 'Total',
+        'lobby.floor': 'Floor',
+        'lobby.lastUpdated': 'Last updated',
+        'lobby.occupancy': 'Occupancy',
+        'lobby.error': 'Lot not found',
+        'lobby.networkError': 'Network error',
+      };
+      return map[key] || fallback || key;
+    },
+  }),
+}));
+
+import { LobbyDisplayPage } from './LobbyDisplay';
+
+const MOCK_DISPLAY_DATA = {
+  success: true,
+  data: {
+    lot_id: 'lot-1',
+    lot_name: 'Downtown Garage',
+    total_slots: 200,
+    available_slots: 80,
+    occupancy_percent: 60,
+    color_status: 'yellow' as const,
+    floors: [
+      { floor_name: 'B1', floor_number: -1, total_slots: 100, available_slots: 40, occupancy_percent: 60 },
+      { floor_name: 'B2', floor_number: -2, total_slots: 100, available_slots: 40, occupancy_percent: 60 },
+    ],
+    timestamp: '2026-03-22T12:00:00Z',
+  },
+};
+
+describe('LobbyDisplayPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockUseParams.mockReturnValue({ lotId: 'lot-1' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<LobbyDisplayPage />);
+    expect(screen.getByTestId('lobby-loading')).toBeInTheDocument();
+  });
+
+  it('renders lot name and availability after loading', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(MOCK_DISPLAY_DATA),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-display')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('lobby-lot-name')).toHaveTextContent('Downtown Garage');
+    expect(screen.getByTestId('lobby-available')).toHaveTextContent('80');
+    expect(screen.getByTestId('lobby-total')).toHaveTextContent('200');
+  });
+
+  it('renders floor breakdown cards', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(MOCK_DISPLAY_DATA),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-floors')).toBeInTheDocument();
+    });
+    const floorCards = screen.getAllByTestId('lobby-floor-card');
+    expect(floorCards).toHaveLength(2);
+    expect(screen.getByText(/B1/)).toBeInTheDocument();
+    expect(screen.getByText(/B2/)).toBeInTheDocument();
+  });
+
+  it('shows error state when lot is not found', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ success: false, error: { code: 'NOT_FOUND', message: 'Parking lot not found' } }),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Parking lot not found')).toBeInTheDocument();
+  });
+
+  it('displays occupancy bar with correct aria attributes', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(MOCK_DISPLAY_DATA),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-bar')).toBeInTheDocument();
+    });
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '60');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('shows last updated timestamp', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(MOCK_DISPLAY_DATA),
+    });
+
+    render(<LobbyDisplayPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lobby-last-updated')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('lobby-last-updated').textContent).toContain('Last updated');
+  });
+});

--- a/parkhub-web/src/views/LobbyDisplay.tsx
+++ b/parkhub-web/src/views/LobbyDisplay.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface FloorDisplay {
+  floor_name: string;
+  floor_number: number;
+  total_slots: number;
+  available_slots: number;
+  occupancy_percent: number;
+}
+
+interface LotDisplayData {
+  lot_id: string;
+  lot_name: string;
+  total_slots: number;
+  available_slots: number;
+  occupancy_percent: number;
+  color_status: 'green' | 'yellow' | 'red';
+  floors: FloorDisplay[];
+  timestamp: string;
+}
+
+const COLOR_MAP = {
+  green: { bar: 'bg-emerald-500', text: 'text-emerald-400', glow: 'shadow-emerald-500/30' },
+  yellow: { bar: 'bg-amber-400', text: 'text-amber-400', glow: 'shadow-amber-400/30' },
+  red: { bar: 'bg-red-500', text: 'text-red-400', glow: 'shadow-red-500/30' },
+};
+
+/** Full-screen lobby display designed for parking garage monitors. */
+export function LobbyDisplayPage() {
+  const { lotId } = useParams<{ lotId: string }>();
+  const { t } = useTranslation();
+  const [data, setData] = useState<LotDisplayData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  const fetchDisplay = useCallback(async () => {
+    if (!lotId) return;
+    try {
+      const res = await fetch(`/api/v1/lots/${lotId}/display`);
+      const json = await res.json();
+      if (json.success && json.data) {
+        setData(json.data);
+        setLastUpdated(new Date());
+        setError(null);
+      } else {
+        setError(json.error?.message || t('lobby.error', 'Lot not found'));
+      }
+    } catch {
+      setError(t('lobby.networkError', 'Network error'));
+    }
+  }, [lotId, t]);
+
+  // Poll every 10 seconds
+  useEffect(() => {
+    fetchDisplay();
+    const interval = setInterval(fetchDisplay, 10_000);
+    return () => clearInterval(interval);
+  }, [fetchDisplay]);
+
+  // Update clock every second
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (error) {
+    return (
+      <div className="min-h-dvh bg-gray-950 flex items-center justify-center" data-testid="lobby-error">
+        <p className="text-red-400 text-4xl font-bold">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="min-h-dvh bg-gray-950 flex items-center justify-center" data-testid="lobby-loading">
+        <div className="w-16 h-16 border-4 border-white/20 border-t-white rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  const colors = COLOR_MAP[data.color_status] || COLOR_MAP.green;
+  const occupancyWidth = Math.min(data.occupancy_percent, 100);
+
+  return (
+    <div
+      className="min-h-dvh bg-gray-950 text-white flex flex-col p-8 select-none overflow-hidden"
+      data-testid="lobby-display"
+    >
+      {/* Header: lot name + clock */}
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-[4rem] leading-tight font-black tracking-tight truncate" data-testid="lobby-lot-name">
+          {data.lot_name}
+        </h1>
+        <time className="text-3xl font-mono text-gray-400 tabular-nums shrink-0 ml-8" data-testid="lobby-clock">
+          {currentTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+        </time>
+      </div>
+
+      {/* Main number display */}
+      <div className="flex-1 flex flex-col items-center justify-center gap-6">
+        <div className="text-center">
+          <span
+            className={`text-[8rem] leading-none font-black tabular-nums ${colors.text}`}
+            data-testid="lobby-available"
+          >
+            {data.available_slots}
+          </span>
+          <span className="text-[4rem] text-gray-500 font-light mx-4">/</span>
+          <span className="text-[4rem] text-gray-400 font-semibold tabular-nums" data-testid="lobby-total">
+            {data.total_slots}
+          </span>
+        </div>
+        <p className="text-2xl text-gray-400 uppercase tracking-widest">
+          {t('lobby.available', 'Available')}
+        </p>
+
+        {/* Occupancy bar */}
+        <div className="w-full max-w-4xl mt-4" data-testid="lobby-bar">
+          <div className="w-full h-8 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className={`h-full ${colors.bar} rounded-full transition-all duration-700 ease-out shadow-lg ${colors.glow}`}
+              style={{ width: `${occupancyWidth}%` }}
+              role="progressbar"
+              aria-valuenow={Math.round(data.occupancy_percent)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={t('lobby.occupancy', 'Occupancy')}
+            />
+          </div>
+          <p className="text-center text-xl text-gray-500 mt-2">
+            {t('lobby.occupancy', 'Occupancy')}: {Math.round(data.occupancy_percent)}%
+          </p>
+        </div>
+      </div>
+
+      {/* Floor breakdown */}
+      {data.floors.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-8" data-testid="lobby-floors">
+          {data.floors.map((floor) => {
+            const floorOcc = Math.min(floor.occupancy_percent, 100);
+            const floorColor = floor.occupancy_percent > 80 ? 'red' : floor.occupancy_percent >= 50 ? 'yellow' : 'green';
+            const fc = COLOR_MAP[floorColor];
+            return (
+              <div
+                key={floor.floor_number}
+                className="bg-gray-900 rounded-2xl p-5 flex flex-col items-center"
+                data-testid="lobby-floor-card"
+              >
+                <p className="text-lg text-gray-400 mb-1">
+                  {t('lobby.floor', 'Floor')} {floor.floor_name || floor.floor_number}
+                </p>
+                <p className={`text-4xl font-black tabular-nums ${fc.text}`}>
+                  {floor.available_slots}
+                </p>
+                <p className="text-sm text-gray-500">
+                  / {floor.total_slots}
+                </p>
+                <div className="w-full h-2 bg-gray-800 rounded-full mt-3 overflow-hidden">
+                  <div
+                    className={`h-full ${fc.bar} rounded-full transition-all duration-700`}
+                    style={{ width: `${floorOcc}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Footer: last updated */}
+      <div className="flex justify-center mt-8 text-gray-600 text-lg">
+        <p data-testid="lobby-last-updated">
+          {t('lobby.lastUpdated', 'Last updated')}: {lastUpdated?.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }) || '—'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -231,6 +231,7 @@ module_routes('themes', 'themes.php');
 module_routes('dynamic_pricing', 'dynamic-pricing.php');
 module_routes('operating_hours', 'operating-hours.php');
 module_routes('realtime', 'realtime.php');
+module_routes('lobby_display', 'lobby.php');
 
 // OAuth — always load routes (module disabled by default, middleware gates access)
 require base_path('routes/modules/oauth.php');

--- a/routes/modules/lobby.php
+++ b/routes/modules/lobby.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Lobby Display module routes (api/v1).
+ * Loaded only when MODULE_LOBBY_DISPLAY=true.
+ *
+ * Public endpoint — no auth required.
+ * Rate-limited to 10 requests/min per IP (kiosk polling).
+ */
+
+use App\Http\Controllers\Api\LobbyDisplayController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:lobby_display', 'throttle:lobby-display'])->group(function () {
+    Route::get('/lots/{id}/display', [LobbyDisplayController::class, 'show']);
+});

--- a/tests/Feature/LobbyDisplayTest.php
+++ b/tests/Feature/LobbyDisplayTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\User;
+use App\Models\Zone;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class LobbyDisplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createLotWithSlots(string $name = 'Downtown Garage', int $slotCount = 10): array
+    {
+        $lot = ParkingLot::create([
+            'name' => $name,
+            'total_slots' => $slotCount,
+            'available_slots' => $slotCount,
+            'status' => 'open',
+        ]);
+
+        $slots = collect();
+        for ($i = 1; $i <= $slotCount; $i++) {
+            $slots->push(ParkingSlot::create([
+                'lot_id' => $lot->id,
+                'slot_number' => str_pad($i, 3, '0', STR_PAD_LEFT),
+                'status' => 'available',
+            ]));
+        }
+
+        return [$lot, $slots];
+    }
+
+    public function test_lobby_display_returns_lot_data(): void
+    {
+        [$lot] = $this->createLotWithSlots('Downtown Garage', 10);
+
+        $response = $this->getJson("/api/v1/lots/{$lot->id}/display");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.lot_name', 'Downtown Garage')
+            ->assertJsonPath('data.total_slots', 10)
+            ->assertJsonPath('data.available_slots', 10)
+            ->assertJsonPath('data.color_status', 'green')
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'lot_id', 'lot_name', 'total_slots', 'available_slots',
+                    'occupancy_percent', 'color_status', 'floors', 'timestamp',
+                ],
+                'error',
+                'meta',
+            ]);
+    }
+
+    public function test_lobby_display_is_public_no_auth_required(): void
+    {
+        [$lot] = $this->createLotWithSlots('Public Lot', 5);
+
+        // No auth header — should still work
+        $response = $this->getJson("/api/v1/lots/{$lot->id}/display");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true);
+    }
+
+    public function test_lobby_display_returns_404_for_unknown_lot(): void
+    {
+        $response = $this->getJson('/api/v1/lots/'.Str::uuid().'/display');
+
+        $response->assertStatus(404)
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error.code', 'NOT_FOUND');
+    }
+
+    public function test_lobby_display_calculates_occupancy_correctly(): void
+    {
+        [$lot, $slots] = $this->createLotWithSlots('Occupancy Lot', 10);
+        $user = User::factory()->create();
+
+        // Book 7 of 10 slots (70% occupied)
+        foreach ($slots->take(7) as $slot) {
+            Booking::create([
+                'id' => Str::uuid(),
+                'lot_id' => $lot->id,
+                'slot_id' => $slot->id,
+                'user_id' => $user->id,
+                'status' => 'active',
+                'start_time' => now()->subHour(),
+                'end_time' => now()->addHour(),
+            ]);
+        }
+
+        $response = $this->getJson("/api/v1/lots/{$lot->id}/display");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.total_slots', 10)
+            ->assertJsonPath('data.available_slots', 3)
+            ->assertJsonPath('data.color_status', 'yellow');
+
+        $occupancy = $response->json('data.occupancy_percent');
+        $this->assertEquals(70, $occupancy);
+    }
+
+    public function test_lobby_display_red_status_at_high_occupancy(): void
+    {
+        [$lot, $slots] = $this->createLotWithSlots('Full Lot', 10);
+        $user = User::factory()->create();
+
+        // Book 9 of 10 slots (90% occupied)
+        foreach ($slots->take(9) as $slot) {
+            Booking::create([
+                'id' => Str::uuid(),
+                'lot_id' => $lot->id,
+                'slot_id' => $slot->id,
+                'user_id' => $user->id,
+                'status' => 'active',
+                'start_time' => now()->subHour(),
+                'end_time' => now()->addHour(),
+            ]);
+        }
+
+        $response = $this->getJson("/api/v1/lots/{$lot->id}/display");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.color_status', 'red')
+            ->assertJsonPath('data.available_slots', 1);
+    }
+
+    public function test_lobby_display_includes_floor_breakdown(): void
+    {
+        $lot = ParkingLot::create([
+            'name' => 'Multi-Floor Garage',
+            'total_slots' => 10,
+            'available_slots' => 10,
+            'status' => 'open',
+        ]);
+
+        $zone1 = Zone::create(['lot_id' => $lot->id, 'name' => 'B1', 'color' => '#FF0000']);
+        $zone2 = Zone::create(['lot_id' => $lot->id, 'name' => 'B2', 'color' => '#00FF00']);
+
+        for ($i = 1; $i <= 5; $i++) {
+            ParkingSlot::create([
+                'lot_id' => $lot->id,
+                'slot_number' => 'B1-'.str_pad($i, 3, '0', STR_PAD_LEFT),
+                'status' => 'available',
+                'zone_id' => $zone1->id,
+            ]);
+        }
+        for ($i = 1; $i <= 5; $i++) {
+            ParkingSlot::create([
+                'lot_id' => $lot->id,
+                'slot_number' => 'B2-'.str_pad($i, 3, '0', STR_PAD_LEFT),
+                'status' => 'available',
+                'zone_id' => $zone2->id,
+            ]);
+        }
+
+        $response = $this->getJson("/api/v1/lots/{$lot->id}/display");
+
+        $response->assertStatus(200);
+
+        $floors = $response->json('data.floors');
+        $this->assertCount(2, $floors);
+        $this->assertEquals('B1', $floors[0]['floor_name']);
+        $this->assertEquals('B2', $floors[1]['floor_name']);
+        $this->assertEquals(5, $floors[0]['total_slots']);
+        $this->assertEquals(5, $floors[1]['total_slots']);
+    }
+
+    public function test_lobby_display_empty_lot_returns_zero_occupancy(): void
+    {
+        $lot = ParkingLot::create([
+            'name' => 'Empty Lot',
+            'total_slots' => 0,
+            'available_slots' => 0,
+            'status' => 'open',
+        ]);
+
+        $response = $this->getJson("/api/v1/lots/{$lot->id}/display");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.total_slots', 0)
+            ->assertJsonPath('data.available_slots', 0)
+            ->assertJsonPath('data.occupancy_percent', 0)
+            ->assertJsonPath('data.color_status', 'green')
+            ->assertJsonPath('data.floors', []);
+    }
+
+    public function test_lobby_display_ignores_expired_bookings(): void
+    {
+        [$lot, $slots] = $this->createLotWithSlots('Expired Lot', 5);
+        $user = User::factory()->create();
+
+        // Create expired bookings (ended 2 hours ago)
+        foreach ($slots as $slot) {
+            Booking::create([
+                'id' => Str::uuid(),
+                'lot_id' => $lot->id,
+                'slot_id' => $slot->id,
+                'user_id' => $user->id,
+                'status' => 'active',
+                'start_time' => now()->subHours(3),
+                'end_time' => now()->subHours(2),
+            ]);
+        }
+
+        $response = $this->getJson("/api/v1/lots/{$lot->id}/display");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.total_slots', 5)
+            ->assertJsonPath('data.available_slots', 5)
+            ->assertJsonPath('data.occupancy_percent', 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Public `GET /api/v1/lots/{id}/display` endpoint (no auth) with 10 req/min rate limit
- Returns lot name, total/available slots, occupancy %, color status (green/yellow/red), floor breakdown, timestamp
- Module toggle `MODULE_LOBBY_DISPLAY=true` in `config/modules.php`
- Frontend `LobbyDisplayPage` synced from Rust edition with full-screen kiosk UI
- Route at `/lobby/:lotId` (public, no auth wrapper)
- i18n keys for `lobby.*` in en.ts and de.ts

## Tests
- 8 PHP feature tests (data, auth-free, 404, occupancy calc, color thresholds, floors, empty lot, expired bookings)
- 6 frontend Vitest tests (synced from Rust)

Closes #170