### PR TITLE
fix(sec): clear CodeQL warnings in Settings + AdminModules (mirror)

### DIFF
--- a/parkhub-web/src/views/AdminModules.tsx
+++ b/parkhub-web/src/views/AdminModules.tsx
@@ -46,8 +46,8 @@ function categoryLabel(t: (k: string, d?: string) => string, cat: string): strin
 /** Status pill reflects runtime_enabled (green), runtime off (amber), or compile-time off (gray). */
 function StatusDot({ m }: { m: ModuleInfo }) {
   const runtime = m.runtime_enabled ?? m.enabled;
-  let cls = 'bg-neutral-500';
-  let label = 'disabled';
+  let cls: string;
+  let label: string;
   if (!m.enabled) {
     // Compile-time disabled — nothing admins can do at runtime.
     cls = 'bg-neutral-500';
@@ -375,7 +375,7 @@ export function AdminModulesPage() {
       {configOpenFor && (
         <ConfigEditorModal
           moduleName={configOpenFor}
-          isOpen={configOpenFor !== null}
+          isOpen
           onClose={() => setConfigOpenFor(null)}
         />
       )}

--- a/parkhub-web/src/views/Settings.tsx
+++ b/parkhub-web/src/views/Settings.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { User, Building, Palette, Bell, Car, Keyboard, Shield, Coins, ChartLine, FileText, ArrowRight } from '@phosphor-icons/react';
+import { User, Building, Bell, Car, Keyboard, Shield, Coins, ChartLine, FileText, ArrowRight } from '@phosphor-icons/react';
 import {
   SCard,
   SRow,


### PR DESCRIPTION
Mirror of [parkhub-rust#338](https://github.com/nash87/parkhub-rust/pull/338). Byte-identical changes to the shared parkhub-web/ tree.

Fixes 4 CodeQL alerts (js/useless-assignment-to-local × 2, js/comparison-between-incompatible-types, js/unused-local-variable) — pure static-analysis cleanup, zero runtime behaviour change.