### PR TITLE
ci(deploy): unblock Render demo deploy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -117,7 +117,6 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: demo
     permissions: {}
     env:
       RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}


### PR DESCRIPTION
The deploy-demo job in docker-publish.yml was silently skipped on every main-branch push: it declared 'environment: demo' but that environment had zero secrets configured, so GitHub hid the repo-level RENDER_API_KEY / RENDER_SERVICE_ID and the if:env.RENDER_API_KEY == '' guard short-circuited.

Dropping the environment scope makes repo secrets apply directly. Render deploy history remains visible in the Render dashboard; no protection rules were set on the environment, so this is a pure unblock.