### PR TITLE
feat(v5): Wave 2 — port Buchen/Kalender/Karte/Profil main screens

### DIFF
--- a/parkhub-web/src/design-v5/App.tsx
+++ b/parkhub-web/src/design-v5/App.tsx
@@ -9,8 +9,12 @@ import { V5AIPanel } from './AIPanel';
 import { breadcrumbFor, byId, type ScreenId } from './nav';
 import { DashboardV5 } from './screens/Dashboard';
 import { BuchungenV5 } from './screens/Buchungen';
+import { BuchenV5 } from './screens/Buchen';
 import { FahrzeugeV5 } from './screens/Fahrzeuge';
+import { KalenderV5 } from './screens/Kalender';
+import { KarteV5 } from './screens/Karte';
 import { CreditsV5 } from './screens/Credits';
+import { ProfilV5 } from './screens/Profil';
 import { PlaceholderV5 } from './screens/Placeholder';
 
 import './fonts';
@@ -24,8 +28,12 @@ import './tokens.css';
 const SCREENS: Partial<Record<ScreenId, ComponentType<{ navigate: (id: ScreenId) => void }>>> = {
   dashboard: DashboardV5,
   buchungen: BuchungenV5,
+  buchen: BuchenV5,
   fahrzeuge: FahrzeugeV5,
+  kalender: KalenderV5,
+  karte: KarteV5,
   credits: CreditsV5,
+  profil: ProfilV5,
 };
 
 const STORAGE_KEY = 'ph-v5-screen';

--- a/parkhub-web/src/design-v5/screens/Buchen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetLots = vi.fn();
+const mockGetLotSlots = vi.fn();
+const mockGetVehicles = vi.fn();
+const mockCreateBooking = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getLots: (...a: unknown[]) => mockGetLots(...a),
+    getLotSlots: (...a: unknown[]) => mockGetLotSlots(...a),
+    getVehicles: (...a: unknown[]) => mockGetVehicles(...a),
+    createBooking: (...a: unknown[]) => mockCreateBooking(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { BuchenV5 } from './Buchen';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <BuchenV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const LOT_OPEN = {
+  id: 'lot-1',
+  name: 'Parkhaus Nord',
+  address: 'Hauptstr. 10',
+  total_slots: 10,
+  available_slots: 6,
+  status: 'open',
+  hourly_rate: 2.5,
+  currency: '€',
+};
+
+const LOT_FULL = {
+  id: 'lot-2',
+  name: 'Parkhaus Süd',
+  total_slots: 5,
+  available_slots: 0,
+  status: 'open',
+};
+
+const LOT_CLOSED = {
+  id: 'lot-3',
+  name: 'Parkhaus West',
+  total_slots: 5,
+  available_slots: 5,
+  status: 'closed',
+};
+
+const SLOT_A = { id: 's-1', lot_id: 'lot-1', slot_number: 'A01', status: 'available' };
+const SLOT_B = { id: 's-2', lot_id: 'lot-1', slot_number: 'A02', status: 'available' };
+const SLOT_OCCUPIED = { id: 's-3', lot_id: 'lot-1', slot_number: 'A03', status: 'occupied' };
+
+describe('BuchenV5', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetVehicles.mockResolvedValue({ success: true, data: [] });
+  });
+
+  it('renders empty state when no lots are open', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_CLOSED] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine offenen Stellplätze')).toBeInTheDocument());
+  });
+
+  it('renders error state when getLots rejects', async () => {
+    mockGetLots.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders open lots as selectable cards', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN, LOT_FULL, LOT_CLOSED] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    // Closed lot filtered out
+    expect(screen.queryByText('Parkhaus West')).not.toBeInTheDocument();
+    // Full lot shown with "Voll" badge
+    expect(screen.getByText('Voll')).toBeInTheDocument();
+    const cards = screen.getAllByTestId('buchen-lot-card');
+    expect(cards).toHaveLength(2);
+  });
+
+  it('advances to step 2 after lot click and shows slot grid', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
+    mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A, SLOT_B, SLOT_OCCUPIED] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-lot-card'));
+    await waitFor(() => expect(screen.getByText('Stellplatz wählen')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByTestId('buchen-slot')).toHaveLength(3));
+    // Occupied slot is disabled
+    const occupiedBtn = screen.getByLabelText(/A03.*belegt/);
+    expect(occupiedBtn).toBeDisabled();
+  });
+
+  it('confirms booking on step 3 and invokes createBooking + success toast', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
+    mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A, SLOT_B] });
+    mockCreateBooking.mockResolvedValue({ success: true, data: { id: 'new-b-1' } });
+    const navigate = vi.fn();
+    renderScreen(navigate);
+
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-lot-card'));
+    await waitFor(() => expect(screen.getAllByTestId('buchen-slot').length).toBeGreaterThan(0));
+    fireEvent.click(screen.getAllByTestId('buchen-slot')[0]);
+    fireEvent.click(screen.getByRole('button', { name: /Weiter/ }));
+
+    await waitFor(() => expect(screen.getByTestId('buchen-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-confirm'));
+
+    await waitFor(() => {
+      expect(mockCreateBooking).toHaveBeenCalledTimes(1);
+      expect(mockToast).toHaveBeenCalledWith('Buchung bestätigt', 'success');
+      expect(navigate).toHaveBeenCalledWith('buchungen');
+    });
+    const payload = mockCreateBooking.mock.calls[0][0];
+    expect(payload.lot_id).toBe('lot-1');
+    expect(payload.slot_id).toBe('s-1');
+  });
+
+  it('emits error toast when createBooking rejects', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
+    mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A] });
+    mockCreateBooking.mockRejectedValue(new Error('boom'));
+    renderScreen();
+
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-lot-card'));
+    await waitFor(() => expect(screen.getByTestId('buchen-slot')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-slot'));
+    fireEvent.click(screen.getByRole('button', { name: /Weiter/ }));
+    await waitFor(() => expect(screen.getByTestId('buchen-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-confirm'));
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('Buchung fehlgeschlagen', 'error'));
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Buchen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.tsx
@@ -1,0 +1,661 @@
+import { useMemo, useState, type CSSProperties, type ReactNode } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, SectionLabel, V5NamedIcon } from '../primitives';
+import { useV5Toast } from '../Toast';
+import {
+  api,
+  type ParkingLot,
+  type ParkingSlot,
+  type Vehicle,
+  type CreateBookingPayload,
+} from '../../api/client';
+import type { ScreenId } from '../nav';
+
+type Step = 1 | 2 | 3;
+
+const DURATIONS: { label: string; hours: number }[] = [
+  { label: '1h', hours: 1 },
+  { label: '2h', hours: 2 },
+  { label: '4h', hours: 4 },
+  { label: '8h', hours: 8 },
+];
+
+const inputStyle: CSSProperties = {
+  padding: '8px 11px',
+  borderRadius: 9,
+  background: 'var(--v5-sur2)',
+  border: '1px solid var(--v5-bor)',
+  color: 'var(--v5-txt)',
+  fontSize: 12,
+  width: '100%',
+  outline: 'none',
+  boxSizing: 'border-box',
+  fontFamily: 'inherit',
+};
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <label style={{ fontSize: 11, fontWeight: 500, color: 'var(--v5-mut)' }}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function defaultStart(): string {
+  const now = new Date();
+  now.setMinutes(0, 0, 0);
+  now.setHours(now.getHours() + 1);
+  // datetime-local expects local-zone ISO (no TZ suffix). Build manually.
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
+}
+
+function formatDateTime(d: Date): string {
+  return d.toLocaleString('de-DE', {
+    weekday: 'short', day: '2-digit', month: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function formatTime(d: Date): string {
+  return d.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
+
+export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+
+  const [step, setStep] = useState<Step>(1);
+  const [selectedLot, setSelectedLot] = useState<ParkingLot | null>(null);
+  const [selectedSlot, setSelectedSlot] = useState<ParkingSlot | null>(null);
+  const [selectedVehicle, setSelectedVehicle] = useState<string>('');
+  const [startDate, setStartDate] = useState<string>(defaultStart);
+  const [duration, setDuration] = useState<number>(2);
+
+  const {
+    data: lotsResp,
+    isLoading: lotsLoading,
+    isError: lotsError,
+  } = useQuery({
+    queryKey: ['buchen-lots'],
+    queryFn: async () => {
+      const res = await api.getLots();
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const { data: vehiclesResp } = useQuery({
+    queryKey: ['buchen-vehicles'],
+    queryFn: async () => {
+      const res = await api.getVehicles();
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const lots = useMemo(() => (lotsResp ?? []).filter((l) => l.status === 'open'), [lotsResp]);
+  const vehicles: Vehicle[] = vehiclesResp ?? [];
+
+  const { data: slotsResp, isLoading: slotsLoading } = useQuery({
+    queryKey: ['buchen-slots', selectedLot?.id],
+    enabled: !!selectedLot,
+    queryFn: async () => {
+      const res = await api.getLotSlots(selectedLot!.id);
+      return res.data ?? [];
+    },
+    staleTime: 15_000,
+  });
+  const slots = slotsResp ?? [];
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateBookingPayload) => api.createBooking(payload),
+    onSuccess: (res) => {
+      if (res.success) {
+        qc.invalidateQueries({ queryKey: ['buchungen'] });
+        toast('Buchung bestätigt', 'success');
+        navigate('buchungen');
+      } else {
+        const msg = res.error?.code === 'INSUFFICIENT_CREDITS'
+          ? 'Nicht genug Credits'
+          : res.error?.message || 'Buchung fehlgeschlagen';
+        toast(msg, 'error');
+      }
+    },
+    onError: () => toast('Buchung fehlgeschlagen', 'error'),
+  });
+
+  if (lotsLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto' }}>
+        <div style={{ height: 32, width: 220, borderRadius: 8, background: 'var(--v5-sur2)', marginBottom: 14, animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 10 }}>
+          {[0, 1, 2].map((i) => (
+            <div key={i} style={{ height: 120, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (lotsError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Stellplätze konnten nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  const start = new Date(startDate);
+  const end = new Date(start.getTime() + duration * 60 * 60 * 1000);
+  const rate = selectedLot?.hourly_rate;
+  const currency = selectedLot?.currency || '€';
+  const estimated = rate != null ? (rate * duration).toFixed(2) : null;
+
+  function handleSelectLot(lot: ParkingLot) {
+    setSelectedLot(lot);
+    setSelectedSlot(null);
+    setStep(2);
+  }
+
+  function handleConfirm() {
+    if (!selectedLot || !selectedSlot) return;
+    createMutation.mutate({
+      lot_id: selectedLot.id,
+      slot_id: selectedSlot.id,
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      vehicle_id: selectedVehicle || undefined,
+    });
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Platz buchen</span>
+          <Badge variant="gray">Schritt {step}/3</Badge>
+        </div>
+        {step > 1 && (
+          <button
+            type="button"
+            onClick={() => setStep((s) => (s === 3 ? 2 : 1) as Step)}
+            style={{ padding: '6px 12px', borderRadius: 9, background: 'transparent', border: '1px solid var(--v5-bor)', color: 'var(--v5-mut)', fontSize: 11, cursor: 'pointer', fontWeight: 500 }}
+          >
+            ← Zurück
+          </button>
+        )}
+      </div>
+
+      <div className="v5-ani" role="list" aria-label="Fortschritt" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 6, animationDelay: '0.06s' }}>
+        {([1, 2, 3] as const).map((s) => {
+          const active = s === step;
+          const done = s < step;
+          return (
+            <div
+              key={s}
+              role="listitem"
+              aria-current={active ? 'step' : undefined}
+              style={{
+                padding: '8px 12px',
+                borderRadius: 10,
+                border: `1.5px solid ${active || done ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                background: active ? 'var(--v5-acc-muted)' : done ? 'color-mix(in oklch, var(--v5-acc) 6%, transparent)' : 'transparent',
+                color: active || done ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                fontSize: 11,
+                fontWeight: 500,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              <span className="v5-mono" style={{ fontSize: 10 }}>0{s}</span>
+              <span>
+                {s === 1 ? 'Stellplatz' : s === 2 ? 'Zeit & Platz' : 'Bestätigen'}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {step === 1 && (
+        <StepLot lots={lots} onSelect={handleSelectLot} />
+      )}
+      {step === 2 && selectedLot && (
+        <StepSlot
+          lot={selectedLot}
+          slots={slots}
+          loading={slotsLoading}
+          selectedSlot={selectedSlot}
+          onSelectSlot={setSelectedSlot}
+          startDate={startDate}
+          onStartDateChange={setStartDate}
+          duration={duration}
+          onDurationChange={setDuration}
+          vehicles={vehicles}
+          selectedVehicle={selectedVehicle}
+          onVehicleChange={setSelectedVehicle}
+          onContinue={() => selectedSlot && setStep(3)}
+          currency={currency}
+          estimated={estimated}
+        />
+      )}
+      {step === 3 && selectedLot && selectedSlot && (
+        <StepConfirm
+          lot={selectedLot}
+          slot={selectedSlot}
+          start={start}
+          end={end}
+          duration={duration}
+          estimated={estimated}
+          currency={currency}
+          vehicle={vehicles.find((v) => v.id === selectedVehicle)}
+          submitting={createMutation.isPending}
+          onConfirm={handleConfirm}
+        />
+      )}
+    </div>
+  );
+}
+
+function StepLot({
+  lots,
+  onSelect,
+}: {
+  lots: ParkingLot[];
+  onSelect: (lot: ParkingLot) => void;
+}) {
+  if (lots.length === 0) {
+    return (
+      <Card className="v5-ani" style={{ padding: 36, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, animationDelay: '0.12s' }}>
+        <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <V5NamedIcon name="map" size={20} color="var(--v5-acc)" />
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Keine offenen Stellplätze</div>
+          <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>Derzeit stehen keine Parkflächen zur Verfügung.</div>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div
+      className="v5-ani"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+        gap: 10,
+        animationDelay: '0.12s',
+      }}
+    >
+      {lots.map((lot, i) => {
+        const occupancy = lot.total_slots > 0 ? Math.round(((lot.total_slots - lot.available_slots) / lot.total_slots) * 100) : 0;
+        const full = lot.available_slots === 0;
+        return (
+          <button
+            key={lot.id}
+            type="button"
+            data-testid="buchen-lot-card"
+            disabled={full}
+            onClick={() => !full && onSelect(lot)}
+            className="v5-lift v5-ani"
+            style={{
+              background: 'var(--v5-sur)',
+              border: '1px solid var(--v5-bor)',
+              borderRadius: 14,
+              boxShadow: 'var(--v5-shadow-card)',
+              padding: 16,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 10,
+              textAlign: 'left',
+              cursor: full ? 'not-allowed' : 'pointer',
+              opacity: full ? 0.55 : 1,
+              animationDelay: `${i * 0.05}s`,
+              fontFamily: 'inherit',
+              color: 'inherit',
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--v5-txt)' }}>{lot.name}</div>
+                {lot.address && (
+                  <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 2, display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <V5NamedIcon name="map" size={10} />
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{lot.address}</span>
+                  </div>
+                )}
+              </div>
+              {full ? <Badge variant="error">Voll</Badge> : <Badge variant="success" dot>Offen</Badge>}
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+              <div>
+                <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.2, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Verfügbar</div>
+                <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-acc)' }}>
+                  <NumberFlow value={lot.available_slots} /> / {lot.total_slots}
+                </div>
+              </div>
+              <div style={{ textAlign: 'right' }}>
+                <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.2, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Belegung</div>
+                <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--v5-txt)' }}>{occupancy}%</div>
+              </div>
+            </div>
+            <div style={{ height: 4, background: 'var(--v5-sur2)', borderRadius: 4, overflow: 'hidden' }}>
+              <div style={{ height: '100%', width: `${Math.max(4, 100 - occupancy)}%`, background: 'var(--v5-acc)', borderRadius: 4, transition: 'width 0.4s ease' }} />
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 11, color: 'var(--v5-mut)' }}>
+              <span>
+                {lot.hourly_rate != null ? `${lot.currency || '€'}${lot.hourly_rate.toFixed(2)}/h` : 'Preis auf Anfrage'}
+              </span>
+              <span style={{ color: 'var(--v5-acc)', fontWeight: 500 }}>Auswählen →</span>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function StepSlot({
+  lot,
+  slots,
+  loading,
+  selectedSlot,
+  onSelectSlot,
+  startDate,
+  onStartDateChange,
+  duration,
+  onDurationChange,
+  vehicles,
+  selectedVehicle,
+  onVehicleChange,
+  onContinue,
+  currency,
+  estimated,
+}: {
+  lot: ParkingLot;
+  slots: ParkingSlot[];
+  loading: boolean;
+  selectedSlot: ParkingSlot | null;
+  onSelectSlot: (s: ParkingSlot) => void;
+  startDate: string;
+  onStartDateChange: (v: string) => void;
+  duration: number;
+  onDurationChange: (v: number) => void;
+  vehicles: Vehicle[];
+  selectedVehicle: string;
+  onVehicleChange: (v: string) => void;
+  onContinue: () => void;
+  currency: string;
+  estimated: string | null;
+}) {
+  const available = slots.filter((s) => s.status === 'available');
+
+  return (
+    <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 280px', gap: 12, animationDelay: '0.12s' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <Card style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <SectionLabel>{lot.name}</SectionLabel>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <Field label="Startzeit">
+              <input
+                id="buchen-start"
+                type="datetime-local"
+                value={startDate}
+                onChange={(e) => onStartDateChange(e.target.value)}
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="Dauer">
+              <div role="group" aria-label="Dauer" style={{ display: 'flex', gap: 5 }}>
+                {DURATIONS.map((d) => {
+                  const active = duration === d.hours;
+                  return (
+                    <button
+                      key={d.hours}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => onDurationChange(d.hours)}
+                      style={{
+                        flex: 1,
+                        padding: '7px 0',
+                        borderRadius: 8,
+                        fontSize: 11,
+                        fontWeight: 500,
+                        cursor: 'pointer',
+                        border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                        background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                        color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                        transition: 'all 0.15s',
+                      }}
+                    >
+                      {d.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </Field>
+          </div>
+          {vehicles.length > 0 && (
+            <Field label="Fahrzeug">
+              <select
+                id="buchen-vehicle"
+                value={selectedVehicle}
+                onChange={(e) => onVehicleChange(e.target.value)}
+                style={inputStyle}
+              >
+                <option value="">— Kein Fahrzeug —</option>
+                {vehicles.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.plate}{v.make ? ` · ${v.make}${v.model ? ` ${v.model}` : ''}` : ''}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          )}
+        </Card>
+
+        <Card style={{ padding: 16 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+            <SectionLabel>Stellplatz wählen</SectionLabel>
+            <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>
+              {available.length} von {slots.length} verfügbar
+            </span>
+          </div>
+          {loading ? (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(64px, 1fr))', gap: 6 }}>
+              {Array.from({ length: 12 }, (_, i) => (
+                <div key={i} style={{ height: 44, borderRadius: 8, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.03}s` }} />
+              ))}
+            </div>
+          ) : available.length === 0 ? (
+            <div style={{ padding: 24, textAlign: 'center', fontSize: 12, color: 'var(--v5-mut)' }}>
+              Keine freien Plätze in diesem Zeitfenster.
+            </div>
+          ) : (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(64px, 1fr))', gap: 6 }}>
+              {slots.map((s) => {
+                const isAvail = s.status === 'available';
+                const isSelected = selectedSlot?.id === s.id;
+                return (
+                  <button
+                    key={s.id}
+                    type="button"
+                    disabled={!isAvail}
+                    aria-pressed={isSelected}
+                    aria-label={`Stellplatz ${s.slot_number}${isAvail ? '' : ' (belegt)'}`}
+                    onClick={() => isAvail && onSelectSlot(s)}
+                    data-testid="buchen-slot"
+                    style={{
+                      padding: '10px 0',
+                      borderRadius: 8,
+                      fontSize: 12,
+                      fontWeight: 600,
+                      cursor: isAvail ? 'pointer' : 'not-allowed',
+                      border: `1.5px solid ${isSelected ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                      background: isSelected ? 'var(--v5-acc)' : isAvail ? 'var(--v5-sur)' : 'var(--v5-sur2)',
+                      color: isSelected ? 'var(--v5-accent-fg)' : isAvail ? 'var(--v5-txt)' : 'var(--v5-mut)',
+                      opacity: isAvail ? 1 : 0.55,
+                      transition: 'all 0.12s',
+                    }}
+                  >
+                    {s.slot_number}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </Card>
+      </div>
+
+      <Card style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10, alignSelf: 'start' }}>
+        <SectionLabel>Zusammenfassung</SectionLabel>
+        <SummaryRow label="Stellplatz" value={lot.name} />
+        <SummaryRow label="Platz" value={selectedSlot?.slot_number ?? '—'} />
+        <SummaryRow label="Von" value={formatDateTime(new Date(startDate))} />
+        <SummaryRow label="Dauer" value={`${duration}h`} />
+        <SummaryRow
+          label="Tarif"
+          value={lot.hourly_rate != null ? `${currency}${lot.hourly_rate.toFixed(2)}/h` : '—'}
+        />
+        <SummaryRow
+          label="Kosten"
+          value={estimated ? `${currency}${estimated}` : '—'}
+          bold
+        />
+        <button
+          type="button"
+          disabled={!selectedSlot}
+          onClick={onContinue}
+          style={{
+            padding: '10px 14px',
+            borderRadius: 10,
+            background: 'var(--v5-acc)',
+            color: 'var(--v5-accent-fg)',
+            border: 'none',
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: selectedSlot ? 'pointer' : 'not-allowed',
+            opacity: selectedSlot ? 1 : 0.5,
+            marginTop: 4,
+          }}
+        >
+          Weiter →
+        </button>
+      </Card>
+    </div>
+  );
+}
+
+function StepConfirm({
+  lot,
+  slot,
+  start,
+  end,
+  duration,
+  estimated,
+  currency,
+  vehicle,
+  submitting,
+  onConfirm,
+}: {
+  lot: ParkingLot;
+  slot: ParkingSlot;
+  start: Date;
+  end: Date;
+  duration: number;
+  estimated: string | null;
+  currency: string;
+  vehicle?: Vehicle;
+  submitting: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <Card className="v5-ani" style={{ padding: 22, display: 'flex', flexDirection: 'column', gap: 14, animationDelay: '0.12s' }}>
+      <div>
+        <SectionLabel>Bestätigung</SectionLabel>
+        <div style={{ fontSize: 18, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}>
+          Bereit zum Buchen
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>
+          Überprüfen Sie alle Details vor der Bestätigung.
+        </div>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+        <SummaryTile label="Stellplatz" value={lot.name} />
+        <SummaryTile label="Platz" value={slot.slot_number} />
+        <SummaryTile label="Von" value={formatDateTime(start)} />
+        <SummaryTile label="Bis" value={formatTime(end)} />
+        <SummaryTile label="Dauer" value={`${duration}h`} />
+        <SummaryTile label="Fahrzeug" value={vehicle ? vehicle.plate : '—'} />
+        <SummaryTile
+          label="Tarif"
+          value={lot.hourly_rate != null ? `${currency}${lot.hourly_rate.toFixed(2)}/h` : '—'}
+        />
+        <SummaryTile
+          label="Geschätzte Kosten"
+          value={estimated ? `${currency}${estimated}` : '—'}
+          emphasis
+        />
+      </div>
+      <button
+        type="button"
+        disabled={submitting}
+        onClick={onConfirm}
+        data-testid="buchen-confirm"
+        style={{
+          padding: '11px 16px',
+          borderRadius: 10,
+          background: 'var(--v5-acc)',
+          color: 'var(--v5-accent-fg)',
+          border: 'none',
+          fontSize: 13,
+          fontWeight: 600,
+          cursor: submitting ? 'default' : 'pointer',
+          opacity: submitting ? 0.7 : 1,
+          marginTop: 4,
+        }}
+      >
+        {submitting ? 'Bestätige …' : 'Buchung bestätigen'}
+      </button>
+    </Card>
+  );
+}
+
+function SummaryRow({ label, value, bold = false }: { label: string; value: string; bold?: boolean }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 12 }}>
+      <span style={{ color: 'var(--v5-mut)' }}>{label}</span>
+      <span style={{ color: 'var(--v5-txt)', fontWeight: bold ? 700 : 500 }}>{value}</span>
+    </div>
+  );
+}
+
+function SummaryTile({ label, value, emphasis = false }: { label: string; value: string; emphasis?: boolean }) {
+  return (
+    <div
+      style={{
+        padding: '10px 12px',
+        borderRadius: 10,
+        background: emphasis ? 'var(--v5-acc-muted)' : 'var(--v5-sur2)',
+        border: `1px solid ${emphasis ? 'color-mix(in oklch, var(--v5-acc) 30%, transparent)' : 'var(--v5-bor)'}`,
+      }}
+    >
+      <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.2, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 13, fontWeight: 600, color: emphasis ? 'var(--v5-acc)' : 'var(--v5-txt)', marginTop: 3 }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Kalender.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Kalender.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockCalendarEvents = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    calendarEvents: (...a: unknown[]) => mockCalendarEvents(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { KalenderV5 } from './Kalender';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <KalenderV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+// Build ISO strings for a known day in the current month so the rendered calendar
+// contains the event regardless of "today" drift.
+function makeEvents() {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  const targetDay = 15; // mid-month, always inside the visible month
+  const start = new Date(y, m, targetDay, 10, 0).toISOString();
+  const end = new Date(y, m, targetDay, 12, 0).toISOString();
+  return {
+    targetDay,
+    events: [
+      {
+        id: 'evt-1',
+        title: 'Parkhaus Nord',
+        start,
+        end,
+        type: 'booking' as const,
+        status: 'confirmed',
+        lot_name: 'Parkhaus Nord',
+      },
+      {
+        id: 'evt-2',
+        title: 'Urlaub',
+        start: new Date(y, m, 16, 0, 0).toISOString(),
+        end: new Date(y, m, 18, 23, 59).toISOString(),
+        type: 'absence' as const,
+        status: 'active',
+      },
+    ],
+  };
+}
+
+describe('KalenderV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty month with no events', async () => {
+    mockCalendarEvents.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Kalender')).toBeInTheDocument());
+    // Empty selection placeholder is shown
+    expect(screen.getByText(/Klicken Sie auf ein Datum/)).toBeInTheDocument();
+  });
+
+  it('renders error state on query failure', async () => {
+    mockCalendarEvents.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders booking + absence events and counts them in the header', async () => {
+    const { events } = makeEvents();
+    mockCalendarEvents.mockResolvedValue({ success: true, data: events });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    // Event title visible in the grid
+    expect(screen.getByText('Urlaub')).toBeInTheDocument();
+    // Summary stats (label + count)
+    expect(screen.getByText('Buchungen')).toBeInTheDocument();
+    expect(screen.getByText('Abwesenheit')).toBeInTheDocument();
+  });
+
+  it('shows selected-day detail card on click', async () => {
+    const { events, targetDay } = makeEvents();
+    mockCalendarEvents.mockResolvedValue({ success: true, data: events });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    const dayCells = screen.getAllByTestId('kalender-day');
+    // Find the cell whose day-number text matches targetDay (first match inside current month)
+    const targetCell = dayCells.find((c) => {
+      const spans = c.querySelectorAll('span');
+      return Array.from(spans).some((s) => s.textContent?.trim() === String(targetDay));
+    });
+    expect(targetCell).toBeTruthy();
+    fireEvent.click(targetCell!);
+    await waitFor(() => expect(screen.getAllByTestId('kalender-detail').length).toBeGreaterThan(0));
+    const detail = screen.getAllByTestId('kalender-detail')[0];
+    expect(within(detail).getByText('Buchung')).toBeInTheDocument();
+  });
+
+  it('navigates to buchen when the "Platz buchen" button is clicked', async () => {
+    mockCalendarEvents.mockResolvedValue({ success: true, data: [] });
+    const navigate = vi.fn();
+    renderScreen(navigate);
+    await waitFor(() => expect(screen.getByText('Platz buchen')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Platz buchen'));
+    expect(navigate).toHaveBeenCalledWith('buchen');
+  });
+
+  it('switches month when the next/prev buttons are pressed', async () => {
+    mockCalendarEvents.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByLabelText('Nächster Monat')).toBeInTheDocument());
+    const initialStart = mockCalendarEvents.mock.calls[0][0];
+    fireEvent.click(screen.getByLabelText('Nächster Monat'));
+    await waitFor(() => expect(mockCalendarEvents.mock.calls.length).toBeGreaterThan(1));
+    const nextStart = mockCalendarEvents.mock.calls[mockCalendarEvents.mock.calls.length - 1][0];
+    expect(nextStart).not.toBe(initialStart);
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Kalender.tsx
+++ b/parkhub-web/src/design-v5/screens/Kalender.tsx
@@ -1,0 +1,356 @@
+import { useMemo, useState } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery } from '@tanstack/react-query';
+import { Badge, Card, SectionLabel, V5NamedIcon } from '../primitives';
+import { api, type CalendarEvent } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const WEEKDAYS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+
+function isSameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function isSameMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+function formatDateKey(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case 'active':
+    case 'confirmed':
+      return 'var(--v5-ok)';
+    case 'pending':
+      return 'var(--v5-warn)';
+    case 'cancelled':
+      return 'var(--v5-err)';
+    case 'completed':
+      return 'var(--v5-acc)';
+    default:
+      return 'var(--v5-mut)';
+  }
+}
+
+export function KalenderV5({ navigate }: { navigate: (id: ScreenId) => void }) {
+  const [currentMonth, setCurrentMonth] = useState<Date>(() => {
+    const d = new Date();
+    d.setDate(1);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  });
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  const rangeStart = useMemo(() => {
+    const d = new Date(currentMonth);
+    d.setDate(1);
+    return formatDateKey(d);
+  }, [currentMonth]);
+
+  const rangeEnd = useMemo(() => {
+    const d = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
+    return formatDateKey(d);
+  }, [currentMonth]);
+
+  const { data: events = [], isLoading, isError } = useQuery({
+    queryKey: ['kalender', rangeStart, rangeEnd],
+    queryFn: async () => {
+      const res = await api.calendarEvents(rangeStart, rangeEnd);
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const days = useMemo(() => {
+    const year = currentMonth.getFullYear();
+    const month = currentMonth.getMonth();
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+    // Monday-start
+    const startDow = firstDay.getDay() === 0 ? 6 : firstDay.getDay() - 1;
+    const result: Date[] = [];
+    for (let i = 0; i < startDow; i++) {
+      result.push(new Date(year, month, 1 - startDow + i));
+    }
+    for (let d = 1; d <= lastDay.getDate(); d++) {
+      result.push(new Date(year, month, d));
+    }
+    while (result.length % 7 !== 0) {
+      result.push(new Date(year, month + 1, result.length - startDow - lastDay.getDate() + 1));
+    }
+    return result;
+  }, [currentMonth]);
+
+  const eventsByDay = useMemo(() => {
+    const map = new Map<string, CalendarEvent[]>();
+    for (const e of events) {
+      const key = formatDateKey(new Date(e.start));
+      const list = map.get(key);
+      if (list) list.push(e);
+      else map.set(key, [e]);
+    }
+    return map;
+  }, [events]);
+
+  const bookingCount = useMemo(() => events.filter((e) => e.type === 'booking').length, [events]);
+  const absenceCount = useMemo(() => events.filter((e) => e.type === 'absence').length, [events]);
+
+  const today = new Date();
+  const selectedEvents = selectedDate ? eventsByDay.get(formatDateKey(selectedDate)) ?? [] : [];
+  const monthLabel = currentMonth.toLocaleDateString('de-DE', { month: 'long', year: 'numeric' });
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ height: 32, width: 220, borderRadius: 8, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        <div style={{ height: 420, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Kalender konnte nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Kalender</span>
+          <Badge variant="gray">
+            <NumberFlow value={events.length} />
+          </Badge>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <button
+            type="button"
+            aria-label="Vorheriger Monat"
+            onClick={() => setCurrentMonth((d) => new Date(d.getFullYear(), d.getMonth() - 1, 1))}
+            style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transform: 'rotate(180deg)' }}
+          >
+            <V5NamedIcon name="chev" size={12} color="var(--v5-mut)" />
+          </button>
+          <div aria-live="polite" style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)', minWidth: 140, textAlign: 'center' }}>
+            {monthLabel}
+          </div>
+          <button
+            type="button"
+            aria-label="Nächster Monat"
+            onClick={() => setCurrentMonth((d) => new Date(d.getFullYear(), d.getMonth() + 1, 1))}
+            style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          >
+            <V5NamedIcon name="chev" size={12} color="var(--v5-mut)" />
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('buchen')}
+            className="v5-btn"
+            style={{ padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, marginLeft: 6 }}
+          >
+            <V5NamedIcon name="plus" size={12} />
+            Platz buchen
+          </button>
+        </div>
+      </div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, animationDelay: '0.06s' }}>
+        <SummaryStat label="Einträge" value={events.length} icon="cal" />
+        <SummaryStat label="Buchungen" value={bookingCount} icon="list" />
+        <SummaryStat label="Abwesenheit" value={absenceCount} icon="users" />
+      </div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 280px', gap: 12, animationDelay: '0.12s' }}>
+        <Card style={{ overflow: 'hidden', padding: 0 }}>
+          <div
+            role="grid"
+            aria-label={`Kalender ${monthLabel}`}
+            style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', borderBottom: '1px solid var(--v5-bor)' }}
+          >
+            {WEEKDAYS.map((label) => (
+              <div
+                key={label}
+                role="columnheader"
+                className="v5-mono"
+                style={{ padding: '10px 0', fontSize: 10, letterSpacing: 1.2, textTransform: 'uppercase', textAlign: 'center', color: 'var(--v5-mut)' }}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' }}>
+            {days.map((day, idx) => {
+              const inMonth = isSameMonth(day, currentMonth);
+              const isToday = isSameDay(day, today);
+              const selected = !!(selectedDate && isSameDay(day, selectedDate));
+              const dayEvents = eventsByDay.get(formatDateKey(day)) ?? [];
+              return (
+                <button
+                  key={idx}
+                  type="button"
+                  data-testid="kalender-day"
+                  aria-label={day.toLocaleDateString('de-DE', { weekday: 'long', day: 'numeric', month: 'long' })}
+                  aria-pressed={selected}
+                  onClick={() => setSelectedDate(day)}
+                  style={{
+                    minHeight: 82,
+                    padding: 6,
+                    background: selected ? 'var(--v5-acc-muted)' : 'transparent',
+                    border: 'none',
+                    borderRight: (idx + 1) % 7 === 0 ? 'none' : '1px solid var(--v5-bor)',
+                    borderBottom: idx < days.length - 7 ? '1px solid var(--v5-bor)' : 'none',
+                    textAlign: 'left',
+                    cursor: 'pointer',
+                    opacity: inMonth ? 1 : 0.4,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 4,
+                    fontFamily: 'inherit',
+                    color: 'inherit',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span
+                      className="v5-mono"
+                      style={{
+                        fontSize: 11,
+                        fontWeight: isToday ? 700 : 500,
+                        color: isToday ? 'var(--v5-accent-fg)' : selected ? 'var(--v5-acc)' : 'var(--v5-txt)',
+                        background: isToday ? 'var(--v5-acc)' : 'transparent',
+                        padding: isToday ? '2px 6px' : 0,
+                        borderRadius: isToday ? 999 : 0,
+                        minWidth: 18,
+                        textAlign: 'center',
+                      }}
+                    >
+                      {day.getDate()}
+                    </span>
+                    {dayEvents.length > 0 && (
+                      <span className="v5-mono" style={{ fontSize: 9, color: 'var(--v5-mut)' }}>
+                        {dayEvents.length}
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    {dayEvents.slice(0, 2).map((e) => (
+                      <div
+                        key={e.id}
+                        title={`${e.title} (${e.status})`}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 4,
+                          fontSize: 10,
+                          color: 'var(--v5-txt)',
+                          background: 'var(--v5-sur2)',
+                          borderRadius: 5,
+                          padding: '2px 5px',
+                        }}
+                      >
+                        <span style={{ width: 5, height: 5, borderRadius: '50%', background: statusColor(e.status), flexShrink: 0 }} />
+                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.title}</span>
+                      </div>
+                    ))}
+                    {dayEvents.length > 2 && (
+                      <div style={{ fontSize: 9, color: 'var(--v5-mut)' }}>+{dayEvents.length - 2}</div>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </Card>
+
+        <Card style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10, alignSelf: 'start' }}>
+          <SectionLabel>
+            {selectedDate
+              ? selectedDate.toLocaleDateString('de-DE', { weekday: 'long', day: 'numeric', month: 'long' })
+              : 'Tag wählen'}
+          </SectionLabel>
+          {selectedDate ? (
+            selectedEvents.length === 0 ? (
+              <div style={{ padding: 18, textAlign: 'center', color: 'var(--v5-mut)', fontSize: 12 }}>
+                Keine Einträge
+              </div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {selectedEvents.map((e) => (
+                  <div
+                    key={e.id}
+                    data-testid="kalender-detail"
+                    style={{
+                      padding: 10,
+                      borderRadius: 10,
+                      background: 'var(--v5-sur2)',
+                      border: '1px solid var(--v5-bor)',
+                      display: 'flex',
+                      gap: 8,
+                      alignItems: 'flex-start',
+                    }}
+                  >
+                    <span
+                      aria-hidden="true"
+                      style={{ width: 3, alignSelf: 'stretch', background: statusColor(e.status), borderRadius: 3 }}
+                    />
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {e.title}
+                      </div>
+                      <div style={{ fontSize: 10, color: 'var(--v5-mut)', marginTop: 2 }}>
+                        {new Date(e.start).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}
+                        {' – '}
+                        {new Date(e.end).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}
+                        {e.lot_name ? ` · ${e.lot_name}` : ''}
+                      </div>
+                      <div style={{ marginTop: 6, display: 'flex', gap: 4 }}>
+                        <Badge variant={e.type === 'booking' ? 'primary' : 'gray'}>
+                          {e.type === 'booking' ? 'Buchung' : 'Abwesenheit'}
+                        </Badge>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )
+          ) : (
+            <div style={{ padding: 18, textAlign: 'center', color: 'var(--v5-mut)', fontSize: 12 }}>
+              Klicken Sie auf ein Datum, um Einträge anzuzeigen.
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function SummaryStat({ label, value, icon }: { label: string; value: number; icon: 'cal' | 'list' | 'users' }) {
+  return (
+    <Card style={{ padding: '12px 14px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>
+            {label}
+          </div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}>
+            <NumberFlow value={value} />
+          </div>
+        </div>
+        <div style={{ width: 26, height: 26, borderRadius: 8, background: 'var(--v5-sur2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <V5NamedIcon name={icon} size={12} color="var(--v5-mut)" />
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Karte.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Karte.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockGetMapMarkers = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    getMapMarkers: (...a: unknown[]) => mockGetMapMarkers(...a),
+  },
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { KarteV5 } from './Karte';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <KarteV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const MARKER_NORD = {
+  id: 'lot-1',
+  name: 'Parkhaus Nord',
+  address: 'Hauptstr. 10',
+  latitude: 48.14,
+  longitude: 11.58,
+  available_slots: 40,
+  total_slots: 50,
+  status: 'open',
+  color: 'green' as const,
+};
+
+const MARKER_SUED = {
+  id: 'lot-2',
+  name: 'Parkhaus Süd',
+  address: 'Marienplatz 5',
+  latitude: 48.13,
+  longitude: 11.57,
+  available_slots: 2,
+  total_slots: 60,
+  status: 'open',
+  color: 'red' as const,
+};
+
+describe('KarteV5', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders empty state when there are no markers', async () => {
+    mockGetMapMarkers.mockResolvedValue({ success: true, data: [] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Keine Standorte')).toBeInTheDocument());
+  });
+
+  it('renders error state on query failure', async () => {
+    mockGetMapMarkers.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders marker pins and list rows with occupancy', async () => {
+    mockGetMapMarkers.mockResolvedValue({ success: true, data: [MARKER_NORD, MARKER_SUED] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('karte-marker')).toHaveLength(2));
+    expect(screen.getAllByTestId('karte-list-row')).toHaveLength(2);
+    // Default selected is the first marker
+    expect(screen.getAllByText('Parkhaus Nord').length).toBeGreaterThan(0);
+    expect(screen.getByText('Viel frei')).toBeInTheDocument();
+  });
+
+  it('updates the selected-lot card when a marker is clicked', async () => {
+    mockGetMapMarkers.mockResolvedValue({ success: true, data: [MARKER_NORD, MARKER_SUED] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('karte-marker')).toHaveLength(2));
+    fireEvent.click(screen.getAllByTestId('karte-marker')[1]);
+    await waitFor(() => expect(screen.getByText('Voll')).toBeInTheDocument());
+    // Active marker aria-pressed is true
+    expect(screen.getAllByTestId('karte-marker')[1]).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('navigates to buchen when the "Platz buchen" button is clicked', async () => {
+    mockGetMapMarkers.mockResolvedValue({ success: true, data: [MARKER_NORD] });
+    const navigate = vi.fn();
+    renderScreen(navigate);
+    await waitFor(() => expect(screen.getByText('Platz buchen')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Platz buchen'));
+    expect(navigate).toHaveBeenCalledWith('buchen');
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Karte.tsx
+++ b/parkhub-web/src/design-v5/screens/Karte.tsx
@@ -1,0 +1,293 @@
+import { useMemo, useState } from 'react';
+import NumberFlow from '@number-flow/react';
+import { useQuery } from '@tanstack/react-query';
+import { Badge, Card, SectionLabel, V5NamedIcon } from '../primitives';
+import { api, type LotMarker, type MarkerColor } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const MARKER_COLOR: Record<MarkerColor, string> = {
+  green: 'var(--v5-ok)',
+  yellow: 'var(--v5-warn)',
+  red: 'var(--v5-err)',
+  gray: 'var(--v5-mut)',
+};
+
+const COLOR_LABEL: Record<MarkerColor, string> = {
+  green: 'Viel frei',
+  yellow: 'Knapp',
+  red: 'Voll',
+  gray: 'Geschlossen',
+};
+
+const COLOR_VARIANT: Record<MarkerColor, 'success' | 'warning' | 'error' | 'gray'> = {
+  green: 'success',
+  yellow: 'warning',
+  red: 'error',
+  gray: 'gray',
+};
+
+export function KarteV5({ navigate }: { navigate: (id: ScreenId) => void }) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const { data: markers = [], isLoading, isError } = useQuery({
+    queryKey: ['karte'],
+    queryFn: async () => {
+      const res = await api.getMapMarkers();
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const totals = useMemo(() => {
+    const free = markers.reduce((sum, m) => sum + m.available_slots, 0);
+    const total = markers.reduce((sum, m) => sum + m.total_slots, 0);
+    const occupancy = total > 0 ? Math.round(((total - free) / total) * 100) : 0;
+    return { free, total, occupancy };
+  }, [markers]);
+
+  const selected = selectedId ? markers.find((m) => m.id === selectedId) ?? null : markers[0] ?? null;
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ height: 32, width: 220, borderRadius: 8, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 280px', gap: 12 }}>
+          <div style={{ height: 380, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+          <div style={{ height: 380, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite' }} />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Karte konnte nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (markers.length === 0) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 36, textAlign: 'center', maxWidth: 380, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+          <div style={{ width: 48, height: 48, borderRadius: 14, background: 'var(--v5-acc-muted)', border: '1.5px dashed color-mix(in oklch, var(--v5-acc) 50%, transparent)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <V5NamedIcon name="map" size={20} color="var(--v5-acc)" />
+          </div>
+          <div>
+            <div style={{ fontWeight: 600, color: 'var(--v5-txt)', fontSize: 13 }}>Keine Standorte</div>
+            <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>Es sind noch keine Parkplätze kartiert.</div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  // Compute lat/lng bounds for the simple visual
+  const lats = markers.map((m) => m.latitude);
+  const lngs = markers.map((m) => m.longitude);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+  const latSpan = Math.max(0.001, maxLat - minLat);
+  const lngSpan = Math.max(0.001, maxLng - minLng);
+
+  function posFor(m: LotMarker): { left: string; top: string } {
+    // Normalise to a 0-100 box with 8% inset padding
+    const leftPct = 8 + ((m.longitude - minLng) / lngSpan) * 84;
+    const topPct = 8 + ((maxLat - m.latitude) / latSpan) * 84;
+    return { left: `${leftPct}%`, top: `${topPct}%` };
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Karte</span>
+          <Badge variant="gray">
+            <NumberFlow value={markers.length} /> Standorte
+          </Badge>
+        </div>
+        <button
+          type="button"
+          onClick={() => navigate('buchen')}
+          className="v5-btn"
+          style={{ padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5 }}
+        >
+          <V5NamedIcon name="plus" size={12} />
+          Platz buchen
+        </button>
+      </div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, animationDelay: '0.06s' }}>
+        <SummaryStat label="Frei" value={totals.free} icon="check" />
+        <SummaryStat label="Gesamt" value={totals.total} icon="list" />
+        <SummaryStat label="Belegung" value={totals.occupancy} suffix="%" icon="trend" />
+      </div>
+
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 300px', gap: 12, animationDelay: '0.12s' }}>
+        <Card style={{ padding: 0, overflow: 'hidden' }}>
+          <div
+            role="img"
+            aria-label="Standortübersicht"
+            style={{
+              position: 'relative',
+              width: '100%',
+              height: 380,
+              background:
+                'repeating-linear-gradient(0deg, var(--v5-sur2) 0 1px, transparent 1px 40px), repeating-linear-gradient(90deg, var(--v5-sur2) 0 1px, transparent 1px 40px), var(--v5-sur)',
+            }}
+          >
+            {markers.map((m) => {
+              const { left, top } = posFor(m);
+              const active = selected?.id === m.id;
+              return (
+                <button
+                  key={m.id}
+                  type="button"
+                  data-testid="karte-marker"
+                  aria-label={`${m.name} – ${m.available_slots} von ${m.total_slots} frei`}
+                  aria-pressed={active}
+                  onClick={() => setSelectedId(m.id)}
+                  style={{
+                    position: 'absolute',
+                    left,
+                    top,
+                    transform: 'translate(-50%, -100%)',
+                    width: active ? 30 : 22,
+                    height: active ? 30 : 22,
+                    borderRadius: '50% 50% 50% 0',
+                    rotate: '-45deg',
+                    background: MARKER_COLOR[m.color],
+                    border: '2px solid var(--v5-sur)',
+                    boxShadow: active ? '0 4px 14px oklch(0 0 0 / 0.25)' : '0 1px 4px oklch(0 0 0 / 0.15)',
+                    cursor: 'pointer',
+                    padding: 0,
+                    transition: 'all 0.15s',
+                  }}
+                />
+              );
+            })}
+          </div>
+        </Card>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {selected && (
+            <Card style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <SectionLabel>Ausgewählter Standort</SectionLabel>
+              <div>
+                <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--v5-txt)' }}>{selected.name}</div>
+                {selected.address && (
+                  <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 2 }}>{selected.address}</div>
+                )}
+              </div>
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+                <Badge variant={COLOR_VARIANT[selected.color]} dot>
+                  {COLOR_LABEL[selected.color]}
+                </Badge>
+                <span className="v5-mono" style={{ fontSize: 11, color: 'var(--v5-mut)' }}>
+                  {selected.available_slots} / {selected.total_slots} frei
+                </span>
+              </div>
+              <OccupancyBar free={selected.available_slots} total={selected.total_slots} />
+            </Card>
+          )}
+
+          <Card style={{ padding: 0, overflow: 'hidden' }}>
+            <div style={{ padding: '12px 16px 8px' }}>
+              <SectionLabel>Alle Standorte</SectionLabel>
+            </div>
+            <div style={{ maxHeight: 260, overflow: 'auto' }}>
+              {markers.map((m, i) => {
+                const active = selected?.id === m.id;
+                return (
+                  <button
+                    key={m.id}
+                    type="button"
+                    data-testid="karte-list-row"
+                    onClick={() => setSelectedId(m.id)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      width: '100%',
+                      padding: '10px 16px',
+                      borderTop: i === 0 ? 'none' : '1px solid var(--v5-bor)',
+                      background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                      border: 'none',
+                      borderRadius: 0,
+                      textAlign: 'left',
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                      color: 'inherit',
+                    }}
+                  >
+                    <span style={{ width: 10, height: 10, borderRadius: '50%', background: MARKER_COLOR[m.color], flexShrink: 0 }} />
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--v5-txt)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {m.name}
+                      </div>
+                      <div style={{ fontSize: 10, color: 'var(--v5-mut)', marginTop: 1 }}>
+                        {m.available_slots} / {m.total_slots} frei
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OccupancyBar({ free, total }: { free: number; total: number }) {
+  const pct = total > 0 ? Math.round((free / total) * 100) : 0;
+  return (
+    <div>
+      <div style={{ height: 4, background: 'var(--v5-sur2)', borderRadius: 4, overflow: 'hidden' }}>
+        <div
+          style={{
+            height: '100%',
+            width: `${Math.max(4, pct)}%`,
+            background: 'var(--v5-acc)',
+            borderRadius: 4,
+            transition: 'width 0.6s ease',
+          }}
+        />
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 4, fontSize: 10, color: 'var(--v5-mut)' }}>
+        <span>{pct}% frei</span>
+        <span>{total - free} belegt</span>
+      </div>
+    </div>
+  );
+}
+
+function SummaryStat({ label, value, suffix, icon }: { label: string; value: number; suffix?: string; icon: 'check' | 'list' | 'trend' }) {
+  return (
+    <Card style={{ padding: '12px 14px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>
+            {label}
+          </div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}>
+            <NumberFlow value={value} />
+            {suffix ?? ''}
+          </div>
+        </div>
+        <div style={{ width: 26, height: 26, borderRadius: 8, background: 'var(--v5-sur2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <V5NamedIcon name={icon} size={12} color="var(--v5-mut)" />
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/parkhub-web/src/design-v5/screens/Profil.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Profil.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockMe = vi.fn();
+const mockUpdateMe = vi.fn();
+const mockChangePassword = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    me: (...a: unknown[]) => mockMe(...a),
+    updateMe: (...a: unknown[]) => mockUpdateMe(...a),
+    changePassword: (...a: unknown[]) => mockChangePassword(...a),
+  },
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  useV5Toast: () => mockToast,
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockSetMode = vi.fn();
+vi.mock('../ThemeProvider', () => ({
+  useV5Theme: () => ({ mode: 'marble_light', setMode: mockSetMode, isVoid: false, isDark: false }),
+  V5_MODES: ['marble_light', 'marble_dark', 'void'] as const,
+  V5_MODE_LABELS: { marble_light: '☀ Marble', marble_dark: '● Marble Dark', void: '◼ Void' },
+}));
+
+import { ProfilV5 } from './Profil';
+
+function renderScreen(navigate = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ProfilV5 navigate={navigate} />
+    </QueryClientProvider>
+  );
+}
+
+const USER = {
+  id: 'u-1',
+  username: 'fk',
+  email: 'florian@example.com',
+  name: 'Florian Kaiser',
+  role: 'user' as const,
+  preferences: {},
+  is_active: true,
+  credits_balance: 10,
+  credits_monthly_quota: 20,
+  department: 'Engineering',
+};
+
+describe('ProfilV5', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders error state when me() fails', async () => {
+    mockMe.mockRejectedValue(new Error('network'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('renders user fields populated from me()', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    renderScreen();
+    await waitFor(() => expect(screen.getByDisplayValue('Florian Kaiser')).toBeInTheDocument());
+    expect(screen.getByDisplayValue('florian@example.com')).toBeInTheDocument();
+    expect(screen.getByText('fk')).toBeInTheDocument();
+  });
+
+  it('enables save after edit and calls updateMe with trimmed values', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockUpdateMe.mockResolvedValue({ success: true, data: { ...USER, name: 'Florian K.' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByDisplayValue('Florian Kaiser')).toBeInTheDocument());
+    const nameInput = screen.getByDisplayValue('Florian Kaiser') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'Florian K.' } });
+    const saveBtn = screen.getByTestId('profil-save');
+    expect(saveBtn).not.toBeDisabled();
+    fireEvent.click(saveBtn);
+    await waitFor(() => {
+      expect(mockUpdateMe).toHaveBeenCalledWith({ name: 'Florian K.', email: 'florian@example.com' });
+      expect(mockToast).toHaveBeenCalledWith('Profil aktualisiert', 'success');
+    });
+  });
+
+  it('shows error toast when updateMe rejects', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockUpdateMe.mockRejectedValue(new Error('boom'));
+    renderScreen();
+    await waitFor(() => expect(screen.getByDisplayValue('Florian Kaiser')).toBeInTheDocument());
+    fireEvent.change(screen.getByDisplayValue('Florian Kaiser'), { target: { value: 'Elly' } });
+    fireEvent.click(screen.getByTestId('profil-save'));
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('Speichern fehlgeschlagen', 'error'));
+  });
+
+  it('submits password change when all fields valid', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockChangePassword.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Mein Profil')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('profil-pw-toggle'));
+    const pwInputs = document.querySelectorAll<HTMLInputElement>('input[type="password"]');
+    expect(pwInputs.length).toBe(3);
+    const [currentPw, newPw, confirmPw] = pwInputs;
+    fireEvent.change(currentPw, { target: { value: 'old-pass-12345' } });
+    fireEvent.change(newPw, { target: { value: 'brand-new-pass-12345' } });
+    fireEvent.change(confirmPw, { target: { value: 'brand-new-pass-12345' } });
+    const submit = screen.getByTestId('profil-pw-submit');
+    expect(submit).not.toBeDisabled();
+    fireEvent.click(submit);
+    await waitFor(() => {
+      expect(mockChangePassword).toHaveBeenCalledWith(
+        'old-pass-12345',
+        'brand-new-pass-12345',
+        'brand-new-pass-12345',
+      );
+      expect(mockToast).toHaveBeenCalledWith('Passwort geändert', 'success');
+    });
+  });
+
+  it('changes language and theme mode', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Mein Profil')).toBeInTheDocument());
+    const langBtns = screen.getAllByTestId('profil-lang');
+    fireEvent.click(langBtns[1]); // English
+    expect(mockToast).toHaveBeenCalledWith('Sprache aktualisiert', 'success');
+    const themeBtns = screen.getAllByTestId('profil-theme');
+    fireEvent.click(themeBtns[2]); // void
+    expect(mockSetMode).toHaveBeenCalledWith('void');
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Profil.tsx
+++ b/parkhub-web/src/design-v5/screens/Profil.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Badge, Card, SectionLabel, V5NamedIcon } from '../primitives';
+import { HelpTip } from '../primitives/HelpTip';
+import { useV5Toast } from '../Toast';
+import { useV5Theme, V5_MODES, V5_MODE_LABELS, type V5Mode } from '../ThemeProvider';
+import { api, type User } from '../../api/client';
+import type { ScreenId } from '../nav';
+
+const LANGUAGES: { code: string; label: string }[] = [
+  { code: 'de', label: 'Deutsch' },
+  { code: 'en', label: 'English' },
+  { code: 'fr', label: 'Français' },
+];
+
+const LANG_STORAGE_KEY = 'i18nextLng';
+
+const inputStyle: CSSProperties = {
+  padding: '8px 11px',
+  borderRadius: 9,
+  background: 'var(--v5-sur2)',
+  border: '1px solid var(--v5-bor)',
+  color: 'var(--v5-txt)',
+  fontSize: 12,
+  width: '100%',
+  outline: 'none',
+  boxSizing: 'border-box',
+  fontFamily: 'inherit',
+};
+
+function Field({ label, children, hint }: { label: string; children: ReactNode; hint?: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <label style={{ fontSize: 11, fontWeight: 500, color: 'var(--v5-mut)', display: 'inline-flex', alignItems: 'center' }}>
+        {label}
+        {hint}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  const toast = useV5Toast();
+  const qc = useQueryClient();
+  const { mode, setMode } = useV5Theme();
+
+  const { data: user, isLoading, isError } = useQuery({
+    queryKey: ['profil'],
+    queryFn: async () => {
+      const res = await api.me();
+      return res.data;
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [lang, setLang] = useState<string>(() => {
+    if (typeof window === 'undefined') return 'de';
+    return window.localStorage.getItem(LANG_STORAGE_KEY) ?? 'de';
+  });
+  const [pwOpen, setPwOpen] = useState(false);
+  const [pwCurrent, setPwCurrent] = useState('');
+  const [pwNew, setPwNew] = useState('');
+  const [pwConfirm, setPwConfirm] = useState('');
+
+  useEffect(() => {
+    if (user) {
+      setName(user.name ?? '');
+      setEmail(user.email ?? '');
+    }
+  }, [user]);
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: Partial<User>) => api.updateMe(payload),
+    onSuccess: (res) => {
+      if (res.success) {
+        qc.invalidateQueries({ queryKey: ['profil'] });
+        toast('Profil aktualisiert', 'success');
+      } else {
+        toast(res.error?.message || 'Speichern fehlgeschlagen', 'error');
+      }
+    },
+    onError: () => toast('Speichern fehlgeschlagen', 'error'),
+  });
+
+  const passwordMutation = useMutation({
+    mutationFn: async (payload: { current: string; next: string; confirm: string }) =>
+      api.changePassword(payload.current, payload.next, payload.confirm),
+    onSuccess: (res) => {
+      if (res.success) {
+        toast('Passwort geändert', 'success');
+        setPwCurrent('');
+        setPwNew('');
+        setPwConfirm('');
+        setPwOpen(false);
+      } else {
+        toast(res.error?.message || 'Passwortänderung fehlgeschlagen', 'error');
+      }
+    },
+    onError: () => toast('Passwortänderung fehlgeschlagen', 'error'),
+  });
+
+  function handleLangChange(code: string) {
+    setLang(code);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(LANG_STORAGE_KEY, code);
+    }
+    toast('Sprache aktualisiert', 'success');
+  }
+
+  function canSaveProfile(): boolean {
+    return !!user && (name.trim() !== (user.name ?? '') || email.trim() !== (user.email ?? ''));
+  }
+
+  function canSavePassword(): boolean {
+    return pwCurrent.length > 0 && pwNew.length >= 12 && pwNew === pwConfirm;
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {[220, 160, 160, 140].map((h, i) => (
+          <div key={i} style={{ height: h, borderRadius: 14, background: 'var(--v5-sur2)', animation: 'ph-v5-pulse 1.6s ease infinite', animationDelay: `${i * 0.1}s` }} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !user) {
+    return (
+      <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
+          <V5NamedIcon name="x" size={26} color="var(--v5-err)" />
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Fehler beim Laden</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>Profil konnte nicht geladen werden.</div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Mein Profil</span>
+        <Badge variant={user.role === 'admin' || user.role === 'superadmin' ? 'purple' : 'primary'}>
+          {user.role}
+        </Badge>
+      </div>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.06s' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <SectionLabel>Kontoinformation</SectionLabel>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <Field label="Name">
+            <input
+              id="profil-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              style={inputStyle}
+            />
+          </Field>
+          <Field
+            label="E-Mail"
+            hint={
+              <HelpTip label="Hinweis zur E-Mail">
+                E-Mail-Bestätigung erforderlich
+              </HelpTip>
+            }
+          >
+            <input
+              id="profil-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              style={inputStyle}
+            />
+          </Field>
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--v5-mut)' }}>
+          Benutzername: <span className="v5-mono" style={{ color: 'var(--v5-txt)' }}>{user.username}</span>
+          {user.department && (
+            <>
+              {' · '}Abteilung: <span style={{ color: 'var(--v5-txt)' }}>{user.department}</span>
+            </>
+          )}
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <button
+            type="button"
+            disabled={!canSaveProfile() || saveMutation.isPending}
+            onClick={() => saveMutation.mutate({ name: name.trim(), email: email.trim() })}
+            data-testid="profil-save"
+            style={{
+              padding: '8px 16px',
+              borderRadius: 9,
+              background: 'var(--v5-acc)',
+              color: 'var(--v5-accent-fg)',
+              border: 'none',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: canSaveProfile() && !saveMutation.isPending ? 'pointer' : 'not-allowed',
+              opacity: canSaveProfile() && !saveMutation.isPending ? 1 : 0.5,
+            }}
+          >
+            {saveMutation.isPending ? 'Speichert …' : 'Speichern'}
+          </button>
+        </div>
+      </Card>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.12s' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <SectionLabel>Sicherheit</SectionLabel>
+            <HelpTip label="Hinweis zum Passwort">
+              Mindestens 12 Zeichen
+            </HelpTip>
+          </div>
+          <button
+            type="button"
+            onClick={() => setPwOpen((o) => !o)}
+            data-testid="profil-pw-toggle"
+            style={{ padding: '6px 12px', borderRadius: 8, background: 'var(--v5-sur2)', border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 11, fontWeight: 500, cursor: 'pointer' }}
+          >
+            {pwOpen ? 'Abbrechen' : 'Passwort ändern'}
+          </button>
+        </div>
+        {pwOpen && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <Field label="Aktuelles Passwort">
+              <input
+                type="password"
+                value={pwCurrent}
+                onChange={(e) => setPwCurrent(e.target.value)}
+                style={inputStyle}
+                autoComplete="current-password"
+              />
+            </Field>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+              <Field label="Neues Passwort">
+                <input
+                  type="password"
+                  value={pwNew}
+                  onChange={(e) => setPwNew(e.target.value)}
+                  style={inputStyle}
+                  autoComplete="new-password"
+                />
+              </Field>
+              <Field label="Bestätigen">
+                <input
+                  type="password"
+                  value={pwConfirm}
+                  onChange={(e) => setPwConfirm(e.target.value)}
+                  style={inputStyle}
+                  autoComplete="new-password"
+                />
+              </Field>
+            </div>
+            {pwNew.length > 0 && pwNew.length < 12 && (
+              <div style={{ fontSize: 11, color: 'var(--v5-warn)' }}>
+                Mindestens 12 Zeichen erforderlich.
+              </div>
+            )}
+            {pwNew.length >= 12 && pwConfirm.length > 0 && pwNew !== pwConfirm && (
+              <div style={{ fontSize: 11, color: 'var(--v5-err)' }}>
+                Passwörter stimmen nicht überein.
+              </div>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                disabled={!canSavePassword() || passwordMutation.isPending}
+                onClick={() => passwordMutation.mutate({ current: pwCurrent, next: pwNew, confirm: pwConfirm })}
+                data-testid="profil-pw-submit"
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 9,
+                  background: 'var(--v5-acc)',
+                  color: 'var(--v5-accent-fg)',
+                  border: 'none',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: canSavePassword() && !passwordMutation.isPending ? 'pointer' : 'not-allowed',
+                  opacity: canSavePassword() && !passwordMutation.isPending ? 1 : 0.5,
+                }}
+              >
+                {passwordMutation.isPending ? 'Ändert …' : 'Passwort speichern'}
+              </button>
+            </div>
+          </div>
+        )}
+      </Card>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.18s' }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <SectionLabel>Sprache</SectionLabel>
+          <HelpTip label="Hinweis zur Sprache">
+            Greift sofort
+          </HelpTip>
+        </div>
+        <div role="group" aria-label="Sprachen" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {LANGUAGES.map((l) => {
+            const active = lang === l.code;
+            return (
+              <button
+                key={l.code}
+                type="button"
+                aria-pressed={active}
+                data-testid="profil-lang"
+                onClick={() => handleLangChange(l.code)}
+                style={{
+                  padding: '6px 14px',
+                  borderRadius: 999,
+                  fontSize: 11,
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                  border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                  background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                  color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                }}
+              >
+                {l.label}
+              </button>
+            );
+          })}
+        </div>
+      </Card>
+
+      <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.24s' }}>
+        <SectionLabel>Darstellung</SectionLabel>
+        <div role="group" aria-label="Darstellungsmodus" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {V5_MODES.map((m: V5Mode) => {
+            const active = mode === m;
+            return (
+              <button
+                key={m}
+                type="button"
+                aria-pressed={active}
+                data-testid="profil-theme"
+                onClick={() => setMode(m)}
+                style={{
+                  padding: '8px 14px',
+                  borderRadius: 10,
+                  fontSize: 11,
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                  border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                  background: active ? 'var(--v5-acc-muted)' : 'transparent',
+                  color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                }}
+              >
+                {V5_MODE_LABELS[m]}
+              </button>
+            );
+          })}
+        </div>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Wave 2 of the v4 -> v5 migration. Ports the remaining 4 Main-section screens from the v4 fallback to native v5 implementations.

- **Buchen** (03) — 3-step booking flow (lot picker -> time/slot -> confirm) with availability cards, slot grid, and live cost summary
- **Kalender** (05) — Monday-start month grid, per-day event chips, day-detail sidebar, absence/booking counts
- **Karte** (06) — Coordinate-normalised marker visual + lot list with occupancy bars (no leaflet in the v5 bundle)
- **Profil** (26) — Account edit, password change, language picker, v5 theme picker, HelpTip hints on email/password/language

All 4 screens mirror the `Buchungen.tsx` canonical pattern: TanStack Query with 30s stale + focus refetch, loading skeleton, error Card, empty state Card, and `useV5Toast` on every mutation. Colors come from `var(--v5-*)` tokens only, primitives from `./primitives`, no new runtime dependencies.

## Test plan

- [x] 23 new Vitest cases across the 4 screens (6+6+5+6) — all pass locally
- [x] Full repo test run clean: **138 files / 2201 tests passed**
- [x] Astro build clean (`npm run build`)
- [x] `src/design-v5/App.tsx` SCREENS map registers all 4 — nav routes through real v5 code, no Placeholder fallback
- [ ] Verify `/v5` loads on Render after merge (SPA; individual screens live in the v5 shell via localStorage)