### PR TITLE
chore(linguist): pin primary-language pill to PHP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,13 @@
 *.md diff=markdown
 *.php diff=php
 
+# Keep GitHub's primary-language pill on PHP. The co-located frontend
+# monorepo is real first-party TypeScript (not vendored), but counting it
+# against repo language stats flips the pill to TypeScript on a PHP/Laravel
+# backend project. linguist-detectable=false preserves syntax highlighting
+# while excluding the directory from aggregate stats.
+parkhub-web/** linguist-detectable=false
+
 /.github export-ignore
 CHANGELOG.md export-ignore
 .styleci.yml export-ignore


### PR DESCRIPTION
One-line .gitattributes change: mark `parkhub-web/\*\*` as `linguist-detectable=false` so GitHub's language pill on the repo homepage shows PHP (the backend stack) rather than TypeScript (the co-located frontend).

Background: repo's actual split is TypeScript 5MB / PHP 2.3MB — linguist goes by checked-in line count, not intent. The frontend isn't vendored, so `linguist-vendored=true` would be wrong; `linguist-detectable=false` is the correct flag for 'first-party but please don't skew the top-level stat'.

Syntax highlighting inside `parkhub-web/\*\*` is unaffected.

No code changes, no CI impact.

## Test plan
- [ ] After merge, repo homepage pill should read PHP within 1-2 refreshes (linguist is cached)
- [ ] Language breakdown bar under About still shows both TS + PHP, just excludes TS from the dominant-language calc