### PR TITLE
fix(v5): mirror rust #374 fleet-screen fixes to PHP Wave 3

### DIFF
--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -1394,6 +1394,15 @@ export interface CheckInStatus {
   checked_out_at: string | null;
 }
 
+/**
+ * Guest booking payload returned by `GET /api/v1/bookings/guest`.
+ *
+ * The `status` union mirrors the backend `Booking::STATUS_*` constants
+ * (see `app/Models/Booking.php` — PENDING, CONFIRMED, ACTIVE, COMPLETED,
+ * CANCELLED, NO_SHOW; EXPIRED is produced by TTL sweeps). Newly created
+ * guest passes land in `confirmed` (GuestBookingController), so clients
+ * MUST accept the full set to render and act on fresh records.
+ */
 export interface GuestBooking {
   id: string;
   lot_id: string;
@@ -1405,7 +1414,14 @@ export interface GuestBooking {
   guest_code: string;
   start_time: string;
   end_time: string;
-  status: 'active' | 'expired' | 'cancelled';
+  status:
+    | 'pending'
+    | 'confirmed'
+    | 'active'
+    | 'completed'
+    | 'expired'
+    | 'cancelled'
+    | 'no_show';
   created_at: string;
 }
 

--- a/parkhub-web/src/components/nav/SidebarV3.test.tsx
+++ b/parkhub-web/src/components/nav/SidebarV3.test.tsx
@@ -4,6 +4,15 @@
  * The component is intentionally stateful and data-driven, so the test
  * surface here stays narrow: verify the focus shell renders on empty data
  * and that the live-pass card appears for an active booking.
+ *
+ * Note on timing: the GitHub Actions hosted runners are consistently slower
+ * at transforming + executing this 1300-line component than the local dev
+ * machine. Two hardening moves keep this suite reliable in CI:
+ *   - Static top-level import (vs. per-test `await import(...)`) so the
+ *     component is parsed exactly once and react-router + phosphor-icons
+ *     don't pay the Vite transform tax inside every `it` block.
+ *   - 15 s waitFor timeout to absorb CI variance when the render pipeline
+ *     queues behind other suites running in parallel.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -38,9 +47,16 @@ vi.mock('../../context/AuthContext', () => ({
   }),
 }));
 
+// Static import — depends on `vi.mock` hoisting by Vitest, not runtime
+// dynamic import. This cuts ~8 s of redundant Vite transform per `it` block
+// in CI while keeping the mock graph correct.
+import { SidebarV3 } from './SidebarV3';
+
 function ok<T>(data: T) {
   return Promise.resolve({ success: true, data } as const);
 }
+
+const WAIT_FOR_OPTS = { timeout: 15_000 } as const;
 
 describe('SidebarV3', () => {
   beforeEach(() => {
@@ -54,8 +70,6 @@ describe('SidebarV3', () => {
     getLotsMock.mockReturnValue(ok<ParkingLot[]>([]));
     getLotSlotsMock.mockReturnValue(ok<ParkingSlot[]>([]));
 
-    const { SidebarV3 } = await import('./SidebarV3');
-
     render(
       <MemoryRouter>
         <SidebarV3 />
@@ -64,11 +78,11 @@ describe('SidebarV3', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/No active booking/i)).toBeInTheDocument();
-    });
+    }, WAIT_FOR_OPTS);
     expect(screen.getByText(/Book now/i)).toBeInTheDocument();
     expect(screen.getByText('Today')).toBeInTheDocument();
     expect(screen.getByText('Book')).toBeInTheDocument();
-  });
+  }, 20_000);
 
   it('renders the Live Pass card for an active booking', async () => {
     const now = new Date();
@@ -100,8 +114,6 @@ describe('SidebarV3', () => {
     getLotsMock.mockReturnValue(ok<ParkingLot[]>([lot]));
     getLotSlotsMock.mockReturnValue(ok<ParkingSlot[]>([]));
 
-    const { SidebarV3 } = await import('./SidebarV3');
-
     render(
       <MemoryRouter>
         <SidebarV3 />
@@ -110,8 +122,8 @@ describe('SidebarV3', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Parked')).toBeInTheDocument();
-    });
+    }, WAIT_FOR_OPTS);
     expect(screen.getByText(/M-AB 7823/)).toBeInTheDocument();
     expect(screen.getByText('Show QR')).toBeInTheDocument();
-  });
+  }, 20_000);
 });

--- a/parkhub-web/src/design-v5/screens/Gaestepass.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Gaestepass.test.tsx
@@ -49,6 +49,13 @@ const GUEST_ACTIVE = {
   status: 'active' as const, created_at: '2026-04-22T10:00:00Z',
 };
 const GUEST_EXPIRED = { ...GUEST_ACTIVE, id: 'g2', guest_code: 'XYZ999', status: 'expired' as const };
+const GUEST_CONFIRMED = { ...GUEST_ACTIVE, id: 'g3', guest_code: 'CNF456', status: 'confirmed' as const };
+const GUEST_PENDING = { ...GUEST_ACTIVE, id: 'g4', guest_code: 'PND789', status: 'pending' as const };
+const GUEST_COMPLETED = { ...GUEST_ACTIVE, id: 'g5', guest_code: 'CMP321', status: 'completed' as const };
+const GUEST_NOSHOW = { ...GUEST_ACTIVE, id: 'g6', guest_code: 'NSW654', status: 'no_show' as const };
+
+const SLOT_A1 = { id: 's1', lot_id: 'lot-1', slot_number: 'A1', status: 'available' };
+const SLOT_A2 = { id: 's2', lot_id: 'lot-1', slot_number: 'A2', status: 'available' };
 
 describe('GaestepassV5', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -120,5 +127,70 @@ describe('GaestepassV5', () => {
     fireEvent.click(screen.getByTestId('open-create-guest'));
     expect(screen.getByTestId('guest-name')).toBeInTheDocument();
     expect(screen.getByTestId('guest-lot')).toBeInTheDocument();
+  });
+
+  it('renders confirmed status with Storno action (newly created Rust pass)', async () => {
+    // Regression for PR #374: Rust creates guest bookings with
+    // `BookingStatus::Confirmed`, so `confirmed` must map to a visible
+    // badge and the cancel button must still be shown.
+    mockGetGuests.mockResolvedValue({ success: true, data: [GUEST_CONFIRMED] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('guest-row')).toBeInTheDocument());
+    expect(screen.getByText('Bestätigt')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-g3')).toBeInTheDocument();
+  });
+
+  it('renders all backend BookingStatus variants with distinct labels', async () => {
+    mockGetGuests.mockResolvedValue({
+      success: true,
+      data: [GUEST_PENDING, GUEST_CONFIRMED, GUEST_ACTIVE, GUEST_COMPLETED, GUEST_EXPIRED, GUEST_NOSHOW],
+    });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('guest-row')).toHaveLength(6));
+    expect(screen.getByText('Ausstehend')).toBeInTheDocument();
+    expect(screen.getByText('Bestätigt')).toBeInTheDocument();
+    expect(screen.getAllByText(/Aktiv/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Abgeschlossen')).toBeInTheDocument();
+    expect(screen.getByText('Abgelaufen')).toBeInTheDocument();
+    expect(screen.getByText('Nicht erschienen')).toBeInTheDocument();
+  });
+
+  it('treats confirmed/pending/active as "open" for active count and Storno affordance', async () => {
+    mockGetGuests.mockResolvedValue({
+      success: true,
+      data: [GUEST_PENDING, GUEST_CONFIRMED, GUEST_ACTIVE, GUEST_EXPIRED],
+    });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('guest-row')).toHaveLength(4));
+    // 3 open (pending, confirmed, active) → 3 Storno buttons.
+    expect(screen.getByTestId('cancel-g4')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-g3')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-g1')).toBeInTheDocument();
+    // Expired → no button.
+    expect(screen.queryByTestId('cancel-g2')).toBeNull();
+    // Active-count badge shows 3 (pending + confirmed + active).
+    expect(screen.getByText('3 aktiv')).toBeInTheDocument();
+  });
+
+  it('renders slot dropdown labels from slot_number (not s.number)', async () => {
+    // Regression for PR #374: ParkingSlot has `slot_number`, not `number`.
+    // The previous code rendered blank <option> labels at runtime.
+    mockGetGuests.mockResolvedValue({ success: true, data: [] });
+    mockGetLots.mockResolvedValue({ success: true, data: [LOT] });
+    mockGetSlots.mockResolvedValue({ success: true, data: [SLOT_A1, SLOT_A2] });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('open-create-guest')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('open-create-guest'));
+    // Select lot to trigger slot fetch.
+    fireEvent.change(screen.getByTestId('guest-lot'), { target: { value: 'lot-1' } });
+    await waitFor(() => {
+      const slotSelect = screen.getByTestId('guest-slot') as HTMLSelectElement;
+      const labels = Array.from(slotSelect.options).map((o) => o.textContent);
+      expect(labels).toContain('A1');
+      expect(labels).toContain('A2');
+    });
   });
 });

--- a/parkhub-web/src/design-v5/screens/Gaestepass.tsx
+++ b/parkhub-web/src/design-v5/screens/Gaestepass.tsx
@@ -12,18 +12,39 @@ import {
 } from '../../api/client';
 import type { ScreenId } from '../nav';
 
+// Backend (Rust `BookingStatus`, PHP `Booking::STATUS_*`) can return the full
+// booking status enum for guest passes. Rust creates fresh guest bookings with
+// `BookingStatus::Confirmed`, so `confirmed` is the most common newly-created
+// status. `pending`, `completed` and `no_show` are rare but legal, and we map
+// them to sensible visual fallbacks so the row is never blank.
 const STATUS_LABEL: Record<GuestBooking['status'], string> = {
+  pending: 'Ausstehend',
+  confirmed: 'Bestätigt',
   active: 'Aktiv',
+  completed: 'Abgeschlossen',
   expired: 'Abgelaufen',
   cancelled: 'Storniert',
+  no_show: 'Nicht erschienen',
 };
 
 function statusVariant(s: GuestBooking['status']) {
   switch (s) {
+    case 'pending': return 'warning' as const;
+    case 'confirmed': return 'info' as const;
     case 'active': return 'success' as const;
+    case 'completed': return 'gray' as const;
     case 'expired': return 'gray' as const;
     case 'cancelled': return 'error' as const;
+    case 'no_show': return 'error' as const;
   }
+}
+
+// A guest pass is "open" (pre-use or in-use) when it is still actionable from
+// the user's perspective — fresh passes land in `confirmed`, then flip to
+// `active` while the time window is open. Both states should count as active
+// and expose the Storno action.
+function isOpenStatus(s: GuestBooking['status']): boolean {
+  return s === 'confirmed' || s === 'active' || s === 'pending';
 }
 
 function formatRange(start: string, end: string): string {
@@ -135,7 +156,7 @@ function CreateGuestModal({
             <select value={slotId} onChange={(e) => setSlotId(e.target.value)} disabled={!lotId} style={inputStyle} data-testid="guest-slot">
               <option value="">{lotId ? 'Bitte wählen…' : 'Erst Parkhaus wählen'}</option>
               {availableSlots.map((s) => (
-                <option key={s.id} value={s.id}>{s.number}</option>
+                <option key={s.id} value={s.id}>{s.slot_number}</option>
               ))}
             </select>
           </Field>
@@ -242,7 +263,7 @@ export function GaestepassV5({ navigate: _navigate }: { navigate: (id: ScreenId)
 
   const bookings: GuestBooking[] = bookingsQuery.data ?? [];
   const lots: ParkingLot[] = lotsQuery.data ?? [];
-  const activeCount = useMemo(() => bookings.filter((b) => b.status === 'active').length, [bookings]);
+  const activeCount = useMemo(() => bookings.filter((b) => isOpenStatus(b.status)).length, [bookings]);
 
   function copyCode(code: string) {
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
@@ -404,7 +425,7 @@ export function GaestepassV5({ navigate: _navigate }: { navigate: (id: ScreenId)
                     <Badge variant={statusVariant(b.status)} dot>{STATUS_LABEL[b.status]}</Badge>
                     <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatRange(b.start_time, b.end_time)}</span>
                   </div>
-                  {b.status === 'active' ? (
+                  {isOpenStatus(b.status) ? (
                     <button
                       type="button"
                       disabled={isCancelling}

--- a/parkhub-web/src/design-v5/screens/Rangliste.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.test.tsx
@@ -74,9 +74,32 @@ describe('RanglisteV5', () => {
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('surfaces error when stats success:false', async () => {
-    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+  it('renders leaderboard with empty stats when admin stats are forbidden (non-admin)', async () => {
+    // Regression for PR #374: `/api/v1/admin/stats` is admin-gated in the Rust
+    // backend (`check_admin`), but /rangliste is reachable by normal users.
+    // FORBIDDEN must degrade gracefully, not hard-fail the screen.
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE, TEAM_BOB] });
     mockGetAdminStats.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('rank-row')).toHaveLength(2));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+    // Alice/Bob names may appear both in the highlight cards and the leaderboard
+    // rows, so assert on presence via getAllByText.
+    expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
+  });
+
+  it('also degrades on HTTP_403 error code from admin stats', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+    mockGetAdminStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_403', message: 'forbidden' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('rank-row')).toHaveLength(1));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+  });
+
+  it('still surfaces error when stats fail with non-auth error', async () => {
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+    mockGetAdminStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_500', message: 'server error' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });

--- a/parkhub-web/src/design-v5/screens/Rangliste.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.test.tsx
@@ -97,6 +97,22 @@ describe('RanglisteV5', () => {
     expect(screen.queryByText('Fehler beim Laden')).toBeNull();
   });
 
+  it('also degrades when admin middleware returns raw string error (PHP RequireAdmin)', async () => {
+    // Regression for Codex #336: PHP's RequireAdmin middleware returns
+    // `{"error": "Forbidden. Administrator access required."}` — a string,
+    // not an object. requestOnce passes that string through as `res.error`,
+    // so `res.error?.code` is undefined. Screen must still degrade gracefully.
+    mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
+    mockGetAdminStats.mockResolvedValue({
+      success: false,
+      data: null,
+      error: 'Forbidden. Administrator access required.',
+    });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('rank-row')).toHaveLength(1));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+  });
+
   it('still surfaces error when stats fail with non-auth error', async () => {
     mockGetTeam.mockResolvedValue({ success: true, data: [TEAM_ALICE] });
     mockGetAdminStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_500', message: 'server error' } });

--- a/parkhub-web/src/design-v5/screens/Rangliste.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.tsx
@@ -58,11 +58,23 @@ export function RanglisteV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
     refetchOnWindowFocus: true,
   });
 
+  // Admin stats are optional decoration on the leaderboard — `/api/v1/admin/stats`
+  // is admin-gated on both the Rust (`check_admin`) and PHP (admin middleware)
+  // backends, so non-admin users predictably receive FORBIDDEN. We degrade
+  // gracefully: the leaderboard still renders with team data only, every
+  // entry falling through to EMPTY_STATS (no badges, score = 0). Network or
+  // other non-auth failures continue to be treated as hard errors so they
+  // surface in the UI.
   const statsQuery = useQuery({
     queryKey: ['admin-stats-extended'],
     queryFn: async () => {
       const res = await api.getAdminStatsExtended();
-      if (!res.success) throw new Error(res.error?.message ?? 'Statistiken konnten nicht geladen werden');
+      if (!res.success) {
+        if (res.error?.code === 'FORBIDDEN' || res.error?.code === 'HTTP_403') {
+          return null;
+        }
+        throw new Error(res.error?.message ?? 'Statistiken konnten nicht geladen werden');
+      }
       return res.data;
     },
     staleTime: 30_000,

--- a/parkhub-web/src/design-v5/screens/Rangliste.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.tsx
@@ -46,6 +46,27 @@ const EMPTY_STATS: UserBookingStats = {
 
 const MEDAL_COLOR = ['oklch(0.82 0.16 85)', 'oklch(0.72 0 0)', 'oklch(0.55 0.1 55)'];
 
+/**
+ * Admin-denial detector. Works across three possible error shapes returned by
+ * `api.getAdminStatsExtended()`:
+ *   1. Structured `{ code: 'FORBIDDEN', … }` — Rust backend
+ *   2. Structured `{ code: 'HTTP_403', … }` — requestOnce fallback when
+ *      `json.error` was absent or non-object-with-code
+ *   3. Raw string `"Forbidden. Administrator access required."` — PHP
+ *      `RequireAdmin` middleware returns `{"error": "…"}`; requestOnce passes
+ *      the string straight through as `res.error`.
+ */
+function isForbiddenError(err: unknown): boolean {
+  if (typeof err === 'string') {
+    return /forbidden|administrator access/i.test(err);
+  }
+  if (err && typeof err === 'object') {
+    const code = (err as { code?: unknown }).code;
+    return code === 'FORBIDDEN' || code === 'HTTP_403';
+  }
+  return false;
+}
+
 export function RanglisteV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
   const teamQuery = useQuery({
     queryKey: ['team-members'],
@@ -70,10 +91,13 @@ export function RanglisteV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
     queryFn: async () => {
       const res = await api.getAdminStatsExtended();
       if (!res.success) {
-        if (res.error?.code === 'FORBIDDEN' || res.error?.code === 'HTTP_403') {
+        if (isForbiddenError(res.error)) {
           return null;
         }
-        throw new Error(res.error?.message ?? 'Statistiken konnten nicht geladen werden');
+        const message = typeof res.error === 'string'
+          ? res.error
+          : res.error?.message ?? 'Statistiken konnten nicht geladen werden';
+        throw new Error(message);
       }
       return res.data;
     },

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.test.tsx
@@ -42,8 +42,27 @@ describe('VorhersagenV5', () => {
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('surfaces error when success:false', async () => {
+  it('renders fallback 7-day forecast when admin stats are forbidden (non-admin)', async () => {
+    // Regression for PR #374: `/api/v1/admin/stats` is admin-gated; non-admin
+    // users must see the deterministic weekday/weekend fallback instead of a
+    // blocking error page.
     mockGetStats.mockResolvedValue({ success: false, data: null, error: { code: 'FORBIDDEN', message: 'denied' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('day-card')).toHaveLength(7));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+    // Fallback confidence is 40% on every day when no historical data arrived.
+    expect(screen.getAllByText(/40% Konfidenz/).length).toBe(7);
+  });
+
+  it('also degrades on HTTP_403 error code from admin stats', async () => {
+    mockGetStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_403', message: 'forbidden' } });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('day-card')).toHaveLength(7));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+  });
+
+  it('still surfaces error when stats fail with non-auth error', async () => {
+    mockGetStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_500', message: 'server error' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.test.tsx
@@ -61,6 +61,20 @@ describe('VorhersagenV5', () => {
     expect(screen.queryByText('Fehler beim Laden')).toBeNull();
   });
 
+  it('also degrades when admin middleware returns raw string error (PHP RequireAdmin)', async () => {
+    // Regression for Codex #336: PHP RequireAdmin returns
+    // `{"error": "Forbidden. Administrator access required."}` — string, not
+    // object. `res.error?.code` is undefined; screen must still fall back.
+    mockGetStats.mockResolvedValue({
+      success: false,
+      data: null,
+      error: 'Forbidden. Administrator access required.',
+    });
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('day-card')).toHaveLength(7));
+    expect(screen.queryByText('Fehler beim Laden')).toBeNull();
+  });
+
   it('still surfaces error when stats fail with non-auth error', async () => {
     mockGetStats.mockResolvedValue({ success: false, data: null, error: { code: 'HTTP_500', message: 'server error' } });
     renderScreen();

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
@@ -62,11 +62,22 @@ function fallbackPrediction(idx: number): { predicted: number; peakHour: number;
 }
 
 export function VorhersagenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
+  // Admin stats are optional inputs — `/api/v1/admin/stats` is admin-gated on
+  // both the Rust (`check_admin`) and PHP (admin middleware) backends. Non-admin
+  // users predictably receive FORBIDDEN; in that case we degrade gracefully
+  // and let the deterministic weekday/weekend fallback drive the forecast
+  // (confidence = 40%). Network or other non-auth failures continue to surface
+  // as hard errors.
   const statsQuery = useQuery({
     queryKey: ['admin-stats-forecast'],
     queryFn: async () => {
       const res = await api.getAdminStatsExtended();
-      if (!res.success) throw new Error(res.error?.message ?? 'Vorhersagen konnten nicht geladen werden');
+      if (!res.success) {
+        if (res.error?.code === 'FORBIDDEN' || res.error?.code === 'HTTP_403') {
+          return null;
+        }
+        throw new Error(res.error?.message ?? 'Vorhersagen konnten nicht geladen werden');
+      }
       return res.data;
     },
     staleTime: 60_000,

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
@@ -61,6 +61,23 @@ function fallbackPrediction(idx: number): { predicted: number; peakHour: number;
   return { predicted: 20, peakHour: 10, offPeakHour: 7 };
 }
 
+/**
+ * Admin-denial detector shared with Rangliste. Works across three error shapes:
+ * structured `{code:'FORBIDDEN'}` (Rust), `{code:'HTTP_403'}` (requestOnce
+ * fallback), and raw string `"Forbidden. Administrator access required."`
+ * (PHP RequireAdmin middleware).
+ */
+function isForbiddenError(err: unknown): boolean {
+  if (typeof err === 'string') {
+    return /forbidden|administrator access/i.test(err);
+  }
+  if (err && typeof err === 'object') {
+    const code = (err as { code?: unknown }).code;
+    return code === 'FORBIDDEN' || code === 'HTTP_403';
+  }
+  return false;
+}
+
 export function VorhersagenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
   // Admin stats are optional inputs — `/api/v1/admin/stats` is admin-gated on
   // both the Rust (`check_admin`) and PHP (admin middleware) backends. Non-admin
@@ -73,10 +90,13 @@ export function VorhersagenV5({ navigate: _navigate }: { navigate: (id: ScreenId
     queryFn: async () => {
       const res = await api.getAdminStatsExtended();
       if (!res.success) {
-        if (res.error?.code === 'FORBIDDEN' || res.error?.code === 'HTTP_403') {
+        if (isForbiddenError(res.error)) {
           return null;
         }
-        throw new Error(res.error?.message ?? 'Vorhersagen konnten nicht geladen werden');
+        const message = typeof res.error === 'string'
+          ? res.error
+          : res.error?.message ?? 'Vorhersagen konnten nicht geladen werden';
+        throw new Error(message);
       }
       return res.data;
     },


### PR DESCRIPTION
## Summary

Mirror of nash87/parkhub-rust#374 against the PHP Wave 3 Fleet screens shipped in #333.

The PHP tree carried the exact same four bugs — the screens were ported verbatim between the two trees — so the fix is a direct port of the reviewed rust patches to keep the trees in lock-step.

- **Rangliste / Vorhersagen**: `/api/v1/admin/stats` is `admin` middleware-gated (`routes/api.php`); non-admin users on these screens used to hit a blocking error. They now degrade gracefully — the leaderboard renders with empty-stats fallback, the forecast falls through to deterministic weekday/weekend values. Non-auth failures still surface as hard errors.
- **GuestBooking.status**: expanded the client TypeScript union to the full backend `Booking::STATUS_*` set (`pending | confirmed | active | completed | expired | cancelled | no_show`). `GuestBookingController` creates passes with `STATUS_CONFIRMED`, so the prior 3-variant union broke badge rendering and the Storno affordance for fresh records.
- **Gaestepass**: slot dropdown labels now render from `slot_number` instead of the non-existent `number`, fixing blank option labels.

## Test plan

- [x] `npm run test` targeted at touched screens + `src/api/client.test.ts` — 119 pass locally (see commit body)
- [ ] CI green on PR
- [ ] Codex review passes cleanly (rust review threads from #374 will auto-apply here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)