### PR TITLE
fix(v5): check ApiResponse.success across all mutations + queries

### DIFF
--- a/parkhub-web/src/design-v5/screens/Buchen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.test.tsx
@@ -151,6 +151,31 @@ describe('BuchenV5', () => {
     await waitFor(() => expect(screen.getByTestId('buchen-confirm')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('buchen-confirm'));
 
-    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('Buchung fehlgeschlagen', 'error'));
+    // onError now propagates the thrown Error's message; falls back to 'Buchung fehlgeschlagen' only if empty
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('boom', 'error'));
+  });
+
+  it('surfaces query error when getLots responds success:false', async () => {
+    mockGetLots.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('calls onError (no success toast) when createBooking responds success:false with INSUFFICIENT_CREDITS', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
+    mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A] });
+    mockCreateBooking.mockResolvedValue({ success: false, data: null, error: { code: 'INSUFFICIENT_CREDITS', message: 'no credits' } });
+    renderScreen();
+
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-lot-card'));
+    await waitFor(() => expect(screen.getByTestId('buchen-slot')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-slot'));
+    fireEvent.click(screen.getByRole('button', { name: /Weiter/ }));
+    await waitFor(() => expect(screen.getByTestId('buchen-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-confirm'));
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('Nicht genug Credits', 'error'));
+    expect(mockToast).not.toHaveBeenCalledWith('Buchung bestätigt', 'success');
   });
 });

--- a/parkhub-web/src/design-v5/screens/Buchen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.tsx
@@ -82,6 +82,7 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
     queryKey: ['buchen-lots'],
     queryFn: async () => {
       const res = await api.getLots();
+      if (!res.success) throw new Error(res.error?.message ?? 'Parkplätze konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
@@ -92,6 +93,7 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
     queryKey: ['buchen-vehicles'],
     queryFn: async () => {
       const res = await api.getVehicles();
+      if (!res.success) throw new Error(res.error?.message ?? 'Fahrzeuge konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
@@ -106,6 +108,7 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
     enabled: !!selectedLot,
     queryFn: async () => {
       const res = await api.getLotSlots(selectedLot!.id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Stellplätze konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 15_000,
@@ -113,20 +116,22 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
   const slots = slotsResp ?? [];
 
   const createMutation = useMutation({
-    mutationFn: (payload: CreateBookingPayload) => api.createBooking(payload),
-    onSuccess: (res) => {
-      if (res.success) {
-        qc.invalidateQueries({ queryKey: ['buchungen'] });
-        toast('Buchung bestätigt', 'success');
-        navigate('buchungen');
-      } else {
+    mutationFn: async (payload: CreateBookingPayload) => {
+      const res = await api.createBooking(payload);
+      if (!res.success) {
         const msg = res.error?.code === 'INSUFFICIENT_CREDITS'
           ? 'Nicht genug Credits'
           : res.error?.message || 'Buchung fehlgeschlagen';
-        toast(msg, 'error');
+        throw new Error(msg);
       }
+      return res.data;
     },
-    onError: () => toast('Buchung fehlgeschlagen', 'error'),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['buchungen'] });
+      toast('Buchung bestätigt', 'success');
+      navigate('buchungen');
+    },
+    onError: (err: Error) => toast(err.message || 'Buchung fehlgeschlagen', 'error'),
   });
 
   if (lotsLoading) {

--- a/parkhub-web/src/design-v5/screens/Buchungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.test.tsx
@@ -103,4 +103,23 @@ describe('BuchungenV5', () => {
     expect(navigate).toHaveBeenCalledWith('einchecken');
     expect(mockToast).toHaveBeenCalledWith('Einchecken geöffnet', 'info');
   });
+
+  it('surfaces query error when success:false', async () => {
+    mockGetBookings.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('calls onError (no success toast) when cancel mutation responds success:false', async () => {
+    mockGetBookings.mockResolvedValue({ success: true, data: [BOOKING_CONFIRMED] });
+    mockCancelBooking.mockResolvedValue({ success: false, data: null, error: { code: 'CONFLICT', message: 'already cancelled' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Storno')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Storno'));
+    await waitFor(() => {
+      expect(mockCancelBooking).toHaveBeenCalledWith('b-conf-001');
+      expect(mockToast).toHaveBeenCalledWith('Stornierung fehlgeschlagen', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Buchung storniert', 'success');
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Buchungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.tsx
@@ -55,6 +55,7 @@ export function BuchungenV5({ navigate }: { navigate: (id: ScreenId) => void }) 
     queryKey: ['buchungen'],
     queryFn: async () => {
       const res = await api.getBookings();
+      if (!res.success) throw new Error(res.error?.message ?? 'Buchungen konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
@@ -62,7 +63,11 @@ export function BuchungenV5({ navigate }: { navigate: (id: ScreenId) => void }) 
   });
 
   const cancelMutation = useMutation({
-    mutationFn: (id: string) => api.cancelBooking(id),
+    mutationFn: async (id: string) => {
+      const res = await api.cancelBooking(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Stornierung fehlgeschlagen');
+      return res.data;
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['buchungen'] });
       toast('Buchung storniert', 'success');

--- a/parkhub-web/src/design-v5/screens/Credits.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Credits.test.tsx
@@ -105,4 +105,24 @@ describe('CreditsV5', () => {
       expect(meter).toHaveAttribute('aria-valuemax', '10');
     });
   });
+
+  it('surfaces query error when success:false', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('calls onError (no redirect) when createCheckout responds success:false', async () => {
+    mockGetUserCredits.mockResolvedValue({ success: true, data: CREDITS });
+    mockCreateCheckout.mockResolvedValue({ success: false, data: null, error: { code: 'STRIPE', message: 'provider down' } });
+    renderScreen();
+    await waitFor(() => screen.getByText('+ Credits kaufen'));
+    fireEvent.click(screen.getByText('+ Credits kaufen'));
+    await waitFor(() => {
+      expect(mockCreateCheckout).toHaveBeenCalledWith(10);
+      expect(mockToast).toHaveBeenCalledWith('Credits kaufen fehlgeschlagen', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Weiterleitung zur Kasse…', 'info');
+    expect(window.location.href).toBe('');
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Credits.tsx
+++ b/parkhub-web/src/design-v5/screens/Credits.tsx
@@ -24,6 +24,7 @@ export function CreditsV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
     queryKey: ['credits'],
     queryFn: async () => {
       const res = await api.getUserCredits();
+      if (!res.success) throw new Error(res.error?.message ?? 'Credits konnten nicht geladen werden');
       return res.data;
     },
     staleTime: 30_000,
@@ -31,11 +32,15 @@ export function CreditsV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
   });
 
   const buyMutation = useMutation({
-    mutationFn: () => api.createCheckout(10),
-    onSuccess: (res) => {
-      if (res.data?.checkout_url) {
+    mutationFn: async () => {
+      const res = await api.createCheckout(10);
+      if (!res.success) throw new Error(res.error?.message ?? 'Credits kaufen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: (data) => {
+      if (data?.checkout_url) {
         toast('Weiterleitung zur Kasse…', 'info');
-        window.location.href = res.data.checkout_url;
+        window.location.href = data.checkout_url;
       } else {
         toast('Keine Checkout-URL erhalten', 'error');
       }

--- a/parkhub-web/src/design-v5/screens/Fahrzeuge.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Fahrzeuge.test.tsx
@@ -106,4 +106,38 @@ describe('FahrzeugeV5', () => {
       expect(mockToast).toHaveBeenCalledWith('Fahrzeug entfernt', 'success');
     });
   });
+
+  it('surfaces query error when success:false', async () => {
+    mockGetVehicles.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('calls onError (no success toast) when createVehicle responds success:false', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [] });
+    mockCreateVehicle.mockResolvedValue({ success: false, data: null, error: { code: 'VALIDATION', message: 'invalid plate' } });
+    renderScreen();
+    await waitFor(() => screen.getByText('Noch keine Fahrzeuge'));
+    fireEvent.click(screen.getAllByText(/Hinzufügen|hinzufügen/).pop()!);
+    fireEvent.change(screen.getByPlaceholderText('M-AB 1234'), { target: { value: 'M-AB 123' } });
+    fireEvent.click(screen.getByText('Speichern'));
+    await waitFor(() => {
+      expect(mockCreateVehicle).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith('Hinzufügen fehlgeschlagen', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Fahrzeug hinzugefügt', 'success');
+  });
+
+  it('calls onError (no success toast) when deleteVehicle responds success:false', async () => {
+    mockGetVehicles.mockResolvedValue({ success: true, data: [VEHICLE_BMW] });
+    mockDeleteVehicle.mockResolvedValue({ success: false, data: null, error: { code: 'NOT_FOUND', message: 'gone' } });
+    renderScreen();
+    await waitFor(() => screen.getByText('M-AB 123'));
+    fireEvent.click(screen.getByLabelText('Fahrzeug M-AB 123 löschen'));
+    await waitFor(() => {
+      expect(mockDeleteVehicle).toHaveBeenCalledWith('v-001');
+      expect(mockToast).toHaveBeenCalledWith('Löschen fehlgeschlagen', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Fahrzeug entfernt', 'success');
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Fahrzeuge.tsx
+++ b/parkhub-web/src/design-v5/screens/Fahrzeuge.tsx
@@ -185,6 +185,7 @@ export function FahrzeugeV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
     queryKey: ['fahrzeuge'],
     queryFn: async () => {
       const res = await api.getVehicles();
+      if (!res.success) throw new Error(res.error?.message ?? 'Fahrzeuge konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
@@ -192,7 +193,11 @@ export function FahrzeugeV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
   });
 
   const addMutation = useMutation({
-    mutationFn: (payload: CreateVehiclePayload) => api.createVehicle(payload),
+    mutationFn: async (payload: CreateVehiclePayload) => {
+      const res = await api.createVehicle(payload);
+      if (!res.success) throw new Error(res.error?.message ?? 'Fahrzeug hinzufügen fehlgeschlagen');
+      return res.data;
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['fahrzeuge'] });
       toast('Fahrzeug hinzugefügt', 'success');
@@ -202,7 +207,11 @@ export function FahrzeugeV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.deleteVehicle(id),
+    mutationFn: async (id: string) => {
+      const res = await api.deleteVehicle(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Fahrzeug löschen fehlgeschlagen');
+      return res.data;
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['fahrzeuge'] });
       toast('Fahrzeug entfernt', 'success');

--- a/parkhub-web/src/design-v5/screens/Kalender.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Kalender.test.tsx
@@ -129,4 +129,10 @@ describe('KalenderV5', () => {
     const nextStart = mockCalendarEvents.mock.calls[mockCalendarEvents.mock.calls.length - 1][0];
     expect(nextStart).not.toBe(initialStart);
   });
+
+  it('surfaces query error when success:false', async () => {
+    mockCalendarEvents.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Kalender.tsx
+++ b/parkhub-web/src/design-v5/screens/Kalender.tsx
@@ -60,6 +60,7 @@ export function KalenderV5({ navigate }: { navigate: (id: ScreenId) => void }) {
     queryKey: ['kalender', rangeStart, rangeEnd],
     queryFn: async () => {
       const res = await api.calendarEvents(rangeStart, rangeEnd);
+      if (!res.success) throw new Error(res.error?.message ?? 'Kalenderdaten konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,

--- a/parkhub-web/src/design-v5/screens/Karte.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Karte.test.tsx
@@ -97,4 +97,10 @@ describe('KarteV5', () => {
     fireEvent.click(screen.getByText('Platz buchen'));
     expect(navigate).toHaveBeenCalledWith('buchen');
   });
+
+  it('surfaces query error when success:false', async () => {
+    mockGetMapMarkers.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
 });

--- a/parkhub-web/src/design-v5/screens/Karte.tsx
+++ b/parkhub-web/src/design-v5/screens/Karte.tsx
@@ -33,6 +33,7 @@ export function KarteV5({ navigate }: { navigate: (id: ScreenId) => void }) {
     queryKey: ['karte'],
     queryFn: async () => {
       const res = await api.getMapMarkers();
+      if (!res.success) throw new Error(res.error?.message ?? 'Karte konnte nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,

--- a/parkhub-web/src/design-v5/screens/Profil.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Profil.test.tsx
@@ -93,7 +93,8 @@ describe('ProfilV5', () => {
     await waitFor(() => expect(screen.getByDisplayValue('Florian Kaiser')).toBeInTheDocument());
     fireEvent.change(screen.getByDisplayValue('Florian Kaiser'), { target: { value: 'Elly' } });
     fireEvent.click(screen.getByTestId('profil-save'));
-    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('Speichern fehlgeschlagen', 'error'));
+    // onError now propagates the thrown Error's message; falls back to 'Speichern fehlgeschlagen' only if empty
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('boom', 'error'));
   });
 
   it('submits password change when all fields valid', async () => {
@@ -131,5 +132,44 @@ describe('ProfilV5', () => {
     const themeBtns = screen.getAllByTestId('profil-theme');
     fireEvent.click(themeBtns[2]); // void
     expect(mockSetMode).toHaveBeenCalledWith('void');
+  });
+
+  it('surfaces query error when me() responds success:false', async () => {
+    mockMe.mockResolvedValue({ success: false, data: null, error: { code: 'UNAUTHENTICATED', message: 'login required' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
+  });
+
+  it('calls onError (no success toast) when updateMe responds success:false', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockUpdateMe.mockResolvedValue({ success: false, data: null, error: { code: 'VALIDATION', message: 'email already in use' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByDisplayValue('Florian Kaiser')).toBeInTheDocument());
+    fireEvent.change(screen.getByDisplayValue('Florian Kaiser'), { target: { value: 'Elly' } });
+    fireEvent.click(screen.getByTestId('profil-save'));
+    await waitFor(() => {
+      expect(mockUpdateMe).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith('email already in use', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Profil aktualisiert', 'success');
+  });
+
+  it('calls onError (no success toast) when changePassword responds success:false', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    mockChangePassword.mockResolvedValue({ success: false, data: null, error: { code: 'INVALID_PASSWORD', message: 'current password wrong' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getByText('Mein Profil')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('profil-pw-toggle'));
+    const pwInputs = document.querySelectorAll<HTMLInputElement>('input[type="password"]');
+    const [currentPw, newPw, confirmPw] = pwInputs;
+    fireEvent.change(currentPw, { target: { value: 'old-pass-12345' } });
+    fireEvent.change(newPw, { target: { value: 'brand-new-pass-12345' } });
+    fireEvent.change(confirmPw, { target: { value: 'brand-new-pass-12345' } });
+    fireEvent.click(screen.getByTestId('profil-pw-submit'));
+    await waitFor(() => {
+      expect(mockChangePassword).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith('current password wrong', 'error');
+    });
+    expect(mockToast).not.toHaveBeenCalledWith('Passwort geändert', 'success');
   });
 });

--- a/parkhub-web/src/design-v5/screens/Profil.tsx
+++ b/parkhub-web/src/design-v5/screens/Profil.tsx
@@ -49,6 +49,7 @@ export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
     queryKey: ['profil'],
     queryFn: async () => {
       const res = await api.me();
+      if (!res.success) throw new Error(res.error?.message ?? 'Profil konnte nicht geladen werden');
       return res.data;
     },
     staleTime: 30_000,
@@ -74,33 +75,32 @@ export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
   }, [user]);
 
   const saveMutation = useMutation({
-    mutationFn: (payload: Partial<User>) => api.updateMe(payload),
-    onSuccess: (res) => {
-      if (res.success) {
-        qc.invalidateQueries({ queryKey: ['profil'] });
-        toast('Profil aktualisiert', 'success');
-      } else {
-        toast(res.error?.message || 'Speichern fehlgeschlagen', 'error');
-      }
+    mutationFn: async (payload: Partial<User>) => {
+      const res = await api.updateMe(payload);
+      if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
+      return res.data;
     },
-    onError: () => toast('Speichern fehlgeschlagen', 'error'),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['profil'] });
+      toast('Profil aktualisiert', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
   });
 
   const passwordMutation = useMutation({
-    mutationFn: async (payload: { current: string; next: string; confirm: string }) =>
-      api.changePassword(payload.current, payload.next, payload.confirm),
-    onSuccess: (res) => {
-      if (res.success) {
-        toast('Passwort geändert', 'success');
-        setPwCurrent('');
-        setPwNew('');
-        setPwConfirm('');
-        setPwOpen(false);
-      } else {
-        toast(res.error?.message || 'Passwortänderung fehlgeschlagen', 'error');
-      }
+    mutationFn: async (payload: { current: string; next: string; confirm: string }) => {
+      const res = await api.changePassword(payload.current, payload.next, payload.confirm);
+      if (!res.success) throw new Error(res.error?.message ?? 'Passwortänderung fehlgeschlagen');
+      return res.data;
     },
-    onError: () => toast('Passwortänderung fehlgeschlagen', 'error'),
+    onSuccess: () => {
+      toast('Passwort geändert', 'success');
+      setPwCurrent('');
+      setPwNew('');
+      setPwConfirm('');
+      setPwOpen(false);
+    },
+    onError: (err: Error) => toast(err.message || 'Passwortänderung fehlgeschlagen', 'error'),
   });
 
   function handleLangChange(code: string) {


### PR DESCRIPTION
## Summary

`api.*` methods return `ApiResponse<T> = { success, data, error }` and do NOT throw on business errors (only network errors). All 8 v5 screens merged via PRs #326/#331 call these inside TanStack Query `mutationFn`/`queryFn` without checking `res.success`. Result: users saw success-toast even when the backend returned `{success:false, error:...}`, and `isError` never tripped so the error card was unreachable for normal API failures (403/404/validation/etc.).

The same bug was flagged by Codex on nash87/parkhub-rust PR #371 (being fixed there in parallel). This PR applies the identical pattern across all 7 PHP v5 screens that touch `api.*` (Dashboard has no api.* calls — unchanged).

## Fix pattern

**Queries**
```ts
queryFn: async () => {
  const res = await api.foo();
  if (!res.success) throw new Error(res.error?.message ?? 'fallback');
  return res.data ?? [];
}
```

**Mutations** (throw from mutationFn so onError runs instead of onSuccess):
```ts
mutationFn: async (payload) => {
  const res = await api.foo(payload);
  if (!res.success) throw new Error(res.error?.message ?? 'fallback');
  return res.data;
}
```

For `Buchen.tsx` + `Profil.tsx` which previously branched on `res.success` inside onSuccess, the mutation now throws and `onError` propagates `err.message`. `Buchen` preserves the `INSUFFICIENT_CREDITS` special-case by building the message inside the throw.

## Screens touched

| Screen | queries fixed | mutations fixed |
|---|---|---|
| Buchungen | 1 (getBookings) | 1 (cancelBooking) |
| Buchen | 3 (getLots, getVehicles, getLotSlots) | 1 (createBooking) |
| Fahrzeuge | 1 (getVehicles) | 2 (createVehicle, deleteVehicle) |
| Kalender | 1 (calendarEvents) | 0 |
| Karte | 1 (getMapMarkers) | 0 |
| Credits | 1 (getUserCredits) | 1 (createCheckout) |
| Profil | 1 (me) | 2 (updateMe, changePassword) |
| **Total** | **9 queries** | **7 mutations** |

## Tests

Each screen gets a new `it('surfaces query error when success:false', …)` test; screens with mutations also get `onError when mutation responds success:false` assertions. 2 pre-existing tests (`Profil.test > shows error toast when updateMe rejects`, `Buchen.test > emits error toast when createBooking rejects`) updated: onError now propagates `err.message` from the rejected Error, so those assertions now check for `'boom'` instead of the hardcoded fallback.

Local: 55/55 v5 screen tests green.

## Test plan

- [x] Run `npm run test -- --run src/design-v5/screens` locally (55 passed)
- [ ] CI: Frontend Build & Test
- [ ] CI: E2E Playwright
- [ ] Manual QA: trigger a backend 403 on each screen, confirm error card appears instead of success toast