### PR TITLE
sync(tests+a11y): cherry-pick Gitea fixes for parity with parkhub-rust

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,7 +22,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        if (config('parkhub.demo_mode')) {
+        if (config('parkhub.demo_mode') || env('DEMO_MODE') === 'true') {
             $this->call(ProductionSimulationSeeder::class);
 
             return;

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -131,6 +131,19 @@ for (const viewport of VIEWPORTS) {
           await page
             .waitForLoadState('networkidle', { timeout: 10_000 })
             .catch(() => { /* some pages stream long-poll — fall through */ });
+          // Hard-wait past the "Loading ParkHub" splash. Without this the
+          // very first paint can land in the screenshot and cause a bogus
+          // diff against the real UI baseline.
+          await page
+            .waitForFunction(
+              () => !/^\s*P?\s*$/.test(document.body?.textContent ?? '')
+                && !/Loading ParkHub/i.test(document.body?.textContent ?? ''),
+              null,
+              { timeout: 10_000 },
+            )
+            .catch(() => {
+              /* some static pages (e.g. /login) may settle instantly — fall through */
+            });
           await page.waitForTimeout(800);
 
           await expect(page).toHaveScreenshot(


### PR DESCRIPTION
## Summary

Syncs test-stability + seed fixes from Gitea `origin/main` to GitHub `main` so parkhub-php's E2E suite matches the discipline already shipped in parkhub-rust's sibling sync.

Cherry-picked from Gitea (in order):
- `8d7cd74` fix(seed): DEMO_MODE routes to ProductionSimulationSeeder + admin password fallback — reduced to a single-line change since the admin-password fallback already landed via PR #302.
- `4fd72ea` test(e2e): wait for React hydration past "Loading ParkHub" splash + token refresh bookkeeping — only `e2e/visual.spec.ts` remained; the other six files already contain the hydration waits from PR #302.
- `102979a` fix(a11y): associate labels with logo + timezone inputs on /setup — already present on `main` via PR #302, skipped (empty cherry-pick).

**Skipped on purpose** (pre-v5 baselines, would fight the v5 design system):
- `6d6f964` test(visual): expand regression coverage from 7 → 20 surfaces
- `6eceb18` test(visual): refresh baselines against fresh ProductionSimulationSeeder

## Diff

```
 database/seeders/DatabaseSeeder.php |  2 +-
 e2e/visual.spec.ts                  | 13 +++++++++++++
 2 files changed, 14 insertions(+), 1 deletion(-)
```

`DatabaseSeeder.php`: `config('parkhub.demo_mode')` is now OR-ed with `env('DEMO_MODE') === 'true'` as a belt-and-braces fallback for config-cache races. `visual.spec.ts`: hard-wait past the "Loading ParkHub" splash before screenshotting so reruns stop diffing the placeholder.

## Test plan

- [ ] CI green on nash87/parkhub-php (lint, phpunit, Playwright)
- [ ] No visual-regression drift vs current v5 baselines
- [ ] `DEMO_MODE=true php artisan migrate:fresh --seed --force` yields the full simulation fleet