### PR TITLE
fix(ui): bump parkhub-web package version 4.12.0 → 4.13.0

### DIFF
--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "4.12.0",
+      "version": "4.13.0",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@hookform/resolvers": "^5.2.2",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary
Login page footer imports version directly from `parkhub-web/package.json`, so the shipped bundle advertised **v4.12.0** while the repo's `VERSION` file was at **4.13.0**. Align the sub-package to the release tag so the deployed login footer shows the right number.

## Test plan
- [ ] CI green
- [ ] Deployed login page footer shows v4.13.0