### PR TITLE
feat: add admin analytics module (30th module)

### DIFF
--- a/app/Http/Controllers/Api/AdminAnalyticsController.php
+++ b/app/Http/Controllers/Api/AdminAnalyticsController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class AdminAnalyticsController extends Controller
+{
+    /**
+     * GET /api/v1/admin/analytics/overview
+     *
+     * Comprehensive analytics dashboard with daily bookings (30d),
+     * revenue by day, peak hours, top lots, user growth (12mo),
+     * and average booking duration.
+     */
+    public function overview(): JsonResponse
+    {
+        $driver = DB::getDriverName();
+
+        // 1. Daily bookings (last 30 days)
+        $dailyBookings = Booking::where('start_time', '>=', now()->subDays(30))
+            ->selectRaw('DATE(start_time) as date, COUNT(*) as count')
+            ->groupBy('date')
+            ->orderBy('date')
+            ->get()
+            ->map(fn ($row) => ['date' => $row->date, 'count' => (int) $row->count]);
+
+        // 2. Revenue by day (last 30 days)
+        $revenueByDay = Booking::where('start_time', '>=', now()->subDays(30))
+            ->whereNotNull('total_price')
+            ->where('status', '!=', 'cancelled')
+            ->selectRaw('DATE(start_time) as date, SUM(total_price) as revenue, COUNT(*) as bookings')
+            ->groupBy('date')
+            ->orderBy('date')
+            ->get()
+            ->map(fn ($row) => [
+                'date' => $row->date,
+                'revenue' => round((float) $row->revenue, 2),
+                'bookings' => (int) $row->bookings,
+            ]);
+
+        // 3. Peak hours (24 bins — bookings grouped by hour of day, last 30 days)
+        if ($driver === 'sqlite') {
+            $peakHours = Booking::where('start_time', '>=', now()->subDays(30))
+                ->selectRaw('CAST(strftime("%H", start_time) AS INTEGER) as hour, COUNT(*) as count')
+                ->groupBy('hour')
+                ->orderBy('hour')
+                ->get();
+        } elseif ($driver === 'pgsql') {
+            $peakHours = Booking::where('start_time', '>=', now()->subDays(30))
+                ->selectRaw('EXTRACT(HOUR FROM start_time)::integer as hour, COUNT(*) as count')
+                ->groupBy('hour')
+                ->orderBy('hour')
+                ->get();
+        } else {
+            $peakHours = Booking::where('start_time', '>=', now()->subDays(30))
+                ->selectRaw('HOUR(start_time) as hour, COUNT(*) as count')
+                ->groupBy('hour')
+                ->orderBy('hour')
+                ->get();
+        }
+
+        // Fill all 24 bins
+        $hourMap = $peakHours->pluck('count', 'hour')->all();
+        $peakHoursBins = [];
+        for ($h = 0; $h < 24; $h++) {
+            $peakHoursBins[] = ['hour' => $h, 'count' => (int) ($hourMap[$h] ?? 0)];
+        }
+
+        // 4. Top lots by booking count (last 30 days)
+        $topLots = Booking::where('bookings.start_time', '>=', now()->subDays(30))
+            ->join('parking_lots', 'bookings.lot_id', '=', 'parking_lots.id')
+            ->selectRaw('parking_lots.id, parking_lots.name, COUNT(*) as booking_count, COALESCE(SUM(bookings.total_price), 0) as revenue')
+            ->groupBy('parking_lots.id', 'parking_lots.name')
+            ->orderByDesc('booking_count')
+            ->limit(10)
+            ->get()
+            ->map(fn ($row) => [
+                'id' => $row->id,
+                'name' => $row->name,
+                'booking_count' => (int) $row->booking_count,
+                'revenue' => round((float) $row->revenue, 2),
+            ]);
+
+        // 5. User growth (last 12 months)
+        if ($driver === 'sqlite') {
+            $userGrowth = User::where('created_at', '>=', now()->subMonths(12))
+                ->selectRaw("strftime('%Y-%m', created_at) as month, COUNT(*) as new_users")
+                ->groupBy('month')
+                ->orderBy('month')
+                ->get();
+        } elseif ($driver === 'pgsql') {
+            $userGrowth = User::where('created_at', '>=', now()->subMonths(12))
+                ->selectRaw("to_char(created_at, 'YYYY-MM') as month, COUNT(*) as new_users")
+                ->groupBy('month')
+                ->orderBy('month')
+                ->get();
+        } else {
+            $userGrowth = User::where('created_at', '>=', now()->subMonths(12))
+                ->selectRaw("DATE_FORMAT(created_at, '%Y-%m') as month, COUNT(*) as new_users")
+                ->groupBy('month')
+                ->orderBy('month')
+                ->get();
+        }
+
+        $userGrowthData = $userGrowth->map(fn ($row) => [
+            'month' => $row->month,
+            'new_users' => (int) $row->new_users,
+        ]);
+
+        // 6. Average booking duration (in hours, last 30 days)
+        if ($driver === 'sqlite') {
+            $avgDuration = Booking::where('start_time', '>=', now()->subDays(30))
+                ->whereNotNull('start_time')
+                ->whereNotNull('end_time')
+                ->selectRaw('AVG((julianday(end_time) - julianday(start_time)) * 24) as avg_hours')
+                ->value('avg_hours');
+        } elseif ($driver === 'pgsql') {
+            $avgDuration = Booking::where('start_time', '>=', now()->subDays(30))
+                ->whereNotNull('start_time')
+                ->whereNotNull('end_time')
+                ->selectRaw('AVG(EXTRACT(EPOCH FROM (end_time - start_time)) / 3600) as avg_hours')
+                ->value('avg_hours');
+        } else {
+            $avgDuration = Booking::where('start_time', '>=', now()->subDays(30))
+                ->whereNotNull('start_time')
+                ->whereNotNull('end_time')
+                ->selectRaw('AVG(TIMESTAMPDIFF(SECOND, start_time, end_time) / 3600) as avg_hours')
+                ->value('avg_hours');
+        }
+
+        return response()->json([
+            'daily_bookings' => $dailyBookings,
+            'revenue_by_day' => $revenueByDay,
+            'peak_hours' => $peakHoursBins,
+            'top_lots' => $topLots,
+            'user_growth' => $userGrowthData,
+            'avg_duration_hours' => $avgDuration ? round((float) $avgDuration, 2) : 0,
+            'total_users' => User::count(),
+            'total_lots' => ParkingLot::count(),
+        ]);
+    }
+}

--- a/config/modules.php
+++ b/config/modules.php
@@ -40,4 +40,5 @@ return [
     'operating_hours' => env('MODULE_OPERATING_HOURS', true),
     'realtime' => env('MODULE_REALTIME', true),
     'lobby_display' => env('MODULE_LOBBY_DISPLAY', true),
+    'analytics' => env('MODULE_ANALYTICS', true),
 ];

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -232,6 +232,7 @@ module_routes('dynamic_pricing', 'dynamic-pricing.php');
 module_routes('operating_hours', 'operating-hours.php');
 module_routes('realtime', 'realtime.php');
 module_routes('lobby_display', 'lobby.php');
+module_routes('analytics', 'analytics.php');
 
 // OAuth — always load routes (module disabled by default, middleware gates access)
 require base_path('routes/modules/oauth.php');

--- a/routes/modules/analytics.php
+++ b/routes/modules/analytics.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Analytics module routes (api/v1).
+ * Loaded only when MODULE_ANALYTICS=true.
+ */
+
+use App\Http\Controllers\Api\AdminAnalyticsController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:analytics', 'auth:sanctum', 'throttle:api', 'admin'])->prefix('admin/analytics')->group(function () {
+    Route::get('/overview', [AdminAnalyticsController::class, 'overview']);
+});

--- a/tests/Feature/AdminAnalyticsTest.php
+++ b/tests/Feature/AdminAnalyticsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminAnalyticsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedData(): array
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $user = User::factory()->create(['role' => 'user']);
+        $lot = ParkingLot::create([
+            'name' => 'Analytics Lot',
+            'total_slots' => 10,
+            'available_slots' => 10,
+            'status' => 'open',
+        ]);
+        $slot = ParkingSlot::create([
+            'lot_id' => $lot->id,
+            'slot_number' => 'A1',
+            'status' => 'available',
+        ]);
+
+        Booking::create([
+            'user_id' => $user->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'lot_name' => 'Analytics Lot',
+            'slot_number' => 'A1',
+            'start_time' => now()->subHours(3),
+            'end_time' => now()->addHours(1),
+            'booking_type' => 'single',
+            'status' => 'confirmed',
+            'total_price' => 12.50,
+        ]);
+
+        Booking::create([
+            'user_id' => $user->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'lot_name' => 'Analytics Lot',
+            'slot_number' => 'A1',
+            'start_time' => now()->subDays(2)->setHour(9),
+            'end_time' => now()->subDays(2)->setHour(17),
+            'booking_type' => 'single',
+            'status' => 'completed',
+            'total_price' => 25.00,
+        ]);
+
+        return [$admin, $user, $lot, $slot];
+    }
+
+    public function test_admin_can_access_analytics_overview(): void
+    {
+        [$admin] = $this->seedData();
+        $token = $admin->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/admin/analytics/overview');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'daily_bookings',
+                    'revenue_by_day',
+                    'peak_hours',
+                    'top_lots',
+                    'user_growth',
+                    'avg_duration_hours',
+                    'total_users',
+                    'total_lots',
+                ],
+            ]);
+    }
+
+    public function test_non_admin_cannot_access_analytics(): void
+    {
+        [, $user] = $this->seedData();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/admin/analytics/overview');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_unauthenticated_cannot_access_analytics(): void
+    {
+        $this->getJson('/api/v1/admin/analytics/overview')
+            ->assertStatus(401);
+    }
+
+    public function test_analytics_returns_24_peak_hour_bins(): void
+    {
+        [$admin] = $this->seedData();
+        $token = $admin->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/admin/analytics/overview');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertCount(24, $data['peak_hours']);
+        $this->assertEquals(0, $data['peak_hours'][0]['hour']);
+        $this->assertEquals(23, $data['peak_hours'][23]['hour']);
+    }
+
+    public function test_analytics_returns_correct_booking_counts(): void
+    {
+        [$admin] = $this->seedData();
+        $token = $admin->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/admin/analytics/overview');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+
+        // We created 2 bookings
+        $totalBookings = collect($data['daily_bookings'])->sum('count');
+        $this->assertEquals(2, $totalBookings);
+    }
+
+    public function test_analytics_returns_revenue_data(): void
+    {
+        [$admin] = $this->seedData();
+        $token = $admin->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/admin/analytics/overview');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+
+        $totalRevenue = collect($data['revenue_by_day'])->sum('revenue');
+        $this->assertEquals(37.50, $totalRevenue);
+    }
+
+    public function test_analytics_returns_top_lots(): void
+    {
+        [$admin] = $this->seedData();
+        $token = $admin->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/admin/analytics/overview');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+
+        $this->assertNotEmpty($data['top_lots']);
+        $this->assertEquals('Analytics Lot', $data['top_lots'][0]['name']);
+        $this->assertEquals(2, $data['top_lots'][0]['booking_count']);
+    }
+
+    public function test_analytics_returns_user_growth(): void
+    {
+        [$admin] = $this->seedData();
+        $token = $admin->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/admin/analytics/overview');
+
+        $response->assertStatus(200);
+        $data = $response->json('data');
+
+        // 2 users created (admin + user)
+        $this->assertEquals(2, $data['total_users']);
+        $totalGrowth = collect($data['user_growth'])->sum('new_users');
+        $this->assertEquals(2, $totalGrowth);
+    }
+
+    public function test_analytics_disabled_when_module_off(): void
+    {
+        [$admin] = $this->seedData();
+        $token = $admin->createToken('test')->plainTextToken;
+
+        config(['modules.analytics' => false]);
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/admin/analytics/overview');
+
+        // Module middleware returns 404 when disabled
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/ModuleSystemExtendedTest.php
+++ b/tests/Feature/ModuleSystemExtendedTest.php
@@ -130,7 +130,7 @@ class ModuleSystemExtendedTest extends TestCase
     public function test_module_service_provider_all_returns_correct_count(): void
     {
         $all = ModuleServiceProvider::all();
-        $this->assertCount(29, $all);
+        $this->assertCount(30, $all);
     }
 
     public function test_modules_endpoint_is_always_public(): void

--- a/tests/Feature/ModuleSystemTest.php
+++ b/tests/Feature/ModuleSystemTest.php
@@ -335,10 +335,10 @@ class ModuleSystemTest extends TestCase
             ->assertOk();
     }
 
-    public function test_all_29_modules_in_config(): void
+    public function test_all_30_modules_in_config(): void
     {
         $modules = config('modules');
 
-        $this->assertCount(29, $modules);
+        $this->assertCount(30, $modules);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `AdminAnalyticsController` with `GET /api/v1/admin/analytics/overview` endpoint
- Returns: daily bookings (30d), revenue by day, peak hours (24 bins), top lots, user growth (12mo), avg duration
- New `MODULE_ANALYTICS=true` in config/modules.php (30th module)
- DB-agnostic: supports SQLite, PostgreSQL, and MySQL
- 9 new PHP tests covering auth, response structure, data accuracy, and module toggle

## Test plan
- [x] 9 new tests in AdminAnalyticsTest pass
- [x] Module count tests updated (29 -> 30)
- [x] Full suite: 942 tests, 2129 assertions, 0 failures
- [x] Pint code style passes