### PR TITLE
fix(v5): calendar uses from/to params + Buchen guards invalid datetime

### DIFF
--- a/parkhub-web/src/api/client.test.ts
+++ b/parkhub-web/src/api/client.test.ts
@@ -787,13 +787,16 @@ describe('API client', () => {
     expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('/api/v1/notifications/read-all');
   });
 
-  it('calls calendarEvents with query params', async () => {
+  it('calls calendarEvents with from/to query params (not start/end — backend ignores those)', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true, status: 200,
       json: () => Promise.resolve({ success: true, data: [] }),
     });
     await api.calendarEvents('2026-01-01', '2026-01-31');
-    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('/api/v1/calendar/events?start=2026-01-01&end=2026-01-31');
+    const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toBe('/api/v1/calendar/events?from=2026-01-01&to=2026-01-31');
+    expect(url).not.toMatch(/[?&]start=/);
+    expect(url).not.toMatch(/[?&]end=/);
   });
 
   it('calls generateCalendarToken', async () => {

--- a/parkhub-web/src/api/client.test.ts
+++ b/parkhub-web/src/api/client.test.ts
@@ -787,16 +787,36 @@ describe('API client', () => {
     expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('/api/v1/notifications/read-all');
   });
 
-  it('calls calendarEvents with from/to query params (not start/end — backend ignores those)', async () => {
+  it('calls calendarEvents with from/to query params, normalising bare-date to to end-of-day (inclusive)', async () => {
+    // Regression for PR #335: the PHP backend filter is `end_time <= $to`;
+    // when `to` is a date-only `YYYY-MM-DD`, Laravel interprets it as
+    // midnight and silently drops bookings ending later on the boundary day.
+    // The client normalises to `YYYY-MM-DD 23:59:59` so the filter is
+    // inclusive of the entire selected day.
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true, status: 200,
       json: () => Promise.resolve({ success: true, data: [] }),
     });
     await api.calendarEvents('2026-01-01', '2026-01-31');
     const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(url).toBe('/api/v1/calendar/events?from=2026-01-01&to=2026-01-31');
+    const parsed = new URL(url, 'http://localhost');
+    expect(parsed.pathname).toBe('/api/v1/calendar/events');
+    expect(parsed.searchParams.get('from')).toBe('2026-01-01');
+    expect(parsed.searchParams.get('to')).toBe('2026-01-31 23:59:59');
     expect(url).not.toMatch(/[?&]start=/);
     expect(url).not.toMatch(/[?&]end=/);
+  });
+
+  it('passes full-datetime to values through calendarEvents untouched', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ success: true, data: [] }),
+    });
+    await api.calendarEvents('2026-01-01 08:00:00', '2026-01-31 17:30:00');
+    const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = new URL(url, 'http://localhost');
+    expect(parsed.searchParams.get('from')).toBe('2026-01-01 08:00:00');
+    expect(parsed.searchParams.get('to')).toBe('2026-01-31 17:30:00');
   });
 
   it('calls generateCalendarToken', async () => {

--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -423,10 +423,19 @@ export const api = {
   // ── Calendar ──
   // Backend (both rust `CalendarQuery` and PHP `BookingCalendarController::calendarEvents`)
   // reads `from`/`to`. Sending `start`/`end` silently skips the filter → unbounded result set.
+  //
+  // Inclusive end-bound normalisation:
+  // The PHP backend applies `where('end_time', '<=', $to)`; when callers
+  // (e.g. `Kalender.tsx` / `Calendar.tsx`) pass a date-only `YYYY-MM-DD`,
+  // Laravel interprets it as `00:00:00` of that day and silently drops any
+  // booking ending later on the boundary day. We normalise a bare date here
+  // to end-of-day `23:59:59` so the filter is inclusive of the entire
+  // selected final day. Full-datetime inputs pass through untouched so
+  // direct-call consumers can override the window precisely.
   calendarEvents: (from: string, to: string) => {
     const params = new URLSearchParams();
     params.set('from', from);
-    params.set('to', to);
+    params.set('to', /^\d{4}-\d{2}-\d{2}$/.test(to) ? `${to} 23:59:59` : to);
     return request<CalendarEvent[]>(`/api/v1/calendar/events?${params.toString()}`);
   },
   generateCalendarToken: () =>

--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -421,8 +421,14 @@ export const api = {
     request<void>(`/api/v1/notifications/center/${id}`, { method: 'DELETE' }),
 
   // ── Calendar ──
-  calendarEvents: (start: string, end: string) =>
-    request<CalendarEvent[]>(`/api/v1/calendar/events?start=${start}&end=${end}`),
+  // Backend (both rust `CalendarQuery` and PHP `BookingCalendarController::calendarEvents`)
+  // reads `from`/`to`. Sending `start`/`end` silently skips the filter → unbounded result set.
+  calendarEvents: (from: string, to: string) => {
+    const params = new URLSearchParams();
+    params.set('from', from);
+    params.set('to', to);
+    return request<CalendarEvent[]>(`/api/v1/calendar/events?${params.toString()}`);
+  },
   generateCalendarToken: () =>
     request<{ token: string; url: string }>('/api/v1/calendar/token', { method: 'POST' }),
 

--- a/parkhub-web/src/design-v5/screens/Buchen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.test.tsx
@@ -161,6 +161,54 @@ describe('BuchenV5', () => {
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
+  it('blocks confirm when startDate is cleared and toasts an error without calling createBooking', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
+    mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A] });
+    renderScreen();
+
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-lot-card'));
+    await waitFor(() => expect(screen.getByTestId('buchen-slot')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-slot'));
+
+    // Clear the datetime-local input — user empties the field before confirming.
+    const startInput = document.getElementById('buchen-start') as HTMLInputElement;
+    expect(startInput).toBeTruthy();
+    fireEvent.change(startInput, { target: { value: '' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Weiter/ }));
+    await waitFor(() => expect(screen.getByTestId('buchen-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-confirm'));
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith('Bitte gültige Zeiten angeben', 'error'),
+    );
+    expect(mockCreateBooking).not.toHaveBeenCalled();
+  });
+
+  it('sends calendarEvents-equivalent ISO datetime-local values to createBooking on valid confirm (regression guard)', async () => {
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
+    mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A] });
+    mockCreateBooking.mockResolvedValue({ success: true, data: { id: 'b-valid' } });
+    renderScreen();
+
+    await waitFor(() => expect(screen.getByText('Parkhaus Nord')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-lot-card'));
+    await waitFor(() => expect(screen.getByTestId('buchen-slot')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-slot'));
+    fireEvent.click(screen.getByRole('button', { name: /Weiter/ }));
+    await waitFor(() => expect(screen.getByTestId('buchen-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('buchen-confirm'));
+
+    await waitFor(() => expect(mockCreateBooking).toHaveBeenCalledTimes(1));
+    const payload = mockCreateBooking.mock.calls[0][0];
+    // Default start is prefilled → toISOString() must succeed and produce a Z-suffixed ISO string.
+    expect(payload.start_time).toMatch(/\dT\d/);
+    expect(payload.end_time).toMatch(/\dT\d/);
+    expect(new Date(payload.start_time).valueOf()).not.toBeNaN();
+    expect(new Date(payload.end_time).valueOf()).not.toBeNaN();
+  });
+
   it('calls onError (no success toast) when createBooking responds success:false with INSUFFICIENT_CREDITS', async () => {
     mockGetLots.mockResolvedValue({ success: true, data: [LOT_OPEN] });
     mockGetLotSlots.mockResolvedValue({ success: true, data: [SLOT_A] });

--- a/parkhub-web/src/design-v5/screens/Buchen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchen.tsx
@@ -52,6 +52,17 @@ function defaultStart(): string {
   return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
 }
 
+/**
+ * A `datetime-local` input can be cleared to an empty string, and
+ * `new Date("").toISOString()` throws `RangeError: Invalid time value`.
+ * Guard the confirm path so the mutation is never called with an
+ * unparseable value (silent-fail bug surfaced by Codex on parkhub-rust PR #373).
+ */
+function isValidDt(s: string | undefined | null): s is string {
+  if (!s) return false;
+  return Number.isFinite(new Date(s).valueOf());
+}
+
 function formatDateTime(d: Date): string {
   return d.toLocaleString('de-DE', {
     weekday: 'short', day: '2-digit', month: '2-digit',
@@ -173,6 +184,13 @@ export function BuchenV5({ navigate }: { navigate: (id: ScreenId) => void }) {
 
   function handleConfirm() {
     if (!selectedLot || !selectedSlot) return;
+    // Empty / unparseable datetime-local values produce Invalid Date, and
+    // `toISOString()` on those throws — the mutation would never fire and
+    // the user would see nothing happen. Surface a toast instead.
+    if (!isValidDt(startDate) || !Number.isFinite(end.valueOf())) {
+      toast('Bitte gültige Zeiten angeben', 'error');
+      return;
+    }
     createMutation.mutate({
       lot_id: selectedLot.id,
       slot_id: selectedSlot.id,


### PR DESCRIPTION
## Summary
Mirrors the parkhub-rust PR #373 fix for two Codex-flagged silent-fail bugs already shipped on main via #331.

- **Calendar query mismatch**: `api.calendarEvents(start, end)` serialized to `?start=...&end=...`, but `BookingCalendarController::calendarEvents` reads `from`/`to`. The month-scope filter was silently dropped → unbounded event set + stale Kalender counts + payload bloat. Rename positional params and build the query via `URLSearchParams`.
- **Buchen invalid-datetime silent fail**: `new Date(startDate).toISOString()` throws `RangeError` on an empty `datetime-local`. The exception fires inside the onClick, the mutation never fires, and the user sees nothing happen. Added an `isValidDt` guard that surfaces a German error toast.

## Test plan
- [x] `npm run test -- --run src/design-v5/screens/{Kalender,Buchen} src/api/client` — 107/107 passing locally
- [x] Client regression test asserts URL contains `from=`/`to=` and neither `start=` nor `end=`
- [x] New Buchen test clears the datetime input and asserts error toast + no `createBooking` call
- [x] New regression-guard test asserts valid defaults still produce parseable ISO via `toISOString()`