### PR TITLE
feat(i18n): translate v5 onboarding tour — 10 locales + tour.* namespace

### DIFF
--- a/parkhub-web/src/design-v5/OnboardingTour.tsx
+++ b/parkhub-web/src/design-v5/OnboardingTour.tsx
@@ -135,33 +135,33 @@ function PrivacyStep() {
   const items = [
     {
       icon: 'shield' as const,
-      title: t('onboarding.privacy.self.title', 'Self-hosted — Ihre Daten bleiben bei Ihnen'),
+      title: t('tour.privacy.self.title', 'Self-hosted — Ihre Daten bleiben bei Ihnen'),
       body: t(
-        'onboarding.privacy.self.body',
+        'tour.privacy.self.body',
         'ParkHub läuft auf Ihrer eigenen Infrastruktur. Wir haben keinen Zugriff auf Ihre Buchungen, Fahrzeuge oder Nutzerdaten — weder live noch in Backups.'
       ),
     },
     {
       icon: 'key' as const,
-      title: t('onboarding.privacy.encryption.title', 'Verschlüsselung by default'),
+      title: t('tour.privacy.encryption.title', 'Verschlüsselung by default'),
       body: t(
-        'onboarding.privacy.encryption.body',
+        'tour.privacy.encryption.body',
         'Alle Verbindungen TLS 1.3. Passwörter als Argon2-Hashes. Session-Tokens mit Family-Rotation + optionaler Redis-Revocation für Multi-Replica.'
       ),
     },
     {
       icon: 'info' as const,
-      title: t('onboarding.privacy.gdpr.title', 'GDPR-konform seit Tag 1'),
+      title: t('tour.privacy.gdpr.title', 'GDPR-konform seit Tag 1'),
       body: t(
-        'onboarding.privacy.gdpr.body',
+        'tour.privacy.gdpr.body',
         'Auskunftsrecht (Art. 15), Löschrecht (Art. 17), Datenportabilität (Art. 20) als Self-Service-Endpoints. Audit-Log für jeden Daten-Access. Impressum + Datenschutz-Seite integriert.'
       ),
     },
     {
       icon: 'check' as const,
-      title: t('onboarding.privacy.minimization.title', 'Datensparsamkeit'),
+      title: t('tour.privacy.minimization.title', 'Datensparsamkeit'),
       body: t(
-        'onboarding.privacy.minimization.body',
+        'tour.privacy.minimization.body',
         'Nur was für den Parkbetrieb nötig ist: Name, Kennzeichen, Buchungszeit. Keine Tracking-Cookies, keine Drittanbieter-Analytics, keine Werbe-SDKs.'
       ),
     },
@@ -171,11 +171,11 @@ function PrivacyStep() {
       <div>
         <SectionLabel>Schritt 1 von 3 · Ihre Daten</SectionLabel>
         <h2 style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', letterSpacing: '-0.5px', margin: '2px 0 6px' }}>
-          {t('onboarding.privacy.title', 'Volle Transparenz zu Ihren Daten')}
+          {t('tour.privacy.title', 'Volle Transparenz zu Ihren Daten')}
         </h2>
         <p style={{ fontSize: 13, color: 'var(--v5-mut)', lineHeight: 1.6, margin: 0 }}>
           {t(
-            'onboarding.privacy.intro',
+            'tour.privacy.intro',
             'Bevor Sie starten — so gehen wir mit Ihren Daten um. Keine versteckten Klauseln, keine Opt-Outs im Kleingedruckten.'
           )}
         </p>
@@ -221,11 +221,11 @@ function FeaturesStep({
       <div>
         <SectionLabel>Schritt 2 von 3 · Module</SectionLabel>
         <h2 style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', letterSpacing: '-0.5px', margin: '2px 0 6px' }}>
-          {t('onboarding.features.title', 'Wählen Sie die Features die Sie brauchen')}
+          {t('tour.features.title', 'Wählen Sie die Features die Sie brauchen')}
         </h2>
         <p style={{ fontSize: 13, color: 'var(--v5-mut)', lineHeight: 1.6, margin: 0 }}>
           {t(
-            'onboarding.features.intro',
+            'tour.features.intro',
             'Jedes Modul ist abschaltbar. Deaktivierte Features verschwinden aus der Navigation und verbrauchen keine Ressourcen. Sie können das jederzeit unter Einstellungen ändern.'
           )}
         </p>
@@ -306,11 +306,11 @@ function TrustStep() {
       <div>
         <SectionLabel>Schritt 3 von 3 · Vertrauen</SectionLabel>
         <h2 style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', letterSpacing: '-0.5px', margin: '2px 0 6px' }}>
-          {t('onboarding.trust.title', 'Warum Sie ParkHub vertrauen können')}
+          {t('tour.trust.title', 'Warum Sie ParkHub vertrauen können')}
         </h2>
         <p style={{ fontSize: 13, color: 'var(--v5-mut)', lineHeight: 1.6, margin: 0 }}>
           {t(
-            'onboarding.trust.intro',
+            'tour.trust.intro',
             'ParkHub wird öffentlich entwickelt. Jede Zeile Code, jeder Build, jeder Audit ist einsehbar. Keine Marketing-Claims — hier ist die Substanz.'
           )}
         </p>
@@ -349,12 +349,12 @@ function TrustStep() {
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
           <V5NamedIcon name="shield" size={14} color="var(--v5-acc)" />
           <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--v5-acc)', letterSpacing: 0.3, textTransform: 'uppercase' }}>
-            {t('onboarding.trust.openBadge', 'Open by default')}
+            {t('tour.trust.openBadge', 'Open by default')}
           </span>
         </div>
         <p style={{ fontSize: 12, color: 'var(--v5-txt)', lineHeight: 1.6, margin: 0 }}>
           {t(
-            'onboarding.trust.openBody',
+            'tour.trust.openBody',
             'Source auf GitHub, Security-Audits öffentlich, Vulnerability-Disclosure-Policy aktiv. Fragen Sie Ihr Team — oder uns direkt.'
           )}
         </p>
@@ -389,7 +389,7 @@ function TourInner() {
   const next = () => {
     if (isLast) {
       markOnboardingTourSeen();
-      toast(t('onboarding.complete', 'Willkommen! Ihr ParkHub ist einsatzbereit.'), 'success');
+      toast(t('tour.complete', 'Willkommen! Ihr ParkHub ist einsatzbereit.'), 'success');
       // Small delay so the toast is visible before we navigate away
       setTimeout(() => navigate('/', { replace: true }), 600);
       return;
@@ -459,7 +459,7 @@ function TourInner() {
               fontFamily: 'inherit',
             }}
           >
-            {t('onboarding.skip', 'Überspringen')}
+            {t('tour.skip', 'Überspringen')}
           </button>
           <div style={{ flex: 1 }} />
           {idx > 0 && (
@@ -477,7 +477,7 @@ function TourInner() {
                 fontFamily: 'inherit',
               }}
             >
-              {t('onboarding.back', 'Zurück')}
+              {t('tour.back', 'Zurück')}
             </button>
           )}
           <button
@@ -496,7 +496,7 @@ function TourInner() {
               fontFamily: 'inherit',
             }}
           >
-            {isLast ? t('onboarding.finish', 'Los geht\'s') : t('onboarding.next', 'Weiter')}
+            {isLast ? t('tour.finish', 'Los geht\'s') : t('tour.next', 'Weiter')}
           </button>
         </div>
       </div>

--- a/parkhub-web/src/i18n/locales/de.ts
+++ b/parkhub-web/src/i18n/locales/de.ts
@@ -1303,5 +1303,42 @@ export default {
     guestBooking: { title: 'Gastausweis', subtitle: 'Gast-Parkausweise erstellen und verwalten', create: 'Neuer Gastausweis', existing: 'Gastausweise', empty: 'Noch keine Gastausweise', formTitle: 'Gastausweis erstellen', guestName: 'Gastname', guestEmail: 'Gast-E-Mail', lot: 'Parkplatz', slot: 'Stellplatz', selectLot: 'Parkplatz waehlen', selectSlot: 'Stellplatz waehlen', startTime: 'Startzeit', endTime: 'Endzeit', creating: 'Wird erstellt...', created: 'Gastausweis erstellt', cancelled: 'Gastausweis storniert', cancel: 'Ausweis stornieren', passCreated: 'Gastausweis erstellt', shareInstructions: 'Teilen Sie diesen Ausweis mit Ihrem Gast', dateRange: 'Datum & Zeit', code: 'Zugangscode', codeCopied: 'Code in Zwischenablage kopiert', share: 'Teilen', shareTitle: 'Gast-Parkausweis', shareText: 'Hier ist Ihr Gast-Parkausweis fuer {{name}}. Zugangscode: {{code}}', linkCopied: 'Link in Zwischenablage kopiert', requiredFields: 'Bitte alle Pflichtfelder ausfuellen', status: { active: 'Aktiv', expired: 'Abgelaufen', cancelled: 'Storniert' } },
     swap: { title: 'Tausch-Anfragen', subtitle: 'Parkplatz-Tausch anfragen und verwalten', create: 'Neuer Tausch', createTitle: 'Tausch-Anfrage erstellen', empty: 'Noch keine Tausch-Anfragen', emptyHint: 'Erstellen Sie eine Tausch-Anfrage, um Stellplaetze mit Kollegen zu tauschen', yourSlot: 'Ihr Stellplatz', theirSlot: 'Deren Stellplatz', yourBooking: 'Ihre Buchung', selectBooking: 'Buchung waehlen', targetBookingId: 'Ziel-Buchungs-ID', targetPlaceholder: 'Buchungs-ID zum Tauschen eingeben', messageLabel: 'Nachricht', messagePlaceholder: 'Optionale Nachricht fuer die andere Partei', send: 'Anfrage senden', created: 'Tausch-Anfrage gesendet', accepted: 'Tausch-Anfrage akzeptiert', declined: 'Tausch-Anfrage abgelehnt', accept: 'Akzeptieren', decline: 'Ablehnen', status: { pending: 'Ausstehend', accepted: 'Akzeptiert', declined: 'Abgelehnt' } },
     webhookDashboard: { title: "Webhook-Zustellungen", subtitle: "Webhook-Zustellungsleistung ueberwachen", help: "Verfolgen Sie Webhook-Zustellungsverlauf, Erfolgsraten, Antwortzeiten und wiederholen Sie fehlgeschlagene Zustellungen.", helpLabel: "Hilfe", deliveryTimeline: "Zustellungszeitlinie", successRate: "Erfolgsrate", avgResponseTime: "Durchschn. Antwortzeit", topErrors: "Haeufigste Fehler", replay: "Wiederholen", replaying: "Wiederholen...", replayed: "Zustellung wiederholt", replayFailed: "Wiederholung fehlgeschlagen", noDeliveries: "Noch keine Zustellungen", stats: "Statistiken", totalDeliveries: "Zustellungen gesamt", successCount: "Erfolgreich", failureCount: "Fehlgeschlagen", responseTime: "{{ms}}ms", statusCode: "Status {{code}}" },
+        tour: {
+        back: 'Zurück',
+        next: 'Weiter',
+        skip: 'Überspringen',
+        finish: 'Los geht\'s',
+        complete: 'Willkommen! Ihr ParkHub ist einsatzbereit.',
+        privacy: {
+          title: 'Volle Transparenz zu Ihren Daten',
+          intro: 'Bevor Sie starten — so gehen wir mit Ihren Daten um. Keine versteckten Klauseln, keine Opt-Outs im Kleingedruckten.',
+          self: {
+            title: 'Self-hosted — Ihre Daten bleiben bei Ihnen',
+            body: 'ParkHub läuft auf Ihrer eigenen Infrastruktur. Wir haben keinen Zugriff auf Ihre Buchungen, Fahrzeuge oder Nutzerdaten — weder live noch in Backups.',
+          },
+          encryption: {
+            title: 'Verschlüsselung by default',
+            body: 'Alle Verbindungen TLS 1.3. Passwörter als Argon2-Hashes. Session-Tokens mit Family-Rotation + optionaler Redis-Revocation für Multi-Replica.',
+          },
+          gdpr: {
+            title: 'GDPR-konform seit Tag 1',
+            body: 'Auskunftsrecht (Art. 15), Löschrecht (Art. 17), Datenportabilität (Art. 20) als Self-Service-Endpoints. Audit-Log für jeden Daten-Access. Impressum + Datenschutz-Seite integriert.',
+          },
+          minimization: {
+            title: 'Datensparsamkeit',
+            body: 'Nur was für den Parkbetrieb nötig ist: Name, Kennzeichen, Buchungszeit. Keine Tracking-Cookies, keine Drittanbieter-Analytics, keine Werbe-SDKs.',
+          },
+        },
+        features: {
+          title: 'Wählen Sie die Features die Sie brauchen',
+          intro: 'Jedes Modul ist abschaltbar. Deaktivierte Features verschwinden aus der Navigation und verbrauchen keine Ressourcen. Sie können das jederzeit unter Einstellungen ändern.',
+        },
+        trust: {
+          title: 'Warum Sie ParkHub vertrauen können',
+          intro: 'ParkHub wird öffentlich entwickelt. Jede Zeile Code, jeder Build, jeder Audit ist einsehbar. Keine Marketing-Claims — hier ist die Substanz.',
+          openBadge: 'Open by default',
+          openBody: 'Source auf GitHub, Security-Audits öffentlich, Vulnerability-Disclosure-Policy aktiv. Fragen Sie Ihr Team — oder uns direkt.',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/en.ts
+++ b/parkhub-web/src/i18n/locales/en.ts
@@ -1782,5 +1782,42 @@ export default {
       responseTime: '{{ms}}ms',
       statusCode: 'Status {{code}}',
     },
+        tour: {
+        back: 'Back',
+        next: 'Next',
+        skip: 'Skip',
+        finish: 'Let\'s go',
+        complete: 'Welcome! Your ParkHub is ready to use.',
+        privacy: {
+          title: 'Full transparency about your data',
+          intro: 'Before you start — here\'s how we handle your data. No hidden clauses, no opt-outs buried in the fine print.',
+          self: {
+            title: 'Self-hosted — your data stays with you',
+            body: 'ParkHub runs on your own infrastructure. We have no access to your bookings, vehicles or user data — neither live nor in backups.',
+          },
+          encryption: {
+            title: 'Encryption by default',
+            body: 'All connections use TLS 1.3. Passwords stored as Argon2 hashes. Session tokens with family rotation plus optional Redis revocation for multi-replica setups.',
+          },
+          gdpr: {
+            title: 'GDPR-compliant from day one',
+            body: 'Right of access (Art. 15), right to erasure (Art. 17), data portability (Art. 20) as self-service endpoints. Audit log for every data access. Imprint and privacy policy pages built in.',
+          },
+          minimization: {
+            title: 'Data minimization',
+            body: 'Only what\'s needed for parking operations: name, license plate, booking time. No tracking cookies, no third-party analytics, no advertising SDKs.',
+          },
+        },
+        features: {
+          title: 'Choose the features you need',
+          intro: 'Every module can be turned off. Disabled features disappear from the navigation and consume no resources. You can change this anytime under Settings.',
+        },
+        trust: {
+          title: 'Why you can trust ParkHub',
+          intro: 'ParkHub is developed in the open. Every line of code, every build, every audit is available for inspection. No marketing claims — here\'s the substance.',
+          openBadge: 'Open by default',
+          openBody: 'Source on GitHub, security audits public, vulnerability disclosure policy active. Ask your team — or ask us directly.',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/es.ts
+++ b/parkhub-web/src/i18n/locales/es.ts
@@ -1090,5 +1090,42 @@ export default {
     guestBooking: { title: 'Pase de Invitado', subtitle: 'Crear y gestionar pases de estacionamiento para invitados', create: 'Nuevo Pase', existing: 'Pases de Invitado', empty: 'Sin pases de invitado', formTitle: 'Crear Pase de Invitado', guestName: 'Nombre del invitado', guestEmail: 'Email del invitado', lot: 'Estacionamiento', slot: 'Plaza', selectLot: 'Seleccionar estacionamiento', selectSlot: 'Seleccionar plaza', startTime: 'Hora de inicio', endTime: 'Hora de fin', creating: 'Creando...', created: 'Pase creado', cancelled: 'Pase cancelado', cancel: 'Cancelar pase', passCreated: 'Pase Creado', shareInstructions: 'Comparte este pase con tu invitado', dateRange: 'Fecha y hora', code: 'Codigo de acceso', codeCopied: 'Codigo copiado', share: 'Compartir', shareTitle: 'Pase de Estacionamiento', shareText: 'Aqui esta tu pase para {{name}}. Codigo: {{code}}', linkCopied: 'Enlace copiado', requiredFields: 'Complete todos los campos obligatorios', status: { active: 'Activo', expired: 'Expirado', cancelled: 'Cancelado' } },
     swap: { title: 'Solicitudes de Intercambio', subtitle: 'Solicitar y gestionar intercambios de plazas', create: 'Nuevo Intercambio', createTitle: 'Crear Solicitud', empty: 'Sin solicitudes', emptyHint: 'Crea una solicitud para intercambiar plazas con un colega', yourSlot: 'Tu Plaza', theirSlot: 'Su Plaza', yourBooking: 'Tu Reserva', selectBooking: 'Seleccionar reserva', targetBookingId: 'ID de reserva destino', targetPlaceholder: 'Ingresa el ID de la reserva', messageLabel: 'Mensaje', messagePlaceholder: 'Mensaje opcional', send: 'Enviar', created: 'Solicitud enviada', accepted: 'Solicitud aceptada', declined: 'Solicitud rechazada', accept: 'Aceptar', decline: 'Rechazar', status: { pending: 'Pendiente', accepted: 'Aceptada', declined: 'Rechazada' } },
     webhookDashboard: { title: "Entregas Webhook", subtitle: "Rendimiento de entregas", help: "Rastrea historial, tasas de exito, tiempos de respuesta y reintenta entregas fallidas.", helpLabel: "Ayuda", deliveryTimeline: "Cronologia", successRate: "Tasa de exito", avgResponseTime: "Tiempo promedio", topErrors: "Errores frecuentes", replay: "Reintentar", replaying: "Reintentando...", replayed: "Reintentada", replayFailed: "Fallo", noDeliveries: "Sin entregas", stats: "Estadisticas", totalDeliveries: "Total", successCount: "Exitosas", failureCount: "Fallidas", responseTime: "{{ms}}ms", statusCode: "Estado {{code}}" },
+        tour: {
+        back: 'Atrás',
+        next: 'Siguiente',
+        skip: 'Omitir',
+        finish: 'Empezar',
+        complete: '¡Bienvenido! Su ParkHub está listo para usar.',
+        privacy: {
+          title: 'Plena transparencia sobre sus datos',
+          intro: 'Antes de empezar — así tratamos sus datos. Sin cláusulas ocultas, sin opt-outs escondidos en la letra pequeña.',
+          self: {
+            title: 'Autoalojado — sus datos se quedan con usted',
+            body: 'ParkHub se ejecuta en su propia infraestructura. No tenemos acceso a sus reservas, vehículos ni datos de usuarios — ni en directo ni en copias de seguridad.',
+          },
+          encryption: {
+            title: 'Cifrado por defecto',
+            body: 'Todas las conexiones en TLS 1.3. Contraseñas almacenadas como hashes Argon2. Tokens de sesión con rotación de familia y revocación Redis opcional para configuraciones multi-replica.',
+          },
+          gdpr: {
+            title: 'Conforme al RGPD desde el primer día',
+            body: 'Derecho de acceso (Art. 15), derecho de supresión (Art. 17), portabilidad de datos (Art. 20) como endpoints self-service. Registro de auditoría para cada acceso a datos. Páginas de aviso legal y política de privacidad integradas.',
+          },
+          minimization: {
+            title: 'Minimización de datos',
+            body: 'Solo lo necesario para la operación del aparcamiento: nombre, matrícula, hora de reserva. Sin cookies de seguimiento, sin analíticas de terceros, sin SDKs publicitarios.',
+          },
+        },
+        features: {
+          title: 'Elija las funciones que necesita',
+          intro: 'Cada módulo se puede desactivar. Las funciones desactivadas desaparecen de la navegación y no consumen recursos. Puede cambiar esto en cualquier momento desde Ajustes.',
+        },
+        trust: {
+          title: 'Por qué puede confiar en ParkHub',
+          intro: 'ParkHub se desarrolla de forma abierta. Cada línea de código, cada build, cada auditoría está disponible para su revisión. Sin promesas de marketing — aquí está la sustancia.',
+          openBadge: 'Open by default',
+          openBody: 'Código fuente en GitHub, auditorías de seguridad públicas, política de divulgación de vulnerabilidades activa. Pregunte a su equipo — o pregúntenos directamente.',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/fr.ts
+++ b/parkhub-web/src/i18n/locales/fr.ts
@@ -1067,5 +1067,42 @@ export default {
     guestBooking: { title: 'Pass Visiteur', subtitle: 'Creer et gerer les pass visiteur', create: 'Nouveau Pass', existing: 'Pass Visiteurs', empty: 'Aucun pass visiteur', formTitle: 'Creer un Pass', guestName: 'Nom du visiteur', guestEmail: 'Email du visiteur', lot: 'Parking', slot: 'Place', selectLot: 'Choisir un parking', selectSlot: 'Choisir une place', startTime: 'Heure de debut', endTime: 'Heure de fin', creating: 'Creation...', created: 'Pass cree', cancelled: 'Pass annule', cancel: 'Annuler', passCreated: 'Pass Cree', shareInstructions: 'Partagez ce pass avec votre visiteur', dateRange: 'Date et heure', code: 'Code d acces', codeCopied: 'Code copie', share: 'Partager', shareTitle: 'Pass de Stationnement', shareText: 'Voici votre pass pour {{name}}. Code: {{code}}', linkCopied: 'Lien copie', requiredFields: 'Veuillez remplir tous les champs', status: { active: 'Actif', expired: 'Expire', cancelled: 'Annule' } },
     swap: { title: 'Demandes d Echange', subtitle: 'Demander et gerer les echanges de places', create: 'Nouvel Echange', createTitle: 'Creer une Demande', empty: 'Aucune demande', emptyHint: 'Creez une demande pour echanger des places', yourSlot: 'Votre Place', theirSlot: 'Leur Place', yourBooking: 'Votre Reservation', selectBooking: 'Choisir une reservation', targetBookingId: 'ID reservation cible', targetPlaceholder: 'Saisissez l ID', messageLabel: 'Message', messagePlaceholder: 'Message optionnel', send: 'Envoyer', created: 'Demande envoyee', accepted: 'Demande acceptee', declined: 'Demande refusee', accept: 'Accepter', decline: 'Refuser', status: { pending: 'En attente', accepted: 'Acceptee', declined: 'Refusee' } },
     webhookDashboard: { title: "Livraisons Webhook", subtitle: "Performances de livraison", help: "Suivez l historique, taux de succes, temps de reponse et rejouez les echecs.", helpLabel: "Aide", deliveryTimeline: "Chronologie", successRate: "Taux de succes", avgResponseTime: "Temps moyen", topErrors: "Erreurs frequentes", replay: "Rejouer", replaying: "Rejeu...", replayed: "Rejouee", replayFailed: "Echec", noDeliveries: "Aucune livraison", stats: "Statistiques", totalDeliveries: "Total", successCount: "Reussies", failureCount: "Echouees", responseTime: "{{ms}}ms", statusCode: "Statut {{code}}" },
+        tour: {
+        back: 'Retour',
+        next: 'Suivant',
+        skip: 'Passer',
+        finish: 'C\'est parti',
+        complete: 'Bienvenue ! Votre ParkHub est prêt à l\'emploi.',
+        privacy: {
+          title: 'Transparence totale sur vos données',
+          intro: 'Avant de commencer — voici comment nous gérons vos données. Aucune clause cachée, aucun opt-out dissimulé en petits caractères.',
+          self: {
+            title: 'Auto-hébergé — vos données restent chez vous',
+            body: 'ParkHub fonctionne sur votre propre infrastructure. Nous n\'avons aucun accès à vos réservations, véhicules ou données utilisateurs — ni en direct ni dans les sauvegardes.',
+          },
+          encryption: {
+            title: 'Chiffrement par défaut',
+            body: 'Toutes les connexions en TLS 1.3. Mots de passe stockés en hachages Argon2. Jetons de session avec rotation de famille et révocation Redis optionnelle pour les configurations multi-replica.',
+          },
+          gdpr: {
+            title: 'Conforme au RGPD dès le premier jour',
+            body: 'Droit d\'accès (Art. 15), droit à l\'effacement (Art. 17), portabilité des données (Art. 20) en endpoints self-service. Journal d\'audit pour chaque accès aux données. Pages mentions légales et politique de confidentialité intégrées.',
+          },
+          minimization: {
+            title: 'Minimisation des données',
+            body: 'Uniquement ce qui est nécessaire à l\'exploitation du parking : nom, plaque d\'immatriculation, horaire de réservation. Aucun cookie de tracking, aucune analyse tierce, aucun SDK publicitaire.',
+          },
+        },
+        features: {
+          title: 'Choisissez les fonctionnalités dont vous avez besoin',
+          intro: 'Chaque module peut être désactivé. Les fonctionnalités désactivées disparaissent de la navigation et ne consomment aucune ressource. Vous pouvez modifier cela à tout moment dans les Paramètres.',
+        },
+        trust: {
+          title: 'Pourquoi vous pouvez faire confiance à ParkHub',
+          intro: 'ParkHub est développé en public. Chaque ligne de code, chaque build, chaque audit est consultable. Pas de promesses marketing — voici la substance.',
+          openBadge: 'Open by default',
+          openBody: 'Code source sur GitHub, audits de sécurité publics, politique de divulgation des vulnérabilités active. Demandez à votre équipe — ou demandez-nous directement.',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/it.ts
+++ b/parkhub-web/src/i18n/locales/it.ts
@@ -1067,5 +1067,42 @@ export default {
     guestBooking: { title: 'Pass Ospite', subtitle: 'Crea e gestisci pass parcheggio ospite', create: 'Nuovo Pass', existing: 'Pass Ospiti', empty: 'Nessun pass ospite', formTitle: 'Crea Pass Ospite', guestName: 'Nome ospite', guestEmail: 'Email ospite', lot: 'Parcheggio', slot: 'Posto', selectLot: 'Seleziona parcheggio', selectSlot: 'Seleziona posto', startTime: 'Ora inizio', endTime: 'Ora fine', creating: 'Creazione...', created: 'Pass creato', cancelled: 'Pass annullato', cancel: 'Annulla', passCreated: 'Pass Creato', shareInstructions: 'Condividi questo pass con il tuo ospite', dateRange: 'Data e ora', code: 'Codice di accesso', codeCopied: 'Codice copiato', share: 'Condividi', shareTitle: 'Pass Parcheggio', shareText: 'Ecco il pass per {{name}}. Codice: {{code}}', linkCopied: 'Link copiato', requiredFields: 'Compilare tutti i campi', status: { active: 'Attivo', expired: 'Scaduto', cancelled: 'Annullato' } },
     swap: { title: 'Richieste di Scambio', subtitle: 'Richiedi e gestisci scambi di posti', create: 'Nuovo Scambio', createTitle: 'Crea Richiesta', empty: 'Nessuna richiesta', emptyHint: 'Crea una richiesta per scambiare posti', yourSlot: 'Il Tuo Posto', theirSlot: 'Il Loro Posto', yourBooking: 'La Tua Prenotazione', selectBooking: 'Seleziona prenotazione', targetBookingId: 'ID prenotazione', targetPlaceholder: 'Inserisci l ID', messageLabel: 'Messaggio', messagePlaceholder: 'Messaggio opzionale', send: 'Invia', created: 'Richiesta inviata', accepted: 'Richiesta accettata', declined: 'Richiesta rifiutata', accept: 'Accetta', decline: 'Rifiuta', status: { pending: 'In attesa', accepted: 'Accettata', declined: 'Rifiutata' } },
     webhookDashboard: { title: "Consegne Webhook", subtitle: "Prestazioni di consegna", help: "Monitora cronologia, tassi di successo, tempi di risposta e rigioca consegne fallite.", helpLabel: "Aiuto", deliveryTimeline: "Cronologia", successRate: "Tasso successo", avgResponseTime: "Tempo medio", topErrors: "Errori frequenti", replay: "Rigioca", replaying: "Rigiocando...", replayed: "Rigiocata", replayFailed: "Fallito", noDeliveries: "Nessuna consegna", stats: "Statistiche", totalDeliveries: "Totale", successCount: "Riuscite", failureCount: "Fallite", responseTime: "{{ms}}ms", statusCode: "Stato {{code}}" },
+        tour: {
+        back: 'Indietro',
+        next: 'Avanti',
+        skip: 'Salta',
+        finish: 'Iniziamo',
+        complete: 'Benvenuto! Il tuo ParkHub è pronto all\'uso.',
+        privacy: {
+          title: 'Piena trasparenza sui tuoi dati',
+          intro: 'Prima di iniziare — ecco come gestiamo i tuoi dati. Nessuna clausola nascosta, nessun opt-out sepolto nelle note in piccolo.',
+          self: {
+            title: 'Self-hosted — i tuoi dati restano con te',
+            body: 'ParkHub funziona sulla tua infrastruttura. Non abbiamo alcun accesso alle tue prenotazioni, veicoli o dati utente — né in tempo reale né nei backup.',
+          },
+          encryption: {
+            title: 'Crittografia by default',
+            body: 'Tutte le connessioni in TLS 1.3. Password memorizzate come hash Argon2. Session token con rotazione di famiglia e revoca Redis opzionale per configurazioni multi-replica.',
+          },
+          gdpr: {
+            title: 'Conforme al GDPR dal primo giorno',
+            body: 'Diritto di accesso (Art. 15), diritto alla cancellazione (Art. 17), portabilità dei dati (Art. 20) come endpoint self-service. Audit log per ogni accesso ai dati. Pagine note legali e informativa sulla privacy integrate.',
+          },
+          minimization: {
+            title: 'Minimizzazione dei dati',
+            body: 'Solo ciò che serve per la gestione del parcheggio: nome, targa, orario di prenotazione. Nessun cookie di tracciamento, nessuna analytics di terze parti, nessun SDK pubblicitario.',
+          },
+        },
+        features: {
+          title: 'Scegli le funzionalità di cui hai bisogno',
+          intro: 'Ogni modulo può essere disattivato. Le funzionalità disattivate scompaiono dalla navigazione e non consumano risorse. Puoi modificare questa scelta in qualsiasi momento nelle Impostazioni.',
+        },
+        trust: {
+          title: 'Perché puoi fidarti di ParkHub',
+          intro: 'ParkHub è sviluppato in modo aperto. Ogni riga di codice, ogni build, ogni audit è consultabile. Niente promesse di marketing — ecco la sostanza.',
+          openBadge: 'Open by default',
+          openBody: 'Codice sorgente su GitHub, audit di sicurezza pubblici, policy di vulnerability disclosure attiva. Chiedi al tuo team — o chiedi direttamente a noi.',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/ja.ts
+++ b/parkhub-web/src/i18n/locales/ja.ts
@@ -89,5 +89,42 @@ export default {
     guestBooking: { title: 'ゲストパス', subtitle: 'ゲスト駐車パスの作成と管理', create: '新規パス', existing: 'ゲストパス一覧', empty: 'ゲストパスはありません', formTitle: 'ゲストパスを作成', guestName: 'ゲスト名', guestEmail: 'ゲストメール', lot: '駐車場', slot: 'スロット', selectLot: '駐車場を選択', selectSlot: 'スロットを選択', startTime: '開始時刻', endTime: '終了時刻', creating: '作成中...', created: 'パスを作成しました', cancelled: 'パスを取り消しました', cancel: '取り消し', passCreated: 'パス作成完了', shareInstructions: 'このパスをゲストと共有してください', dateRange: '日時', code: 'アクセスコード', codeCopied: 'コードをコピーしました', share: '共有', shareTitle: 'ゲスト駐車パス', shareText: '{{name}}さんの駐車パスです。コード: {{code}}', linkCopied: 'リンクをコピーしました', requiredFields: '必須項目を入力してください', status: { active: 'アクティブ', expired: '期限切れ', cancelled: '取消済' } },
     swap: { title: '交換リクエスト', subtitle: '駐車スロットの交換をリクエスト・管理', create: '新規交換', createTitle: '交換リクエストを作成', empty: '交換リクエストはありません', emptyHint: '同僚とスロットを交換するリクエストを作成', yourSlot: 'あなたのスロット', theirSlot: '相手のスロット', yourBooking: 'あなたの予約', selectBooking: '予約を選択', targetBookingId: '対象予約ID', targetPlaceholder: '交換する予約IDを入力', messageLabel: 'メッセージ', messagePlaceholder: '任意のメッセージ', send: '送信', created: 'リクエストを送信しました', accepted: 'リクエストが承認されました', declined: 'リクエストが辞退されました', accept: '承認', decline: '辞退', status: { pending: '保留中', accepted: '承認済', declined: '辞退済' } },
     webhookDashboard: { title: "Webhook配信", subtitle: "配信パフォーマンス", help: "履歴、成功率、応答時間を追跡し、失敗した配信を再送。", helpLabel: "ヘルプ", deliveryTimeline: "タイムライン", successRate: "成功率", avgResponseTime: "平均応答時間", topErrors: "頻出エラー", replay: "再送", replaying: "再送中...", replayed: "再送済み", replayFailed: "失敗", noDeliveries: "配信なし", stats: "統計", totalDeliveries: "合計", successCount: "成功", failureCount: "失敗", responseTime: "{{ms}}ms", statusCode: "ステータス {{code}}" },
+        tour: {
+        back: '戻る',
+        next: '次へ',
+        skip: 'スキップ',
+        finish: 'はじめる',
+        complete: 'ようこそ！ParkHubの準備が整いました。',
+        privacy: {
+          title: 'あなたのデータについて、完全な透明性を',
+          intro: 'はじめる前に — 私たちがあなたのデータをどう扱うかをご説明します。隠れた条項も、細かな文字に埋もれたオプトアウトも一切ありません。',
+          self: {
+            title: 'セルフホスト — あなたのデータはあなたのもとに',
+            body: 'ParkHubはあなた自身のインフラ上で動作します。私たちはあなたの予約、車両、ユーザーデータにアクセスすることはできません — ライブでもバックアップでもです。',
+          },
+          encryption: {
+            title: 'Encryption by default',
+            body: 'すべての接続はTLS 1.3。パスワードはArgon2ハッシュで保存。Session tokensはファミリーローテーション対応、マルチレプリカ構成向けにオプションでRedisによる失効機能も利用可能です。',
+          },
+          gdpr: {
+            title: '初日からGDPR準拠',
+            body: 'アクセス権（Art. 15）、削除権（Art. 17）、データポータビリティ（Art. 20）をセルフサービスのエンドポイントとして提供。すべてのデータアクセスに監査ログ。運営者表示とプライバシーポリシーのページも組み込み済みです。',
+          },
+          minimization: {
+            title: 'データ最小化',
+            body: '駐車場運営に必要なものだけ：氏名、ナンバープレート、予約時間。トラッキングクッキーなし、サードパーティの解析なし、広告SDKなし。',
+          },
+        },
+        features: {
+          title: '必要な機能を選んでください',
+          intro: 'どのモジュールもオフにできます。無効化された機能はナビゲーションから消え、リソースも消費しません。設定からいつでも変更できます。',
+        },
+        trust: {
+          title: 'ParkHubを信頼できる理由',
+          intro: 'ParkHubはオープンに開発されています。すべてのコード行、すべてのビルド、すべての監査を確認できます。マーケティングの約束ではなく — これが中身です。',
+          openBadge: 'Open by default',
+          openBody: 'ソースコードはGitHub上、セキュリティ監査は公開、脆弱性開示ポリシーも運用中。チームに確認してください — または私たちに直接お問い合わせください。',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/pl.ts
+++ b/parkhub-web/src/i18n/locales/pl.ts
@@ -89,5 +89,42 @@ export default {
     guestBooking: { title: 'Przepustka Goscia', subtitle: 'Tworzenie i zarzadzanie przepustkami parkingowymi', create: 'Nowa Przepustka', existing: 'Przepustki Gosci', empty: 'Brak przepustek', formTitle: 'Utworz Przepustke', guestName: 'Imie goscia', guestEmail: 'Email goscia', lot: 'Parking', slot: 'Miejsce', selectLot: 'Wybierz parking', selectSlot: 'Wybierz miejsce', startTime: 'Poczatek', endTime: 'Koniec', creating: 'Tworzenie...', created: 'Przepustka utworzona', cancelled: 'Przepustka anulowana', cancel: 'Anuluj', passCreated: 'Przepustka Utworzona', shareInstructions: 'Udostepnij te przepustke gosciowi', dateRange: 'Data i czas', code: 'Kod dostepu', codeCopied: 'Kod skopiowany', share: 'Udostepnij', shareTitle: 'Przepustka Parkingowa', shareText: 'Przepustka dla {{name}}. Kod: {{code}}', linkCopied: 'Link skopiowany', requiredFields: 'Wypelnij wszystkie pola', status: { active: 'Aktywna', expired: 'Wygasla', cancelled: 'Anulowana' } },
     swap: { title: 'Prosby o Zamiane', subtitle: 'Prosby o zamiane miejsc parkingowych', create: 'Nowa Zamiana', createTitle: 'Utworz Prosbe', empty: 'Brak prosb', emptyHint: 'Utworz prosbe o zamiane miejsc z kolega', yourSlot: 'Twoje Miejsce', theirSlot: 'Ich Miejsce', yourBooking: 'Twoja Rezerwacja', selectBooking: 'Wybierz rezerwacje', targetBookingId: 'ID rezerwacji docelowej', targetPlaceholder: 'Wpisz ID rezerwacji', messageLabel: 'Wiadomosc', messagePlaceholder: 'Opcjonalna wiadomosc', send: 'Wyslij', created: 'Prosba wyslana', accepted: 'Prosba zaakceptowana', declined: 'Prosba odrzucona', accept: 'Akceptuj', decline: 'Odrzuc', status: { pending: 'Oczekujaca', accepted: 'Zaakceptowana', declined: 'Odrzucona' } },
     webhookDashboard: { title: "Dostarczenia Webhook", subtitle: "Wydajnosc dostarczania", help: "Sledz historie, wskazniki sukcesu, czasy odpowiedzi i ponawiaj nieudane dostarczenia.", helpLabel: "Pomoc", deliveryTimeline: "Chronologia", successRate: "Wskaznik sukcesu", avgResponseTime: "Sredni czas", topErrors: "Czeste bledy", replay: "Ponow", replaying: "Ponawianie...", replayed: "Ponowione", replayFailed: "Niepowodzenie", noDeliveries: "Brak dostarczeni", stats: "Statystyki", totalDeliveries: "Lacznie", successCount: "Udane", failureCount: "Nieudane", responseTime: "{{ms}}ms", statusCode: "Status {{code}}" },
+        tour: {
+        back: 'Wstecz',
+        next: 'Dalej',
+        skip: 'Pomiń',
+        finish: 'Zaczynamy',
+        complete: 'Witamy! Twój ParkHub jest gotowy do użycia.',
+        privacy: {
+          title: 'Pełna przejrzystość dotycząca Twoich danych',
+          intro: 'Zanim zaczniesz — zobacz, jak traktujemy Twoje dane. Żadnych ukrytych klauzul, żadnych opt-outów ukrytych drobnym drukiem.',
+          self: {
+            title: 'Self-hosted — Twoje dane zostają u Ciebie',
+            body: 'ParkHub działa na Twojej własnej infrastrukturze. Nie mamy dostępu do Twoich rezerwacji, pojazdów ani danych użytkowników — ani na żywo, ani w kopiach zapasowych.',
+          },
+          encryption: {
+            title: 'Szyfrowanie by default',
+            body: 'Wszystkie połączenia w TLS 1.3. Hasła przechowywane jako hashe Argon2. Session tokens z rotacją rodzinną i opcjonalnym unieważnianiem w Redis dla konfiguracji multi-replica.',
+          },
+          gdpr: {
+            title: 'Zgodność z RODO od pierwszego dnia',
+            body: 'Prawo dostępu (Art. 15), prawo do usunięcia (Art. 17), przenoszalność danych (Art. 20) jako endpointy self-service. Dziennik audytu dla każdego dostępu do danych. Zintegrowane strony z impressum i polityką prywatności.',
+          },
+          minimization: {
+            title: 'Minimalizacja danych',
+            body: 'Tylko to, co niezbędne do obsługi parkingu: imię, numer rejestracyjny, czas rezerwacji. Żadnych cookies śledzących, żadnych analityk firm trzecich, żadnych SDK reklamowych.',
+          },
+        },
+        features: {
+          title: 'Wybierz funkcje, których potrzebujesz',
+          intro: 'Każdy moduł można wyłączyć. Wyłączone funkcje znikają z nawigacji i nie zużywają zasobów. Możesz to zmienić w dowolnym momencie w Ustawieniach.',
+        },
+        trust: {
+          title: 'Dlaczego możesz zaufać ParkHub',
+          intro: 'ParkHub jest rozwijany jawnie. Każda linia kodu, każdy build, każdy audyt są do wglądu. Żadnych marketingowych obietnic — oto konkrety.',
+          openBadge: 'Open by default',
+          openBody: 'Kod źródłowy na GitHubie, audyty bezpieczeństwa publiczne, aktywna polityka ujawniania podatności. Zapytaj swój zespół — lub zapytaj nas bezpośrednio.',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/pt.ts
+++ b/parkhub-web/src/i18n/locales/pt.ts
@@ -641,5 +641,42 @@ export default {
     guestBooking: { title: 'Passe de Convidado', subtitle: 'Criar e gerir passes de estacionamento para convidados', create: 'Novo Passe', existing: 'Passes de Convidado', empty: 'Sem passes', formTitle: 'Criar Passe', guestName: 'Nome do convidado', guestEmail: 'Email do convidado', lot: 'Estacionamento', slot: 'Vaga', selectLot: 'Selecionar estacionamento', selectSlot: 'Selecionar vaga', startTime: 'Hora de inicio', endTime: 'Hora de fim', creating: 'Criando...', created: 'Passe criado', cancelled: 'Passe cancelado', cancel: 'Cancelar', passCreated: 'Passe Criado', shareInstructions: 'Partilhe este passe com o convidado', dateRange: 'Data e hora', code: 'Codigo de acesso', codeCopied: 'Codigo copiado', share: 'Partilhar', shareTitle: 'Passe de Estacionamento', shareText: 'Passe para {{name}}. Codigo: {{code}}', linkCopied: 'Link copiado', requiredFields: 'Preencha todos os campos', status: { active: 'Ativo', expired: 'Expirado', cancelled: 'Cancelado' } },
     swap: { title: 'Pedidos de Troca', subtitle: 'Pedir e gerir trocas de vagas', create: 'Nova Troca', createTitle: 'Criar Pedido', empty: 'Sem pedidos', emptyHint: 'Crie um pedido para trocar vagas', yourSlot: 'A Sua Vaga', theirSlot: 'A Vaga Deles', yourBooking: 'A Sua Reserva', selectBooking: 'Selecionar reserva', targetBookingId: 'ID da reserva', targetPlaceholder: 'Introduza o ID', messageLabel: 'Mensagem', messagePlaceholder: 'Mensagem opcional', send: 'Enviar', created: 'Pedido enviado', accepted: 'Pedido aceite', declined: 'Pedido recusado', accept: 'Aceitar', decline: 'Recusar', status: { pending: 'Pendente', accepted: 'Aceite', declined: 'Recusado' } },
     webhookDashboard: { title: "Entregas Webhook", subtitle: "Desempenho de entregas", help: "Rastreie historico, taxas de sucesso, tempos de resposta e reenvie entregas falhas.", helpLabel: "Ajuda", deliveryTimeline: "Cronologia", successRate: "Taxa de sucesso", avgResponseTime: "Tempo medio", topErrors: "Erros frequentes", replay: "Reenviar", replaying: "Reenviando...", replayed: "Reenviada", replayFailed: "Falhou", noDeliveries: "Sem entregas", stats: "Estatisticas", totalDeliveries: "Total", successCount: "Bem-sucedidas", failureCount: "Falhas", responseTime: "{{ms}}ms", statusCode: "Status {{code}}" },
+        tour: {
+        back: 'Voltar',
+        next: 'Avançar',
+        skip: 'Pular',
+        finish: 'Vamos lá',
+        complete: 'Bem-vindo! O seu ParkHub está pronto para usar.',
+        privacy: {
+          title: 'Total transparência sobre os seus dados',
+          intro: 'Antes de começar — veja como lidamos com os seus dados. Sem cláusulas ocultas, sem opt-outs escondidos nas letras miúdas.',
+          self: {
+            title: 'Auto-hospedado — os seus dados ficam consigo',
+            body: 'O ParkHub funciona na sua própria infraestrutura. Não temos qualquer acesso às suas reservas, veículos ou dados de utilizadores — nem ao vivo nem em backups.',
+          },
+          encryption: {
+            title: 'Criptografia por padrão',
+            body: 'Todas as conexões em TLS 1.3. Senhas armazenadas como hashes Argon2. Session tokens com rotação de família e revogação Redis opcional para configurações multi-replica.',
+          },
+          gdpr: {
+            title: 'Em conformidade com o RGPD desde o primeiro dia',
+            body: 'Direito de acesso (Art. 15), direito ao apagamento (Art. 17), portabilidade de dados (Art. 20) como endpoints self-service. Registo de auditoria para cada acesso a dados. Páginas de informações legais e política de privacidade integradas.',
+          },
+          minimization: {
+            title: 'Minimização de dados',
+            body: 'Apenas o necessário para a operação do estacionamento: nome, matrícula, horário da reserva. Sem cookies de rastreamento, sem analytics de terceiros, sem SDKs publicitários.',
+          },
+        },
+        features: {
+          title: 'Escolha as funcionalidades de que precisa',
+          intro: 'Cada módulo pode ser desligado. As funcionalidades desativadas desaparecem da navegação e não consomem recursos. Pode alterar isto a qualquer momento em Definições.',
+        },
+        trust: {
+          title: 'Porque pode confiar no ParkHub',
+          intro: 'O ParkHub é desenvolvido de forma aberta. Cada linha de código, cada build, cada auditoria está disponível para consulta. Sem promessas de marketing — aqui está a substância.',
+          openBadge: 'Open by default',
+          openBody: 'Código-fonte no GitHub, auditorias de segurança públicas, política de divulgação de vulnerabilidades ativa. Pergunte à sua equipa — ou pergunte-nos diretamente.',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/tr.ts
+++ b/parkhub-web/src/i18n/locales/tr.ts
@@ -89,5 +89,42 @@ export default {
     guestBooking: { title: 'Misafir Karti', subtitle: 'Misafir park kartlari olustur ve yonet', create: 'Yeni Kart', existing: 'Misafir Kartlari', empty: 'Misafir karti yok', formTitle: 'Misafir Karti Olustur', guestName: 'Misafir adi', guestEmail: 'Misafir email', lot: 'Otopark', slot: 'Yer', selectLot: 'Otopark sec', selectSlot: 'Yer sec', startTime: 'Baslangic', endTime: 'Bitis', creating: 'Olusturuluyor...', created: 'Kart olusturuldu', cancelled: 'Kart iptal edildi', cancel: 'Iptal', passCreated: 'Kart Olusturuldu', shareInstructions: 'Bu karti misafirinizle paylasin', dateRange: 'Tarih ve saat', code: 'Erisim kodu', codeCopied: 'Kod kopyalandi', share: 'Paylas', shareTitle: 'Misafir Park Karti', shareText: '{{name}} icin park karti. Kod: {{code}}', linkCopied: 'Link kopyalandi', requiredFields: 'Tum alanlari doldurun', status: { active: 'Aktif', expired: 'Suresi doldu', cancelled: 'Iptal edildi' } },
     swap: { title: 'Takas Talepleri', subtitle: 'Park yeri takas talepleri', create: 'Yeni Takas', createTitle: 'Takas Talebi Olustur', empty: 'Takas talebi yok', emptyHint: 'Meslektasinizla yer degistirmek icin talep olusturun', yourSlot: 'Sizin Yeriniz', theirSlot: 'Onlarin Yeri', yourBooking: 'Rezervasyonunuz', selectBooking: 'Rezervasyon sec', targetBookingId: 'Hedef rezervasyon ID', targetPlaceholder: 'Rezervasyon ID girin', messageLabel: 'Mesaj', messagePlaceholder: 'Istege bagli mesaj', send: 'Gonder', created: 'Talep gonderildi', accepted: 'Talep kabul edildi', declined: 'Talep reddedildi', accept: 'Kabul Et', decline: 'Reddet', status: { pending: 'Beklemede', accepted: 'Kabul edildi', declined: 'Reddedildi' } },
     webhookDashboard: { title: "Webhook Teslimatlari", subtitle: "Teslimat performansi", help: "Gecmisi, basari oranlarini, yanit surelerini izleyin ve basarisiz teslimatlari yeniden deneyin.", helpLabel: "Yardim", deliveryTimeline: "Zaman cizelgesi", successRate: "Basari orani", avgResponseTime: "Ort. yanit suresi", topErrors: "Sik hatalar", replay: "Yeniden dene", replaying: "Deneniyor...", replayed: "Yeniden denendi", replayFailed: "Basarisiz", noDeliveries: "Teslimat yok", stats: "Istatistikler", totalDeliveries: "Toplam", successCount: "Basarili", failureCount: "Basarisiz", responseTime: "{{ms}}ms", statusCode: "Durum {{code}}" },
+        tour: {
+        back: 'Geri',
+        next: 'İleri',
+        skip: 'Atla',
+        finish: 'Hadi başlayalım',
+        complete: 'Hoş geldiniz! ParkHub\'ınız kullanıma hazır.',
+        privacy: {
+          title: 'Verileriniz konusunda tam şeffaflık',
+          intro: 'Başlamadan önce — verilerinizi nasıl işlediğimizi görün. Gizli madde yok, küçük puntolara gömülü opt-out\'lar yok.',
+          self: {
+            title: 'Self-hosted — verileriniz sizde kalır',
+            body: 'ParkHub kendi altyapınızda çalışır. Rezervasyonlarınıza, araçlarınıza veya kullanıcı verilerinize erişimimiz yoktur — ne canlı olarak ne de yedeklerde.',
+          },
+          encryption: {
+            title: 'Varsayılan olarak şifreleme',
+            body: 'Tüm bağlantılar TLS 1.3 ile. Parolalar Argon2 hash\'leri olarak saklanır. Session token\'ları aile rotasyonu ile birlikte, çoklu replika kurulumları için opsiyonel Redis revocation.',
+          },
+          gdpr: {
+            title: 'İlk günden itibaren GDPR uyumlu',
+            body: 'Erişim hakkı (Art. 15), silme hakkı (Art. 17), veri taşınabilirliği (Art. 20) self-service endpoint\'ler olarak. Her veri erişimi için audit log. Künye ve gizlilik politikası sayfaları entegre.',
+          },
+          minimization: {
+            title: 'Veri minimizasyonu',
+            body: 'Sadece otopark işletimi için gerekli olanlar: ad, plaka, rezervasyon saati. Takip çerezi yok, üçüncü taraf analitik yok, reklam SDK\'sı yok.',
+          },
+        },
+        features: {
+          title: 'İhtiyacınız olan özellikleri seçin',
+          intro: 'Her modül kapatılabilir. Devre dışı bırakılan özellikler navigasyondan kaybolur ve hiç kaynak tüketmez. Bunu istediğiniz zaman Ayarlar\'dan değiştirebilirsiniz.',
+        },
+        trust: {
+          title: 'ParkHub\'a neden güvenebilirsiniz',
+          intro: 'ParkHub açık şekilde geliştirilir. Her kod satırı, her build, her denetim incelenebilir. Pazarlama vaatleri yok — işte içerik.',
+          openBadge: 'Open by default',
+          openBody: 'Kaynak kodu GitHub\'da, güvenlik denetimleri kamuya açık, vulnerability disclosure politikası aktif. Ekibinize sorun — ya da doğrudan bize.',
+        },
+      },
   },
 };

--- a/parkhub-web/src/i18n/locales/zh.ts
+++ b/parkhub-web/src/i18n/locales/zh.ts
@@ -89,5 +89,42 @@ export default {
     guestBooking: { title: '访客通行证', subtitle: '创建和管理访客停车通行证', create: '新建通行证', existing: '访客通行证', empty: '暂无访客通行证', formTitle: '创建访客通行证', guestName: '访客姓名', guestEmail: '访客邮箱', lot: '停车场', slot: '车位', selectLot: '选择停车场', selectSlot: '选择车位', startTime: '开始时间', endTime: '结束时间', creating: '创建中...', created: '通行证已创建', cancelled: '通行证已取消', cancel: '取消', passCreated: '通行证已创建', shareInstructions: '将此通行证分享给您的访客', dateRange: '日期时间', code: '访问码', codeCopied: '已复制访问码', share: '分享', shareTitle: '访客停车通行证', shareText: '{{name}}的停车通行证。访问码：{{code}}', linkCopied: '链接已复制', requiredFields: '请填写所有必填项', status: { active: '有效', expired: '已过期', cancelled: '已取消' } },
     swap: { title: '交换请求', subtitle: '请求和管理车位交换', create: '新建交换', createTitle: '创建交换请求', empty: '暂无交换请求', emptyHint: '创建交换请求与同事交换车位', yourSlot: '您的车位', theirSlot: '对方车位', yourBooking: '您的预订', selectBooking: '选择预订', targetBookingId: '目标预订ID', targetPlaceholder: '输入要交换的预订ID', messageLabel: '留言', messagePlaceholder: '可选留言', send: '发送', created: '请求已发送', accepted: '请求已接受', declined: '请求已拒绝', accept: '接受', decline: '拒绝', status: { pending: '待处理', accepted: '已接受', declined: '已拒绝' } },
     webhookDashboard: { title: "Webhook投递", subtitle: "投递性能监控", help: "追踪历史记录、成功率、响应时间，重放失败的投递。", helpLabel: "帮助", deliveryTimeline: "时间线", successRate: "成功率", avgResponseTime: "平均响应时间", topErrors: "常见错误", replay: "重放", replaying: "重放中...", replayed: "已重放", replayFailed: "失败", noDeliveries: "暂无投递", stats: "统计", totalDeliveries: "总计", successCount: "成功", failureCount: "失败", responseTime: "{{ms}}ms", statusCode: "状态 {{code}}" },
+        tour: {
+        back: '返回',
+        next: '下一步',
+        skip: '跳过',
+        finish: '开始使用',
+        complete: '欢迎！您的 ParkHub 已准备就绪。',
+        privacy: {
+          title: '您的数据，完全透明',
+          intro: '开始之前 — 先了解我们如何处理您的数据。没有隐藏条款，也没有埋在细则里的选择退出。',
+          self: {
+            title: '自托管 — 您的数据始终在您手中',
+            body: 'ParkHub 运行在您自己的基础设施上。我们无法访问您的预订、车辆或用户数据 — 无论是实时数据还是备份。',
+          },
+          encryption: {
+            title: 'Encryption by default',
+            body: '所有连接均采用 TLS 1.3。密码以 Argon2 哈希形式存储。Session tokens 支持家族轮换，多副本部署可选 Redis 撤销机制。',
+          },
+          gdpr: {
+            title: '从第一天起即符合 GDPR',
+            body: '访问权（Art. 15）、删除权（Art. 17）、数据可携带权（Art. 20）均作为自助式端点提供。每一次数据访问都有审计日志。网站信息和隐私政策页面已内置。',
+          },
+          minimization: {
+            title: '数据最小化',
+            body: '仅收集停车业务所需的信息：姓名、车牌号、预订时间。无追踪 Cookie，无第三方分析，无广告 SDK。',
+          },
+        },
+        features: {
+          title: '选择您需要的功能',
+          intro: '每个模块都可以关闭。已停用的功能会从导航中消失，也不会占用任何资源。您可以随时在设置中更改。',
+        },
+        trust: {
+          title: '为什么您可以信任 ParkHub',
+          intro: 'ParkHub 在公开环境中开发。每一行代码、每一次构建、每一次审计都可供查看。没有营销口号 — 这里只讲实质。',
+          openBadge: 'Open by default',
+          openBody: '源代码托管在 GitHub，安全审计公开，漏洞披露政策持续有效。请向您的团队求证 — 或直接联系我们。',
+        },
+      },
   },
 };


### PR DESCRIPTION
Follow-up to the v5 foundation (PR #326). The `/tour` onboarding shipped with hardcoded German defaults; every non-DE browser hit fallback text.

## Changes

- Rename i18n keys `onboarding.*` → `tour.*` in OnboardingTour.tsx. Avoids collision with the pre-existing `onboarding.*` namespace (first-login password/use-case/org flow).
- Translate 21 keys into all 10 locales: en, de, fr, es, it, pt, tr, pl, ja, zh.
- Tone kept warm and transparent; technical terms (TLS 1.3, Argon2, GDPR/RGPD/RODO with Art. 15/17/20, Session Tokens, Multi-Replica) consistent across languages.

## Tests

2160/2160 pass locally — i18n key validator confirms no missing translations on any locale.