### PR TITLE
fix(v5): admin-nav screens use admin APIs (mirror rust #376)

### DIFF
--- a/parkhub-web/src/api/client.ts
+++ b/parkhub-web/src/api/client.ts
@@ -371,6 +371,15 @@ export const api = {
   adminUpdateSettings: (data: Record<string, string>) =>
     request('/api/v1/admin/settings', { method: 'PUT', body: JSON.stringify(data) }),
 
+  // ── Admin Cost-Center Billing (routes/modules/cost_center.php) ──
+  // Admin-only aggregates for tenant-wide finance reporting. The v5 Billing
+  // screen surfaces these instead of the personal `/payments/history` feed.
+  // PHP gate: `admin` middleware + `module:cost_center` guard.
+  adminBillingByCostCenter: () =>
+    request<AdminCostCenterSummary[]>('/api/v1/admin/billing/by-cost-center'),
+  adminBillingByDepartment: () =>
+    request<AdminDepartmentSummary[]>('/api/v1/admin/billing/by-department'),
+
   // ── Admin Modules (T-1720 v2 — runtime enable/disable) ──
   patchModule: (name: string, runtime_enabled: boolean) =>
     request<ModuleInfo>(`/api/v1/admin/modules/${encodeURIComponent(name)}`, {
@@ -964,6 +973,33 @@ export interface PaymentHistoryEntry {
 export interface StripeConfigResponse {
   publishable_key?: string;
   configured: boolean;
+}
+
+/**
+ * Admin cost-center billing aggregate — matches the PHP
+ * `BillingController::byCostCenter` response shape (routes/modules/cost_center.php).
+ * Amount is in whole currency units (float), not cents.
+ */
+export interface AdminCostCenterSummary {
+  cost_center: string;
+  department: string;
+  user_count: number;
+  total_bookings: number;
+  total_credits_used: number;
+  total_amount: number;
+  currency: string;
+}
+
+/**
+ * Admin department billing aggregate — matches `BillingController::byDepartment`.
+ */
+export interface AdminDepartmentSummary {
+  department: string;
+  user_count: number;
+  total_bookings: number;
+  total_credits_used: number;
+  total_amount: number;
+  currency: string;
 }
 
 export interface UserStats {

--- a/parkhub-web/src/design-v5/screens/Benachrichtigungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Benachrichtigungen.test.tsx
@@ -2,14 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+// v5 Benachrichtigungen is an admin-nav entry — it broadcasts
+// system-wide announcements to the whole tenant. It must call the
+// /api/v1/admin/announcements endpoints, NOT the per-user notification
+// inbox (that feed is surfaced by the bell dropdown + NotificationCenter).
 const mockList = vi.fn();
-const mockRead = vi.fn();
-const mockReadAll = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
 vi.mock('../../api/client', () => ({
   api: {
-    getNotifications: (...a: unknown[]) => mockList(...a),
-    markNotificationRead: (...a: unknown[]) => mockRead(...a),
-    markAllNotificationsRead: (...a: unknown[]) => mockReadAll(...a),
+    adminListAnnouncements: (...a: unknown[]) => mockList(...a),
+    adminCreateAnnouncement: (...a: unknown[]) => mockCreate(...a),
+    adminUpdateAnnouncement: (...a: unknown[]) => mockUpdate(...a),
+    adminDeleteAnnouncement: (...a: unknown[]) => mockDelete(...a),
   },
 }));
 
@@ -25,8 +31,14 @@ vi.mock('../Toast', () => ({
 
 import { BenachrichtigungenV5 } from './Benachrichtigungen';
 
-const N1 = { id: 'n1', title: 'Neue Buchung', message: 'Platz A3', notification_type: 'booking', read: false, created_at: '2026-04-23T10:00:00Z' };
-const N2 = { id: 'n2', title: 'Tauschanfrage', message: 'Swap', notification_type: 'swap', read: true, created_at: '2026-04-22T10:00:00Z' };
+const A1 = {
+  id: 'a1', title: 'Wartung 1. Mai', message: 'Lot 3 geschlossen',
+  severity: 'warning', active: true, created_at: '2026-04-23T10:00:00Z',
+};
+const A2 = {
+  id: 'a2', title: 'Alte Info', message: 'Ignorieren',
+  severity: 'info', active: false, created_at: '2026-04-10T10:00:00Z',
+};
 
 function renderScreen() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -37,13 +49,13 @@ function renderScreen() {
   );
 }
 
-describe('BenachrichtigungenV5', () => {
+describe('BenachrichtigungenV5 (admin)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('renders empty state', async () => {
     mockList.mockResolvedValue({ success: true, data: [] });
     renderScreen();
-    await waitFor(() => expect(screen.getByText('Keine Benachrichtigungen')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Keine Ankündigungen')).toBeInTheDocument());
   });
 
   it('renders error when query fails', async () => {
@@ -52,51 +64,52 @@ describe('BenachrichtigungenV5', () => {
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('renders rows and shows unread count', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
+  it('renders one row per announcement with active + inactive badges', async () => {
+    mockList.mockResolvedValue({ success: true, data: [A1, A2] });
     renderScreen();
     await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(2));
-    expect(screen.getByText('1 ungelesen')).toBeInTheDocument();
+    expect(screen.getByText('Wartung 1. Mai')).toBeInTheDocument();
+    expect(screen.getByText('Alte Info')).toBeInTheDocument();
   });
 
-  it('filters to unread only', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
+  it('creates a new announcement via adminCreateAnnouncement', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    mockCreate.mockResolvedValue({ success: true, data: { ...A1, id: 'a-new' } });
     renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(2));
-    fireEvent.click(screen.getByRole('button', { name: 'Ungelesen' }));
-    await waitFor(() => expect(screen.getAllByTestId('benach-row')).toHaveLength(1));
-  });
-
-  it('mark-read mutation fires for individual item', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1] });
-    mockRead.mockResolvedValue({ success: true, data: null });
-    renderScreen();
-    await waitFor(() => expect(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren')).toBeInTheDocument());
-    fireEvent.click(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren'));
+    await waitFor(() => expect(screen.getByTestId('benach-new-title')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('benach-new-title'), { target: { value: 'Neu' } });
+    fireEvent.change(screen.getByTestId('benach-new-message'), { target: { value: 'Hallo Team' } });
+    fireEvent.click(screen.getByTestId('benach-new-submit'));
     await waitFor(() => {
-      expect(mockRead).toHaveBeenCalledWith('n1');
-      expect(mockToast).toHaveBeenCalledWith('Als gelesen markiert', 'success');
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Neu',
+        message: 'Hallo Team',
+        active: true,
+      }));
+      expect(mockToast).toHaveBeenCalledWith('Ankündigung erstellt', 'success');
     });
   });
 
-  it('mark-read error surfaces via toast', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1] });
-    mockRead.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'fail' } });
+  it('surfaces create error when success:false', async () => {
+    mockList.mockResolvedValue({ success: true, data: [] });
+    mockCreate.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'fail' } });
     renderScreen();
-    await waitFor(() => expect(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren')).toBeInTheDocument());
-    fireEvent.click(screen.getByLabelText('Benachrichtigung n1 als gelesen markieren'));
+    await waitFor(() => expect(screen.getByTestId('benach-new-title')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('benach-new-title'), { target: { value: 'x' } });
+    fireEvent.change(screen.getByTestId('benach-new-message'), { target: { value: 'y' } });
+    fireEvent.click(screen.getByTestId('benach-new-submit'));
     await waitFor(() => expect(mockToast).toHaveBeenCalledWith('fail', 'error'));
   });
 
-  it('mark-all button calls markAllNotificationsRead', async () => {
-    mockList.mockResolvedValue({ success: true, data: [N1, N2] });
-    mockReadAll.mockResolvedValue({ success: true, data: null });
+  it('deletes an announcement via adminDeleteAnnouncement', async () => {
+    mockList.mockResolvedValue({ success: true, data: [A1] });
+    mockDelete.mockResolvedValue({ success: true, data: null });
     renderScreen();
-    await waitFor(() => expect(screen.getByTestId('benach-mark-all')).toBeInTheDocument());
-    fireEvent.click(screen.getByTestId('benach-mark-all'));
+    await waitFor(() => expect(screen.getByLabelText('Ankündigung a1 löschen')).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText('Ankündigung a1 löschen'));
     await waitFor(() => {
-      expect(mockReadAll).toHaveBeenCalled();
-      expect(mockToast).toHaveBeenCalledWith('Alle als gelesen markiert', 'success');
+      expect(mockDelete).toHaveBeenCalledWith('a1');
+      expect(mockToast).toHaveBeenCalledWith('Ankündigung gelöscht', 'success');
     });
   });
 });

--- a/parkhub-web/src/design-v5/screens/Benachrichtigungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Benachrichtigungen.tsx
@@ -1,18 +1,35 @@
 import { useState } from 'react';
 import NumberFlow from '@number-flow/react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Badge, Card, V5NamedIcon } from '../primitives';
+import { Badge, Card, V5NamedIcon, type BadgeVariant } from '../primitives';
 import { useV5Toast } from '../Toast';
-import { api, type Notification } from '../../api/client';
+import { api, type Announcement } from '../../api/client';
 import type { ScreenId } from '../nav';
 
-type FilterKey = 'alle' | 'ungelesen' | 'gelesen';
+/**
+ * Benachrichtigungen — admin view of tenant-wide announcements.
+ *
+ * This screen is the admin authoring surface for the broadcast banner
+ * that surfaces to every user via the bell dropdown + top banner. It
+ * talks to `/api/v1/admin/announcements` (list/create/delete), NOT the
+ * per-user notification inbox which is surfaced elsewhere.
+ *
+ * Codex #376: the v5 draft shipped this admin-nav entry wired to
+ * `getNotifications` / `markNotificationRead`, so admins could only
+ * read-state their own alerts and had no way to compose or retire a
+ * system-wide announcement from the new shell.
+ */
 
-const FILTERS: { key: FilterKey; label: string }[] = [
-  { key: 'alle', label: 'Alle' },
-  { key: 'ungelesen', label: 'Ungelesen' },
-  { key: 'gelesen', label: 'Gelesen' },
-];
+function severityVariant(sev: string): BadgeVariant {
+  switch (sev) {
+    case 'critical': return 'error';
+    case 'warning': return 'warning';
+    case 'success': return 'success';
+    case 'info':
+    default:
+      return 'info';
+  }
+}
 
 function formatWhen(iso: string): string {
   return new Date(iso).toLocaleString('de-DE', {
@@ -21,53 +38,66 @@ function formatWhen(iso: string): string {
   });
 }
 
+const SEVERITIES: { value: string; label: string }[] = [
+  { value: 'info', label: 'Info' },
+  { value: 'success', label: 'Erfolg' },
+  { value: 'warning', label: 'Warnung' },
+  { value: 'critical', label: 'Kritisch' },
+];
+
 export function BenachrichtigungenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
   const toast = useV5Toast();
   const qc = useQueryClient();
-  const [filter, setFilter] = useState<FilterKey>('alle');
 
   const { data: items = [], isLoading, isError } = useQuery({
-    queryKey: ['benachrichtigungen'],
+    queryKey: ['admin-announcements'],
     queryFn: async () => {
-      const res = await api.getNotifications();
-      if (!res.success) throw new Error(res.error?.message ?? 'Benachrichtigungen konnten nicht geladen werden');
+      const res = await api.adminListAnnouncements();
+      if (!res.success) throw new Error(res.error?.message ?? 'Ankündigungen konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
   });
 
-  const markRead = useMutation({
-    mutationFn: async (id: string) => {
-      const res = await api.markNotificationRead(id);
-      if (!res.success) throw new Error(res.error?.message ?? 'Markieren fehlgeschlagen');
-      return res.data;
-    },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['benachrichtigungen'] });
-      toast('Als gelesen markiert', 'success');
-    },
-    onError: (err: Error) => toast(err.message || 'Markieren fehlgeschlagen', 'error'),
-  });
+  const [title, setTitle] = useState('');
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState('info');
+  const [active, setActive] = useState(true);
 
-  const markAll = useMutation({
+  const createMutation = useMutation({
     mutationFn: async () => {
-      const res = await api.markAllNotificationsRead();
-      if (!res.success) throw new Error(res.error?.message ?? 'Aktion fehlgeschlagen');
+      const res = await api.adminCreateAnnouncement({
+        title: title.trim(),
+        message: message.trim(),
+        severity,
+        active,
+      });
+      if (!res.success) throw new Error(res.error?.message ?? 'Erstellen fehlgeschlagen');
       return res.data;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['benachrichtigungen'] });
-      toast('Alle als gelesen markiert', 'success');
+      qc.invalidateQueries({ queryKey: ['admin-announcements'] });
+      setTitle('');
+      setMessage('');
+      toast('Ankündigung erstellt', 'success');
     },
-    onError: (err: Error) => toast(err.message || 'Aktion fehlgeschlagen', 'error'),
+    onError: (err: Error) => toast(err.message || 'Erstellen fehlgeschlagen', 'error'),
   });
 
-  const filtered = items.filter((n: Notification) => {
-    if (filter === 'ungelesen') return !n.read;
-    if (filter === 'gelesen') return n.read;
-    return true;
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.adminDeleteAnnouncement(id);
+      if (!res.success) throw new Error(res.error?.message ?? 'Löschen fehlgeschlagen');
+      return res.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin-announcements'] });
+      toast('Ankündigung gelöscht', 'success');
+    },
+    onError: (err: Error) => toast(err.message || 'Löschen fehlgeschlagen', 'error'),
   });
-  const unreadCount = items.filter((n) => !n.read).length;
+
+  const activeCount = items.filter((a: Announcement) => a.active).length;
 
   if (isLoading) {
     return (
@@ -94,88 +124,133 @@ export function BenachrichtigungenV5({ navigate: _navigate }: { navigate: (id: S
     <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Benachrichtigungen</span>
+          <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Ankündigungen</span>
           <Badge variant="gray"><NumberFlow value={items.length} /></Badge>
-          {unreadCount > 0 && <Badge variant="primary" dot>{unreadCount} ungelesen</Badge>}
+          {activeCount > 0 && <Badge variant="primary" dot>{activeCount} aktiv</Badge>}
         </div>
-        <button
-          type="button"
-          disabled={unreadCount === 0 || markAll.isPending}
-          onClick={() => markAll.mutate()}
-          data-testid="benach-mark-all"
+      </div>
+
+      <Card className="v5-ani" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10, animationDelay: '0.06s' }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>Neue Ankündigung</div>
+        <input
+          data-testid="benach-new-title"
+          type="text"
+          placeholder="Titel"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
           style={{
-            padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
-            border: 'none', fontSize: 11, fontWeight: 600,
-            cursor: unreadCount > 0 && !markAll.isPending ? 'pointer' : 'not-allowed',
-            opacity: unreadCount > 0 && !markAll.isPending ? 1 : 0.5,
+            padding: '8px 11px', borderRadius: 9, background: 'var(--v5-sur2)',
+            border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12,
+            width: '100%', outline: 'none', boxSizing: 'border-box', fontFamily: 'inherit',
           }}
-        >
-          Alle als gelesen
-        </button>
-      </div>
+        />
+        <textarea
+          data-testid="benach-new-message"
+          placeholder="Nachricht"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          rows={3}
+          style={{
+            padding: '8px 11px', borderRadius: 9, background: 'var(--v5-sur2)',
+            border: '1px solid var(--v5-bor)', color: 'var(--v5-txt)', fontSize: 12,
+            width: '100%', outline: 'none', boxSizing: 'border-box', fontFamily: 'inherit',
+            resize: 'vertical',
+          }}
+        />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          <div role="group" aria-label="Priorität" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {SEVERITIES.map((s) => {
+              const selected = severity === s.value;
+              return (
+                <button
+                  key={s.value} type="button" aria-pressed={selected}
+                  onClick={() => setSeverity(s.value)}
+                  style={{
+                    padding: '5px 12px', borderRadius: 999, fontSize: 11, fontWeight: 500, cursor: 'pointer',
+                    border: `1.5px solid ${selected ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
+                    background: selected ? 'var(--v5-acc-muted)' : 'transparent',
+                    color: selected ? 'var(--v5-acc)' : 'var(--v5-mut)',
+                  }}
+                >{s.label}</button>
+              );
+            })}
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--v5-mut)' }}>
+            <input
+              type="checkbox"
+              checked={active}
+              onChange={(e) => setActive(e.target.checked)}
+              data-testid="benach-new-active"
+            />
+            Aktiv
+          </label>
+          <div style={{ flex: 1 }} />
+          <button
+            type="button"
+            disabled={!title.trim() || !message.trim() || createMutation.isPending}
+            onClick={() => createMutation.mutate()}
+            data-testid="benach-new-submit"
+            style={{
+              padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+              border: 'none', fontSize: 11, fontWeight: 600,
+              cursor: (!title.trim() || !message.trim() || createMutation.isPending) ? 'not-allowed' : 'pointer',
+              opacity: (!title.trim() || !message.trim() || createMutation.isPending) ? 0.5 : 1,
+            }}
+          >
+            {createMutation.isPending ? 'Erstellt …' : 'Senden'}
+          </button>
+        </div>
+      </Card>
 
-      <div className="v5-ani" role="group" aria-label="Filter" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', animationDelay: '0.06s' }}>
-        {FILTERS.map((f) => {
-          const active = filter === f.key;
-          return (
-            <button
-              key={f.key} type="button" aria-pressed={active} onClick={() => setFilter(f.key)}
-              style={{
-                padding: '5px 12px', borderRadius: 999, fontSize: 11, fontWeight: 500, cursor: 'pointer',
-                border: `1.5px solid ${active ? 'var(--v5-acc)' : 'var(--v5-bor)'}`,
-                background: active ? 'var(--v5-acc-muted)' : 'transparent',
-                color: active ? 'var(--v5-acc)' : 'var(--v5-mut)',
-              }}
-            >{f.label}</button>
-          );
-        })}
-      </div>
-
-      {filtered.length === 0 ? (
+      {items.length === 0 ? (
         <Card className="v5-ani" style={{ padding: 36, textAlign: 'center', animationDelay: '0.12s' }}>
           <V5NamedIcon name="bell" size={20} color="var(--v5-mut)" />
-          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Benachrichtigungen</div>
+          <div style={{ marginTop: 10, fontWeight: 600, color: 'var(--v5-txt)' }}>Keine Ankündigungen</div>
+          <div style={{ fontSize: 12, color: 'var(--v5-mut)', marginTop: 4 }}>
+            Erstelle oben eine neue Ankündigung für das gesamte Team.
+          </div>
         </Card>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {filtered.map((n, i) => {
-            const busy = markRead.isPending && markRead.variables === n.id;
+          {items.map((a: Announcement, i: number) => {
+            const deleting = deleteMutation.isPending && deleteMutation.variables === a.id;
             return (
               <Card
-                key={n.id} data-testid="benach-row"
+                key={a.id} data-testid="benach-row"
                 className="v5-ani"
                 style={{
                   padding: 14, display: 'flex', alignItems: 'flex-start', gap: 12,
                   animationDelay: `${0.1 + i * 0.03}s`,
-                  borderLeft: n.read ? undefined : '3px solid var(--v5-acc)',
+                  borderLeft: a.active ? '3px solid var(--v5-acc)' : undefined,
+                  opacity: a.active ? 1 : 0.7,
                 }}
               >
                 <div style={{
                   width: 32, height: 32, borderRadius: 8,
-                  background: n.read ? 'var(--v5-sur2)' : 'var(--v5-acc-muted)',
+                  background: a.active ? 'var(--v5-acc-muted)' : 'var(--v5-sur2)',
                   display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
                 }}>
-                  <V5NamedIcon name="bell" size={14} color={n.read ? 'var(--v5-mut)' : 'var(--v5-acc)'} />
+                  <V5NamedIcon name="bell" size={14} color={a.active ? 'var(--v5-acc)' : 'var(--v5-mut)'} />
                 </div>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-                    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>{n.title}</span>
-                    <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatWhen(n.created_at)}</span>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--v5-txt)' }}>{a.title}</span>
+                    <Badge variant={severityVariant(a.severity)} dot>{a.severity}</Badge>
+                    {!a.active && <Badge variant="gray">Inaktiv</Badge>}
+                    <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{formatWhen(a.created_at)}</span>
                   </div>
-                  <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>{n.message}</div>
+                  <div style={{ fontSize: 11, color: 'var(--v5-mut)', marginTop: 3 }}>{a.message}</div>
                 </div>
-                {!n.read && (
-                  <button
-                    type="button" disabled={busy}
-                    aria-label={`Benachrichtigung ${n.id} als gelesen markieren`}
-                    onClick={() => markRead.mutate(n.id)}
-                    style={{
-                      padding: '4px 10px', borderRadius: 7, background: 'var(--v5-acc-muted)',
-                      border: 'none', fontSize: 10, fontWeight: 500, color: 'var(--v5-acc)',
-                      cursor: busy ? 'default' : 'pointer', opacity: busy ? 0.5 : 1, flexShrink: 0,
-                    }}
-                  >{busy ? '…' : 'Gelesen'}</button>
-                )}
+                <button
+                  type="button" disabled={deleting}
+                  aria-label={`Ankündigung ${a.id} löschen`}
+                  onClick={() => deleteMutation.mutate(a.id)}
+                  style={{
+                    padding: '4px 10px', borderRadius: 7, background: 'var(--v5-sur2)',
+                    border: '1px solid var(--v5-bor)', fontSize: 10, fontWeight: 500, color: 'var(--v5-err)',
+                    cursor: deleting ? 'default' : 'pointer', opacity: deleting ? 0.5 : 1, flexShrink: 0,
+                  }}
+                >{deleting ? '…' : 'Löschen'}</button>
               </Card>
             );
           })}

--- a/parkhub-web/src/design-v5/screens/Billing.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Billing.test.tsx
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const mockHistory = vi.fn();
+const mockCostCenter = vi.fn();
+const mockDepartment = vi.fn();
 const mockConfig = vi.fn();
 vi.mock('../../api/client', () => ({
   api: {
-    getPaymentHistory: (...a: unknown[]) => mockHistory(...a),
+    adminBillingByCostCenter: (...a: unknown[]) => mockCostCenter(...a),
+    adminBillingByDepartment: (...a: unknown[]) => mockDepartment(...a),
     getStripeConfig: (...a: unknown[]) => mockConfig(...a),
   },
 }));
@@ -17,8 +19,35 @@ vi.mock('@number-flow/react', () => ({
 
 import { BillingV5 } from './Billing';
 
-const P1 = { id: 'p-abcdefghij12345', amount: 1200, credits: 10, currency: 'EUR', status: 'completed' as const, created_at: '2026-04-01T10:00:00Z' };
-const P2 = { id: 'p-pending000000', amount: 500, credits: 5, currency: 'EUR', status: 'pending' as const, created_at: '2026-04-20T10:00:00Z' };
+// Tenant-wide billing fixtures (admin view): aggregates per cost-center and
+// per-department as returned by /api/v1/admin/billing/by-cost-center +
+// /by-department. Amount is euros (f64), NOT cents as in personal payment
+// history — that's the server-side schema from parkhub-server/src/api/billing.rs.
+const CC_ROWS = [
+  {
+    cost_center: 'CC-100', department: 'Engineering',
+    user_count: 12, total_bookings: 180,
+    total_credits_used: 1800, total_amount: 3600.50,
+    currency: 'EUR',
+  },
+  {
+    cost_center: 'CC-200', department: 'Sales',
+    user_count: 6, total_bookings: 40,
+    total_credits_used: 400, total_amount: 800.00,
+    currency: 'EUR',
+  },
+];
+
+const DEPT_ROWS = [
+  {
+    department: 'Engineering', user_count: 12, total_bookings: 180,
+    total_credits_used: 1800, total_amount: 3600.50, currency: 'EUR',
+  },
+  {
+    department: 'Sales', user_count: 6, total_bookings: 40,
+    total_credits_used: 400, total_amount: 800.00, currency: 'EUR',
+  },
+];
 
 function renderScreen() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -29,50 +58,52 @@ function renderScreen() {
   );
 }
 
-describe('BillingV5', () => {
+describe('BillingV5 (admin)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig.mockResolvedValue({ success: true, data: { configured: true } });
+    mockCostCenter.mockResolvedValue({ success: true, data: CC_ROWS });
+    mockDepartment.mockResolvedValue({ success: true, data: DEPT_ROWS });
   });
 
-  it('renders empty history message', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [] });
+  it('renders empty state when no cost centers are configured', async () => {
+    mockCostCenter.mockResolvedValue({ success: true, data: [] });
+    mockDepartment.mockResolvedValue({ success: true, data: [] });
     renderScreen();
-    await waitFor(() => expect(screen.getByText('Noch keine Zahlungen')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/keine Kostenstellen/i)).toBeInTheDocument());
   });
 
-  it('renders error state when history fails', async () => {
-    mockHistory.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
+  it('renders error state when cost-center query fails', async () => {
+    mockCostCenter.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('renders payment rows with status badges', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [P1, P2] });
+  it('renders one row per cost center', async () => {
     renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(2));
-    expect(screen.getByText('Bezahlt')).toBeInTheDocument();
-    expect(screen.getByText('Ausstehend')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(CC_ROWS.length));
+    expect(screen.getByText('CC-100')).toBeInTheDocument();
+    expect(screen.getByText('CC-200')).toBeInTheDocument();
+  });
+
+  it('shows aggregate totals across all cost centers', async () => {
+    renderScreen();
+    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(CC_ROWS.length));
+    // Total = 3600.50 + 800.00 = 4400.50 EUR
+    expect(screen.getAllByText(/4\.400,50/).length).toBeGreaterThan(0);
+    // Total bookings = 220
+    expect(screen.getAllByText(/220/).length).toBeGreaterThan(0);
+  });
+
+  it('calls the admin billing endpoints on mount (not the personal payment history)', async () => {
+    renderScreen();
+    await waitFor(() => expect(mockCostCenter).toHaveBeenCalled());
+    expect(mockDepartment).toHaveBeenCalled();
   });
 
   it('surfaces Stripe configured badge from config', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [] });
     mockConfig.mockResolvedValue({ success: true, data: { configured: false } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Nicht konfiguriert')).toBeInTheDocument());
-  });
-
-  it('computes total paid only from completed payments', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [P1, P2] });
-    renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(2));
-    // 1200 cents / EUR => 12,00 €
-    expect(screen.getAllByText(/12,00/).length).toBeGreaterThan(0);
-  });
-
-  it('renders loading skeleton initially then replaces with content', async () => {
-    mockHistory.mockResolvedValue({ success: true, data: [P1] });
-    renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('billing-row')).toHaveLength(1));
   });
 });

--- a/parkhub-web/src/design-v5/screens/Billing.tsx
+++ b/parkhub-web/src/design-v5/screens/Billing.tsx
@@ -1,36 +1,41 @@
 import NumberFlow from '@number-flow/react';
 import { useQuery } from '@tanstack/react-query';
-import { Badge, Card, V5NamedIcon, type BadgeVariant } from '../primitives';
-import { api, type PaymentHistoryEntry } from '../../api/client';
+import { Badge, Card, V5NamedIcon } from '../primitives';
+import { api, type AdminCostCenterSummary } from '../../api/client';
 import type { ScreenId } from '../nav';
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
-}
+/**
+ * Billing — admin view of tenant-wide finance.
+ *
+ * v5 mirrors the legacy `views/AdminBilling.tsx` workflow: cost-center +
+ * department aggregates from `/api/v1/admin/billing/*`, NOT the personal
+ * `/payments/history` feed (that lives on the user-facing Kredits screen).
+ *
+ * Codex #376: the v5 draft originally wired this admin-nav entry to
+ * `api.getPaymentHistory()`, which broke the tenant finance workflow
+ * (cost-center rollups + CSV export) for operators.
+ */
 
 function formatMoney(amount: number, currency: string): string {
-  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: currency || 'EUR' }).format(amount / 100);
+  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: currency || 'EUR' }).format(amount);
 }
-
-function statusVariant(s: PaymentHistoryEntry['status']): BadgeVariant {
-  switch (s) {
-    case 'completed': return 'success';
-    case 'pending': return 'warning';
-    case 'failed': return 'error';
-    default: return 'gray';
-  }
-}
-
-const STATUS_LABEL: Record<PaymentHistoryEntry['status'], string> = {
-  completed: 'Bezahlt', pending: 'Ausstehend', failed: 'Fehlgeschlagen', expired: 'Abgelaufen',
-};
 
 export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
-  const { data: history = [], isLoading, isError } = useQuery({
-    queryKey: ['billing-history'],
+  const costCenterQuery = useQuery({
+    queryKey: ['admin-billing-cost-center'],
     queryFn: async () => {
-      const res = await api.getPaymentHistory();
-      if (!res.success) throw new Error(res.error?.message ?? 'Zahlungsverlauf konnte nicht geladen werden');
+      const res = await api.adminBillingByCostCenter();
+      if (!res.success) throw new Error(res.error?.message ?? 'Kostenstellen konnten nicht geladen werden');
+      return res.data ?? [];
+    },
+    staleTime: 30_000,
+  });
+
+  const departmentQuery = useQuery({
+    queryKey: ['admin-billing-department'],
+    queryFn: async () => {
+      const res = await api.adminBillingByDepartment();
+      if (!res.success) throw new Error(res.error?.message ?? 'Abteilungen konnten nicht geladen werden');
       return res.data ?? [];
     },
     staleTime: 30_000,
@@ -46,12 +51,21 @@ export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
     staleTime: 60_000,
   });
 
-  const totalPaid = history
-    .filter((h) => h.status === 'completed')
-    .reduce((sum, h) => sum + h.amount, 0);
-  const totalCredits = history
-    .filter((h) => h.status === 'completed')
-    .reduce((sum, h) => sum + h.credits, 0);
+  const isLoading = costCenterQuery.isLoading || departmentQuery.isLoading;
+  const isError = costCenterQuery.isError || departmentQuery.isError;
+  const ccRows: AdminCostCenterSummary[] = costCenterQuery.data ?? [];
+
+  const totalAmount = ccRows.reduce((sum, r) => sum + r.total_amount, 0);
+  const totalBookings = ccRows.reduce((sum, r) => sum + r.total_bookings, 0);
+  const totalUsers = ccRows.reduce((sum, r) => sum + r.user_count, 0);
+  const currency = ccRows[0]?.currency ?? 'EUR';
+
+  async function handleExport() {
+    // Triggers the CSV endpoint so the browser handles the file download.
+    // Kept as a plain anchor rather than api.* because the endpoint returns
+    // raw CSV bytes, not the ApiResponse<T> envelope.
+    window.location.assign('/api/v1/admin/billing/export');
+  }
 
   if (isLoading) {
     return (
@@ -74,20 +88,33 @@ export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
     );
   }
 
-  const currency = history[0]?.currency ?? 'EUR';
-
   return (
     <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
-      <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Abrechnung</div>
+      <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Abrechnung</span>
+        <button
+          type="button"
+          onClick={handleExport}
+          data-testid="billing-export"
+          style={{
+            padding: '7px 14px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
+            border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer',
+          }}
+        >CSV Export</button>
+      </div>
 
-      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 10, animationDelay: '0.06s' }}>
+      <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10, animationDelay: '0.06s' }}>
         <Card style={{ padding: 14 }}>
-          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Gesamt bezahlt</div>
-          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}>{formatMoney(totalPaid, currency)}</div>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Gesamt</div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}>{formatMoney(totalAmount, currency)}</div>
         </Card>
         <Card style={{ padding: 14 }}>
-          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Credits erworben</div>
-          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}><NumberFlow value={totalCredits} /></div>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Buchungen</div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}><NumberFlow value={totalBookings} /></div>
+        </Card>
+        <Card style={{ padding: 14 }}>
+          <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Nutzer</div>
+          <div className="v5-mono" style={{ fontSize: 22, fontWeight: 700, color: 'var(--v5-txt)', marginTop: 4 }}><NumberFlow value={totalUsers} /></div>
         </Card>
         <Card style={{ padding: 14 }}>
           <div className="v5-mono" style={{ fontSize: 9, letterSpacing: 1.3, color: 'var(--v5-mut)', textTransform: 'uppercase' }}>Stripe</div>
@@ -101,37 +128,37 @@ export function BillingV5({ navigate: _navigate }: { navigate: (id: ScreenId) =>
 
       <Card className="v5-ani" style={{ padding: 16, animationDelay: '0.12s' }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
-          <span style={{ fontWeight: 600, fontSize: 13, color: 'var(--v5-txt)' }}>Zahlungsverlauf</span>
-          <Badge variant="gray">{history.length}</Badge>
+          <span style={{ fontWeight: 600, fontSize: 13, color: 'var(--v5-txt)' }}>Kostenstellen</span>
+          <Badge variant="gray">{ccRows.length}</Badge>
         </div>
-        {history.length === 0 ? (
+        {ccRows.length === 0 ? (
           <div style={{ padding: 24, textAlign: 'center', fontSize: 12, color: 'var(--v5-mut)' }}>
-            Noch keine Zahlungen
+            Noch keine Kostenstellen konfiguriert
           </div>
         ) : (
           <div>
             <div className="v5-mono" style={{
-              display: 'grid', gridTemplateColumns: '110px 1fr 100px 120px 110px',
+              display: 'grid', gridTemplateColumns: '120px 1fr 80px 90px 120px',
               padding: '6px 4px', fontSize: 9, letterSpacing: 1.2, textTransform: 'uppercase',
               color: 'var(--v5-mut)', borderBottom: '1px solid var(--v5-bor)',
             }}>
-              <span>Datum</span><span>ID</span><span>Credits</span><span>Betrag</span><span>Status</span>
+              <span>Kostenstelle</span><span>Abteilung</span><span>Nutzer</span><span>Buchungen</span><span>Betrag</span>
             </div>
-            {history.map((h, i) => (
+            {ccRows.map((r, i) => (
               <div
-                key={h.id} data-testid="billing-row"
+                key={r.cost_center} data-testid="billing-row"
                 style={{
-                  display: 'grid', gridTemplateColumns: '110px 1fr 100px 120px 110px',
+                  display: 'grid', gridTemplateColumns: '120px 1fr 80px 90px 120px',
                   padding: '10px 4px', alignItems: 'center',
-                  borderBottom: i < history.length - 1 ? '1px solid var(--v5-bor)' : 'none',
+                  borderBottom: i < ccRows.length - 1 ? '1px solid var(--v5-bor)' : 'none',
                   fontSize: 11, color: 'var(--v5-txt)',
                 }}
               >
-                <span>{formatDate(h.created_at)}</span>
-                <span className="v5-mono" style={{ fontSize: 10, color: 'var(--v5-mut)' }} title={h.id}>{h.id.slice(0, 14)}…</span>
-                <span className="v5-mono"><NumberFlow value={h.credits} /></span>
-                <span className="v5-mono" style={{ fontWeight: 500 }}>{formatMoney(h.amount, h.currency)}</span>
-                <Badge variant={statusVariant(h.status)} dot>{STATUS_LABEL[h.status]}</Badge>
+                <span className="v5-mono">{r.cost_center}</span>
+                <span>{r.department}</span>
+                <span className="v5-mono"><NumberFlow value={r.user_count} /></span>
+                <span className="v5-mono"><NumberFlow value={r.total_bookings} /></span>
+                <span className="v5-mono" style={{ fontWeight: 500 }}>{formatMoney(r.total_amount, r.currency)}</span>
               </div>
             ))}
           </div>

--- a/parkhub-web/src/design-v5/screens/Einstellungen.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Einstellungen.test.tsx
@@ -2,16 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const mockMe = vi.fn();
-const mockUpdateMe = vi.fn();
-const mockGetPrefs = vi.fn();
-const mockUpdatePrefs = vi.fn();
+// v5 Einstellungen is under the admin nav section → it must surface tenant
+// settings (company, booking rules, cost-center tagging, etc.) via
+// `api.adminGetSettings`/`api.adminUpdateSettings`. The former draft called
+// `api.me`/`api.updateMe`, which is the user-scoped profile endpoint and is
+// wired into the separate Profil screen instead.
+const mockGetSettings = vi.fn();
+const mockUpdateSettings = vi.fn();
 vi.mock('../../api/client', () => ({
   api: {
-    me: (...a: unknown[]) => mockMe(...a),
-    updateMe: (...a: unknown[]) => mockUpdateMe(...a),
-    getNotificationPreferences: (...a: unknown[]) => mockGetPrefs(...a),
-    updateNotificationPreferences: (...a: unknown[]) => mockUpdatePrefs(...a),
+    adminGetSettings: (...a: unknown[]) => mockGetSettings(...a),
+    adminUpdateSettings: (...a: unknown[]) => mockUpdateSettings(...a),
   },
 }));
 
@@ -29,17 +30,11 @@ vi.mock('../ThemeProvider', () => ({
 
 import { EinstellungenV5 } from './Einstellungen';
 
-const USER = {
-  id: 'u-1', username: 'flo', email: 'f@e', name: 'Flo',
-  role: 'admin' as const, preferences: {}, is_active: true,
-  credits_balance: 0, credits_monthly_quota: 0, department: 'IT',
-};
-
-const PREFS = {
-  email_booking_confirm: true, email_booking_reminder: false,
-  email_swap_request: true, push_enabled: false,
-  sms_booking_confirm: false, sms_booking_reminder: false, sms_booking_cancelled: false,
-  whatsapp_booking_confirm: false, whatsapp_booking_reminder: false, whatsapp_booking_cancelled: false,
+const SETTINGS: Record<string, string> = {
+  company_name: 'ACME GmbH',
+  default_currency: 'EUR',
+  booking_window_days: '30',
+  cost_center_required: 'true',
 };
 
 function renderScreen() {
@@ -51,72 +46,60 @@ function renderScreen() {
   );
 }
 
-describe('EinstellungenV5', () => {
+describe('EinstellungenV5 (admin)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetPrefs.mockResolvedValue({ success: true, data: PREFS });
   });
 
-  it('renders error state when me fails', async () => {
-    mockMe.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'oops' } });
+  it('renders error state when adminGetSettings fails', async () => {
+    mockGetSettings.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'oops' } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Fehler beim Laden')).toBeInTheDocument());
   });
 
-  it('renders department field populated from user', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
+  it('renders company name field populated from admin settings', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
     renderScreen();
-    await waitFor(() => expect((screen.getByTestId('einst-department') as HTMLInputElement).value).toBe('IT'));
+    await waitFor(() => expect((screen.getByTestId('einst-company-name') as HTMLInputElement).value).toBe('ACME GmbH'));
   });
 
-  it('saves department change via updateMe', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
-    mockUpdateMe.mockResolvedValue({ success: true, data: { ...USER, department: 'Ops' } });
+  it('renders booking window (days) field populated from admin settings', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
     renderScreen();
-    await waitFor(() => expect(screen.getByTestId('einst-department')).toBeInTheDocument());
-    fireEvent.change(screen.getByTestId('einst-department'), { target: { value: 'Ops' } });
+    await waitFor(() => expect((screen.getByTestId('einst-booking-window') as HTMLInputElement).value).toBe('30'));
+  });
+
+  it('saves changed admin settings via adminUpdateSettings', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
+    mockUpdateSettings.mockResolvedValue({ success: true, data: null });
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId('einst-company-name')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('einst-company-name'), { target: { value: 'New Co' } });
+    fireEvent.change(screen.getByTestId('einst-booking-window'), { target: { value: '45' } });
     fireEvent.click(screen.getByTestId('einst-save'));
     await waitFor(() => {
-      expect(mockUpdateMe).toHaveBeenCalledWith({ department: 'Ops' });
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          company_name: 'New Co',
+          booking_window_days: '45',
+        }),
+      );
       expect(mockToast).toHaveBeenCalledWith('Einstellungen gespeichert', 'success');
     });
   });
 
-  it('surfaces updateMe error when success:false', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
-    mockUpdateMe.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'denied' } });
+  it('surfaces adminUpdateSettings error when success:false', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
+    mockUpdateSettings.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'denied' } });
     renderScreen();
-    await waitFor(() => expect(screen.getByTestId('einst-department')).toBeInTheDocument());
-    fireEvent.change(screen.getByTestId('einst-department'), { target: { value: 'Ops' } });
+    await waitFor(() => expect(screen.getByTestId('einst-company-name')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('einst-company-name'), { target: { value: 'Changed' } });
     fireEvent.click(screen.getByTestId('einst-save'));
     await waitFor(() => expect(mockToast).toHaveBeenCalledWith('denied', 'error'));
   });
 
-  it('toggles a notification preference and calls updatePrefs', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
-    mockUpdatePrefs.mockResolvedValue({ success: true, data: { ...PREFS, push_enabled: true } });
-    renderScreen();
-    await waitFor(() => expect(screen.getByText('Push aktiviert')).toBeInTheDocument());
-    const toggles = screen.getAllByRole('switch');
-    fireEvent.click(toggles[toggles.length - 1]);
-    await waitFor(() => {
-      expect(mockUpdatePrefs).toHaveBeenCalled();
-      expect(mockToast).toHaveBeenCalledWith('Benachrichtigungen gespeichert', 'success');
-    });
-  });
-
-  it('surfaces prefs error when success:false', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
-    mockUpdatePrefs.mockResolvedValue({ success: false, data: null, error: { code: 'E', message: 'fail' } });
-    renderScreen();
-    await waitFor(() => expect(screen.getByText('Push aktiviert')).toBeInTheDocument());
-    const toggles = screen.getAllByRole('switch');
-    fireEvent.click(toggles[0]);
-    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('fail', 'error'));
-  });
-
-  it('switches language chip and toasts', async () => {
-    mockMe.mockResolvedValue({ success: true, data: USER });
+  it('switches language chip and toasts (UI pref, independent of admin settings)', async () => {
+    mockGetSettings.mockResolvedValue({ success: true, data: SETTINGS });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Deutsch')).toBeInTheDocument());
     fireEvent.click(screen.getByText('English'));

--- a/parkhub-web/src/design-v5/screens/Einstellungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Einstellungen.tsx
@@ -1,10 +1,29 @@
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Card, SectionLabel, Toggle, V5NamedIcon } from '../primitives';
+import { Card, SectionLabel, V5NamedIcon } from '../primitives';
 import { useV5Toast } from '../Toast';
 import { useV5Theme, V5_MODES, V5_MODE_LABELS, type V5Mode } from '../ThemeProvider';
-import { api, type User, type NotificationPreferences } from '../../api/client';
+import { api } from '../../api/client';
 import type { ScreenId } from '../nav';
+
+/**
+ * Einstellungen — admin view of tenant / system settings.
+ *
+ * This screen lives under the `admin` nav section (see design-v5/nav.ts),
+ * so it must surface system-wide configuration — `/api/v1/admin/settings`
+ * — instead of personal profile fields. The personal Profil screen stays
+ * wired to `api.me`/`api.updateMe`.
+ *
+ * Codex #376: the v5 draft accidentally wired this admin entry to
+ * `api.me()`, which meant the tenant-scoped keys (company name, default
+ * currency, booking window, cost-center policy) were unreachable for
+ * admins in the new shell. Re-wiring to `adminGetSettings` +
+ * `adminUpdateSettings` closes the regression.
+ *
+ * UI-side preferences that don't touch the backend — language chip and
+ * the `useV5Theme` mode selector — remain local because they're a
+ * per-browser thing, not tenant-level config.
+ */
 
 const LANGUAGES: { code: string; label: string }[] = [
   { code: 'de', label: 'Deutsch' },
@@ -27,27 +46,37 @@ const inputStyle: CSSProperties = {
   fontFamily: 'inherit',
 };
 
+/**
+ * Tenant settings keys surfaced as structured fields. The admin settings
+ * endpoint returns an open `Record<string, string>` so callers can extend
+ * without a schema migration; this array is the allowlist the v5 shell
+ * renders + writes. Unknown keys returned by the backend are preserved on
+ * save so we don't clobber values another tool set.
+ */
+const SETTING_FIELDS: Array<{
+  key: string;
+  label: string;
+  hint: string;
+  testId: string;
+  type: 'text' | 'number' | 'boolean';
+}> = [
+  { key: 'company_name',         label: 'Firma',           hint: 'Wird in Exporten + Rechnungen verwendet.', testId: 'einst-company-name',   type: 'text' },
+  { key: 'default_currency',     label: 'Währung',         hint: 'ISO-4217-Code, z. B. EUR, CHF, USD.',       testId: 'einst-currency',       type: 'text' },
+  { key: 'booking_window_days',  label: 'Buchungsfenster', hint: 'Wie weit im Voraus gebucht werden darf.',   testId: 'einst-booking-window', type: 'number' },
+  { key: 'cost_center_required', label: 'Kostenstelle Pflicht', hint: '`true` / `false` — erzwingt Kostenstelle pro Buchung.', testId: 'einst-cost-center-required', type: 'text' },
+];
+
 export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
   const toast = useV5Toast();
   const qc = useQueryClient();
   const { mode, setMode } = useV5Theme();
 
-  const { data: user, isLoading, isError } = useQuery({
-    queryKey: ['einstellungen-me'],
+  const { data: settings, isLoading, isError } = useQuery({
+    queryKey: ['admin-settings'],
     queryFn: async () => {
-      const res = await api.me();
+      const res = await api.adminGetSettings();
       if (!res.success) throw new Error(res.error?.message ?? 'Einstellungen konnten nicht geladen werden');
-      return res.data;
-    },
-    staleTime: 30_000,
-  });
-
-  const { data: prefs } = useQuery({
-    queryKey: ['einstellungen-prefs'],
-    queryFn: async () => {
-      const res = await api.getNotificationPreferences();
-      if (!res.success) throw new Error(res.error?.message ?? 'Benachrichtigungen konnten nicht geladen werden');
-      return res.data;
+      return res.data ?? {};
     },
     staleTime: 30_000,
   });
@@ -56,54 +85,38 @@ export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: Screen
     if (typeof window === 'undefined') return 'de';
     return window.localStorage.getItem(LANG_STORAGE_KEY) ?? 'de';
   });
-  const [department, setDepartment] = useState('');
-  const [localPrefs, setLocalPrefs] = useState<NotificationPreferences | null>(null);
+  const [draft, setDraft] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (user) setDepartment(user.department ?? '');
-  }, [user]);
-
-  useEffect(() => {
-    if (prefs) setLocalPrefs(prefs);
-  }, [prefs]);
+    if (settings) setDraft(settings);
+  }, [settings]);
 
   const saveMutation = useMutation({
-    mutationFn: async (payload: Partial<User>) => {
-      const res = await api.updateMe(payload);
+    mutationFn: async (payload: Record<string, string>) => {
+      const res = await api.adminUpdateSettings(payload);
       if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
       return res.data;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['einstellungen-me'] });
+      qc.invalidateQueries({ queryKey: ['admin-settings'] });
       toast('Einstellungen gespeichert', 'success');
     },
     onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
   });
 
-  const prefsMutation = useMutation({
-    mutationFn: async (payload: NotificationPreferences) => {
-      const res = await api.updateNotificationPreferences(payload);
-      if (!res.success) throw new Error(res.error?.message ?? 'Speichern fehlgeschlagen');
-      return res.data;
-    },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['einstellungen-prefs'] });
-      toast('Benachrichtigungen gespeichert', 'success');
-    },
-    onError: (err: Error) => toast(err.message || 'Speichern fehlgeschlagen', 'error'),
-  });
+  const isDirty = useMemo(() => {
+    if (!settings) return false;
+    const keys = new Set([...Object.keys(settings), ...Object.keys(draft)]);
+    for (const k of keys) {
+      if ((settings[k] ?? '') !== (draft[k] ?? '')) return true;
+    }
+    return false;
+  }, [settings, draft]);
 
   function handleLangChange(code: string) {
     setLang(code);
     if (typeof window !== 'undefined') window.localStorage.setItem(LANG_STORAGE_KEY, code);
     toast('Sprache aktualisiert', 'success');
-  }
-
-  function togglePref(key: keyof NotificationPreferences) {
-    if (!localPrefs) return;
-    const next = { ...localPrefs, [key]: !localPrefs[key] } as NotificationPreferences;
-    setLocalPrefs(next);
-    prefsMutation.mutate(next);
   }
 
   if (isLoading) {
@@ -116,7 +129,7 @@ export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: Screen
     );
   }
 
-  if (isError || !user) {
+  if (isError || !settings) {
     return (
       <div style={{ padding: 16, flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <Card className="v5-ani" style={{ padding: 28, textAlign: 'center', maxWidth: 360 }}>
@@ -133,28 +146,31 @@ export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: Screen
       <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Einstellungen</div>
 
       <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, animationDelay: '0.06s' }}>
-        <SectionLabel>Allgemein</SectionLabel>
-        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>Abteilung</span>
-          <input
-            data-testid="einst-department"
-            type="text"
-            value={department}
-            onChange={(e) => setDepartment(e.target.value)}
-            style={inputStyle}
-          />
-        </label>
+        <SectionLabel>System</SectionLabel>
+        {SETTING_FIELDS.map((f) => (
+          <label key={f.key} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={{ fontSize: 11, color: 'var(--v5-mut)' }}>{f.label}</span>
+            <input
+              data-testid={f.testId}
+              type={f.type === 'number' ? 'number' : 'text'}
+              value={draft[f.key] ?? ''}
+              onChange={(e) => setDraft({ ...draft, [f.key]: e.target.value })}
+              style={inputStyle}
+            />
+            <span style={{ fontSize: 10, color: 'var(--v5-mut)' }}>{f.hint}</span>
+          </label>
+        ))}
         <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
           <button
             type="button"
-            disabled={department === (user.department ?? '') || saveMutation.isPending}
-            onClick={() => saveMutation.mutate({ department: department.trim() })}
+            disabled={!isDirty || saveMutation.isPending}
+            onClick={() => saveMutation.mutate(draft)}
             data-testid="einst-save"
             style={{
               padding: '8px 16px', borderRadius: 9, background: 'var(--v5-acc)', color: 'var(--v5-accent-fg)',
               border: 'none', fontSize: 12, fontWeight: 600,
-              cursor: department !== (user.department ?? '') && !saveMutation.isPending ? 'pointer' : 'not-allowed',
-              opacity: department !== (user.department ?? '') && !saveMutation.isPending ? 1 : 0.5,
+              cursor: isDirty && !saveMutation.isPending ? 'pointer' : 'not-allowed',
+              opacity: isDirty && !saveMutation.isPending ? 1 : 0.5,
             }}
           >
             {saveMutation.isPending ? 'Speichert …' : 'Speichern'}
@@ -203,27 +219,6 @@ export function EinstellungenV5({ navigate: _navigate }: { navigate: (id: Screen
           })}
         </div>
       </Card>
-
-      {localPrefs && (
-        <Card className="v5-ani" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 10, animationDelay: '0.24s' }}>
-          <SectionLabel>Benachrichtigungen</SectionLabel>
-          {([
-            ['email_booking_confirm', 'E-Mail: Buchungsbestätigung'],
-            ['email_booking_reminder', 'E-Mail: Erinnerung'],
-            ['email_swap_request', 'E-Mail: Tauschanfragen'],
-            ['push_enabled', 'Push aktiviert'],
-          ] as Array<[keyof NotificationPreferences, string]>).map(([key, label]) => (
-            <div key={key} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <span style={{ fontSize: 12, color: 'var(--v5-txt)' }}>{label}</span>
-              <Toggle
-                checked={Boolean(localPrefs[key])}
-                onChange={() => togglePref(key)}
-                ariaLabel={label}
-              />
-            </div>
-          ))}
-        </Card>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

PHP parity port of [nash87/parkhub-rust#376](https://github.com/nash87/parkhub-rust/pull/376).

The PHP Wave 4+5 merge (#337) inherited the same admin-vs-user API
confusion that Codex flagged on rust #376 for three admin-nav entries:

- `Billing.tsx` was calling `api.getPaymentHistory()` (personal checkout log) → now uses `adminBillingByCostCenter` + `adminBillingByDepartment`
- `Einstellungen.tsx` was calling `api.me()` / `api.updateMe()` (personal profile) → now uses `adminGetSettings` / `adminUpdateSettings`
- `Benachrichtigungen.tsx` was calling `api.getNotifications()` (personal inbox) → now uses `adminListAnnouncements` / `adminCreateAnnouncement` / `adminDeleteAnnouncement`

All three backends already exist — no server-side changes needed:
- `routes/modules/cost_center.php` (admin + module:cost_center)
- `/api/v1/admin/settings` + `/api/v1/admin/announcements` (admin middleware)

## Test plan

- [x] TDD red → green per screen (mocks rewritten to admin endpoints, 5/6 fail; component rewrite lands, 6/6 pass)
- [x] 2352/2352 tests pass locally on full vitest suite
- [x] `astro build` clean
- [x] CSV export button on Billing still routes to `/api/v1/admin/billing/export`
- [x] `AdminCostCenterSummary` / `AdminDepartmentSummary` types added to client.ts