### PR TITLE
feat(v5): upgrade Analytics bar chart to uPlot canvas

### DIFF
--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -36,6 +36,7 @@
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.14.1",
         "tailwindcss": "^4.2.1",
+        "uplot": "1.6.32",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -8290,6 +8291,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uplot": {
+      "version": "1.6.32",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
+      "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
+      "license": "MIT"
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -48,6 +48,7 @@
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.14.1",
     "tailwindcss": "^4.2.1",
+    "uplot": "1.6.32",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/parkhub-web/src/design-v5/primitives/UPlotChart.test.tsx
+++ b/parkhub-web/src/design-v5/primitives/UPlotChart.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+// Mock uplot BEFORE importing UPlotChart — jsdom has no canvas 2d ctx.
+// We record constructor args + expose destroy/setSize spies so the tests
+// can verify our wrapper's contract with uPlot without booting a real chart.
+const destroySpy = vi.fn();
+const setSizeSpy = vi.fn();
+const ctorSpy = vi.fn();
+
+vi.mock('uplot', () => {
+  class FakeUPlot {
+    constructor(opts: unknown, data: unknown, target: HTMLElement) {
+      ctorSpy(opts, data, target);
+      // mimic uPlot's DOM: append a canvas child so our wrapper can set aria-label
+      const canvas = document.createElement('canvas');
+      target.appendChild(canvas);
+    }
+    destroy = destroySpy;
+    setSize = setSizeSpy;
+  }
+  return { default: FakeUPlot };
+});
+
+// Avoid CSS import pulling in real file during jsdom test — stub it.
+vi.mock('uplot/dist/uPlot.min.css', () => ({}));
+
+import { UPlotChart } from './UPlotChart';
+
+describe('UPlotChart', () => {
+  beforeEach(() => {
+    destroySpy.mockClear();
+    setSizeSpy.mockClear();
+    ctorSpy.mockClear();
+  });
+
+  it('renders a canvas element with the given aria-label', () => {
+    const { container } = render(
+      <UPlotChart data={[[1, 2, 3], [10, 20, 30]]} ariaLabel="Buchungen pro Tag" />
+    );
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeInTheDocument();
+    expect(canvas?.getAttribute('aria-label')).toBe('Buchungen pro Tag');
+  });
+
+  it('exposes role="img" on the chart container for a11y', () => {
+    const { container } = render(
+      <UPlotChart data={[[1, 2], [5, 10]]} ariaLabel="Stunden" />
+    );
+    const img = container.querySelector('[role="img"]');
+    expect(img).toBeInTheDocument();
+    expect(img?.getAttribute('aria-label')).toBe('Stunden');
+  });
+
+  it('disposes uPlot instance on unmount', () => {
+    const { unmount } = render(<UPlotChart data={[[1, 2], [5, 10]]} />);
+    expect(destroySpy).not.toHaveBeenCalled();
+    unmount();
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('constructs uPlot with the provided aligned data', () => {
+    render(<UPlotChart data={[[1, 2, 3], [10, 20, 30]]} />);
+    expect(ctorSpy).toHaveBeenCalledTimes(1);
+    const [, data] = ctorSpy.mock.calls[0];
+    expect(data).toEqual([[1, 2, 3], [10, 20, 30]]);
+  });
+
+  it('renders placeholder when data is empty (no x values)', () => {
+    const { container } = render(<UPlotChart data={[[], []]} ariaLabel="Leer" />);
+    // No canvas should be mounted when there's nothing to plot
+    expect(container.querySelector('canvas')).not.toBeInTheDocument();
+    expect(ctorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/parkhub-web/src/design-v5/primitives/UPlotChart.tsx
+++ b/parkhub-web/src/design-v5/primitives/UPlotChart.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from 'react';
+import uPlot from 'uplot';
+import 'uplot/dist/uPlot.min.css';
+
+/* ═════════════════════════════════════════════════════════════
+   UPlotChart — thin React wrapper around uPlot (MIT, ~40KB).
+
+   Canvas-rendered, zero-runtime-deps, ~2-3× Chart.js perf at
+   ~1/5 the bundle. Tokens drive color via --v5-acc / --v5-acc-muted.
+
+   Contract:
+     - `data`   : uPlot.AlignedData — [xs[], ...series[][]]
+     - `options`: optional partial uPlot.Options overrides
+     - `ariaLabel`: placed on inner <canvas> for screen readers
+     - `height` : px, defaults to 240
+     - Destroys the uPlot instance on unmount (no leaks)
+     - Listens to window resize + calls plot.setSize() responsively
+   ═════════════════════════════════════════════════════════════ */
+
+export interface UPlotChartProps {
+  data: uPlot.AlignedData;
+  options?: Partial<uPlot.Options>;
+  ariaLabel?: string;
+  height?: number;
+}
+
+export function UPlotChart({ data, options, ariaLabel, height = 240 }: UPlotChartProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const plotRef = useRef<uPlot | null>(null);
+
+  // Guard: uPlot requires >=1 x-value. Render a labelled empty slot instead.
+  const hasData = Array.isArray(data) && data.length > 0 && Array.isArray(data[0]) && data[0].length > 0;
+
+  useEffect(() => {
+    if (!hasData || !hostRef.current) return;
+    const host = hostRef.current;
+    const width = host.clientWidth || 520;
+
+    const baseOpts: uPlot.Options = {
+      width,
+      height,
+      // Caller may override any of this via `options`
+      series: [
+        {},
+        {
+          stroke: 'var(--v5-acc)',
+          fill: 'var(--v5-acc-muted)',
+          width: 2,
+          points: { show: false },
+        },
+      ],
+      scales: {
+        x: { time: false },
+      },
+      legend: { show: false },
+      cursor: { drag: { x: false, y: false } },
+      ...(options ?? {}),
+    };
+
+    const plot = new uPlot(baseOpts, data, host);
+    plotRef.current = plot;
+
+    // Apply aria-label to the rendered canvas for screen readers.
+    if (ariaLabel) {
+      const canvas = host.querySelector('canvas');
+      if (canvas) canvas.setAttribute('aria-label', ariaLabel);
+    }
+
+    const onResize = () => {
+      if (!hostRef.current || !plotRef.current) return;
+      plotRef.current.setSize({ width: hostRef.current.clientWidth, height });
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      plot.destroy();
+      plotRef.current = null;
+    };
+  }, [data, options, ariaLabel, height, hasData]);
+
+  if (!hasData) {
+    return (
+      <div
+        role="img"
+        aria-label={ariaLabel}
+        style={{ fontSize: 11, color: 'var(--v5-mut)', padding: '14px 0' }}
+      >
+        Keine Daten
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={hostRef}
+      role="img"
+      aria-label={ariaLabel}
+      style={{ width: '100%' }}
+    />
+  );
+}

--- a/parkhub-web/src/design-v5/primitives/index.tsx
+++ b/parkhub-web/src/design-v5/primitives/index.tsx
@@ -1,6 +1,8 @@
 import { type CSSProperties, type ReactNode } from 'react';
 import { icons, type IconKey } from '../icons';
 
+export { UPlotChart, type UPlotChartProps } from './UPlotChart';
+
 /* ═════════════════════════════════════════════════════════════
    v5 Primitives — thin, tokenized, composable
    All surfaces read from CSS custom properties (--v5-*) so a

--- a/parkhub-web/src/design-v5/screens/Analytics.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Analytics.test.tsx
@@ -13,6 +13,21 @@ vi.mock('@number-flow/react', () => ({
   default: ({ value }: { value: number }) => <span>{value}</span>,
 }));
 
+// uPlot needs a real 2D canvas context; jsdom has none. Mock uplot and its CSS
+// so the Analytics screen renders deterministically inside the test env.
+vi.mock('uplot', () => {
+  class FakeUPlot {
+    constructor(_opts: unknown, _data: unknown, target: HTMLElement) {
+      const canvas = document.createElement('canvas');
+      target.appendChild(canvas);
+    }
+    destroy() {}
+    setSize() {}
+  }
+  return { default: FakeUPlot };
+});
+vi.mock('uplot/dist/uPlot.min.css', () => ({}));
+
 import { AnalyticsV5 } from './Analytics';
 
 const STATS = {
@@ -53,28 +68,25 @@ describe('AnalyticsV5', () => {
     expect(screen.getByText('Aktive Buchungen')).toBeInTheDocument();
   });
 
-  it('renders both bar charts', async () => {
+  it('renders both charts as uPlot canvases with aria-labels', async () => {
     mockStats.mockResolvedValue({ success: true, data: STATS });
-    renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('analytics-chart')).toHaveLength(2));
-  });
-
-  it('hour chart renders 24 bars', async () => {
-    mockStats.mockResolvedValue({ success: true, data: STATS });
-    renderScreen();
-    await waitFor(() => expect(screen.getAllByTestId('analytics-chart').length).toBeGreaterThan(0));
-    const charts = screen.getAllByTestId('analytics-chart');
-    // hour chart should have rects for 24 hours
-    const hourRects = charts[0].querySelectorAll('rect');
-    expect(hourRects.length).toBe(24);
+    const { container } = renderScreen();
+    await waitFor(() =>
+      expect(screen.getByRole('img', { name: /Auslastung nach Stunde/ })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('img', { name: /Auslastung nach Wochentag/ })).toBeInTheDocument();
+    // uPlot renders canvas, not inline-SVG <rect>s — guard the regression.
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelectorAll('[data-testid="analytics-chart"] rect').length).toBe(0);
   });
 
   it('gracefully handles missing occupancy data', async () => {
     mockStats.mockResolvedValue({ success: true, data: { total_users: 1, total_lots: 1, total_bookings: 1, active_bookings: 1 } });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Nutzer')).toBeInTheDocument());
-    // Should still render chart containers (with 0 values)
-    expect(screen.getAllByTestId('analytics-chart')).toHaveLength(2);
+    // Chart containers still present for both hour + day series (values may be 0, not empty).
+    expect(screen.getByRole('img', { name: /Auslastung nach Stunde/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Auslastung nach Wochentag/ })).toBeInTheDocument();
   });
 
   it('renders title', async () => {

--- a/parkhub-web/src/design-v5/screens/Analytics.tsx
+++ b/parkhub-web/src/design-v5/screens/Analytics.tsx
@@ -1,68 +1,104 @@
 import NumberFlow from '@number-flow/react';
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Card, SectionLabel, StatCard, V5NamedIcon } from '../primitives';
+import { Card, SectionLabel, StatCard, UPlotChart, V5NamedIcon } from '../primitives';
 import { api } from '../../api/client';
 import type { ScreenId } from '../nav';
 
-function BarChart({ data, label, color = 'var(--v5-acc)' }: {
-  data: { label: string; value: number }[];
+const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+
+/** Canvas-rendered chart block backed by uPlot (MIT, ~40KB). */
+function ChartBlock({
+  label,
+  xs,
+  ys,
+  tickLabels,
+  stroke = 'var(--v5-acc)',
+  fill = 'var(--v5-acc-muted)',
+}: {
   label: string;
-  color?: string;
+  xs: number[];
+  ys: number[];
+  tickLabels: string[];
+  stroke?: string;
+  fill?: string;
 }) {
-  if (data.length === 0) {
+  if (xs.length === 0) {
     return (
-      <div style={{ fontSize: 11, color: 'var(--v5-mut)', padding: '14px 0' }}>Keine Daten</div>
+      <div>
+        <SectionLabel>{label}</SectionLabel>
+        <div
+          role="img"
+          aria-label={label}
+          style={{ fontSize: 11, color: 'var(--v5-mut)', padding: '14px 0' }}
+        >
+          Keine Daten
+        </div>
+      </div>
     );
   }
-  const max = Math.max(...data.map((d) => d.value), 1);
-  const width = 520;
-  const height = 120;
-  const pad = 6;
-  const barW = (width - pad * 2) / data.length;
+
+  const options: Partial<import('uplot').Options> = {
+    series: [
+      {},
+      {
+        stroke,
+        fill,
+        width: 2,
+        paths: (u, sidx, i0, i1) => {
+          // Bar-style paths via uPlot's built-in bars plugin-style drawing.
+          const { ctx } = u;
+          const xVals = u.data[0] as number[];
+          const yVals = u.data[sidx] as number[];
+          const path = new Path2D();
+          const n = xVals.length;
+          if (n === 0) return null;
+          const span = n > 1 ? xVals[1]! - xVals[0]! : 1;
+          const barW = Math.max(2, u.valToPos(span, 'x', true) - u.valToPos(0, 'x', true) - 4);
+          const zeroY = u.valToPos(0, 'y', true);
+          for (let i = i0; i <= i1; i++) {
+            const cx = u.valToPos(xVals[i]!, 'x', true);
+            const cy = u.valToPos(yVals[i]!, 'y', true);
+            const h = zeroY - cy;
+            path.rect(cx - barW / 2, cy, barW, h);
+          }
+          ctx.save();
+          ctx.fillStyle = typeof fill === 'string' ? fill : 'currentColor';
+          ctx.fill(path);
+          ctx.restore();
+          return null;
+        },
+        points: { show: false },
+      },
+    ],
+    axes: [
+      {
+        stroke: 'var(--v5-mut)',
+        grid: { show: false },
+        ticks: { show: false },
+        values: (_u, splits) => splits.map((v) => tickLabels[Math.round(v)] ?? ''),
+        size: 22,
+      },
+      {
+        stroke: 'var(--v5-mut)',
+        grid: { stroke: 'var(--v5-bord)', width: 1 },
+        ticks: { show: false },
+        size: 32,
+      },
+    ],
+    scales: {
+      x: { time: false, range: [xs[0]! - 0.5, xs[xs.length - 1]! + 0.5] },
+      y: { range: (_u, _dMin, dMax) => [0, Math.max(dMax, 1) * 1.1] },
+    },
+  };
+
   return (
     <div>
       <SectionLabel>{label}</SectionLabel>
-      <svg
-        viewBox={`0 0 ${width} ${height + 24}`}
-        style={{ width: '100%', height: 'auto', display: 'block' }}
-        role="img"
-        aria-label={label}
-        data-testid="analytics-chart"
-      >
-        {data.map((d, i) => {
-          const h = (d.value / max) * height;
-          const x = pad + i * barW;
-          const y = height - h;
-          return (
-            <g key={`${d.label}-${i}`}>
-              <rect
-                x={x + 2}
-                y={y}
-                width={barW - 4}
-                height={h}
-                fill={color}
-                rx={3}
-                opacity={0.85}
-              />
-              <text
-                x={x + barW / 2}
-                y={height + 14}
-                fontSize="9"
-                fill="var(--v5-mut)"
-                textAnchor="middle"
-                fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
-              >
-                {d.label}
-              </text>
-            </g>
-          );
-        })}
-      </svg>
+      <UPlotChart data={[xs, ys]} options={options} ariaLabel={label} height={140} />
     </div>
   );
 }
-
-const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
 
 export function AnalyticsV5({ navigate: _navigate }: { navigate: (id: ScreenId) => void }) {
   const { data: stats, isLoading, isError } = useQuery({
@@ -74,6 +110,32 @@ export function AnalyticsV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
     },
     staleTime: 60_000,
   });
+
+  const hourData = useMemo(() => {
+    const byHour = stats?.occupancy_by_hour ?? {};
+    const xs: number[] = [];
+    const ys: number[] = [];
+    const ticks: string[] = [];
+    for (let h = 0; h < 24; h++) {
+      const key = String(h).padStart(2, '0');
+      xs.push(h);
+      ys.push(Number(byHour[key] ?? byHour[String(h)] ?? 0));
+      ticks.push(key);
+    }
+    return { xs, ys, ticks };
+  }, [stats]);
+
+  const dayData = useMemo(() => {
+    const byDay = stats?.occupancy_by_day ?? {};
+    const xs: number[] = [];
+    const ys: number[] = [];
+    DAY_LABELS.forEach((lbl, i) => {
+      const entry = byDay[lbl] ?? byDay[String(i)] ?? null;
+      xs.push(i);
+      ys.push(entry ? entry.avg_percentage : 0);
+    });
+    return { xs, ys, ticks: DAY_LABELS };
+  }, [stats]);
 
   if (isLoading) {
     return (
@@ -96,19 +158,6 @@ export function AnalyticsV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
     );
   }
 
-  const byHour = stats.occupancy_by_hour ?? {};
-  const hourBars: { label: string; value: number }[] = [];
-  for (let h = 0; h < 24; h++) {
-    const key = String(h).padStart(2, '0');
-    hourBars.push({ label: key, value: Number(byHour[key] ?? byHour[String(h)] ?? 0) });
-  }
-
-  const byDay = stats.occupancy_by_day ?? {};
-  const dayBars = DAY_LABELS.map((lbl, i) => {
-    const entry = byDay[lbl] ?? byDay[String(i)] ?? null;
-    return { label: lbl, value: entry ? entry.avg_percentage : 0 };
-  });
-
   return (
     <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div className="v5-ani" style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Analytics</div>
@@ -121,16 +170,24 @@ export function AnalyticsV5({ navigate: _navigate }: { navigate: (id: ScreenId) 
       </div>
 
       <Card className="v5-ani" style={{ padding: 16, animationDelay: '0.12s' }}>
-        <BarChart data={hourBars} label="Auslastung nach Stunde (%)" />
+        <ChartBlock
+          label="Auslastung nach Stunde (%)"
+          xs={hourData.xs}
+          ys={hourData.ys}
+          tickLabels={hourData.ticks}
+        />
       </Card>
 
       <Card className="v5-ani" style={{ padding: 16, animationDelay: '0.18s' }}>
-        <BarChart data={dayBars} label="Auslastung nach Wochentag (%)" color="var(--v5-ok, oklch(0.65 0.17 160))" />
+        <ChartBlock
+          label="Auslastung nach Wochentag (%)"
+          xs={dayData.xs}
+          ys={dayData.ys}
+          tickLabels={dayData.ticks}
+          stroke="var(--v5-ok, oklch(0.65 0.17 160))"
+          fill="var(--v5-ok-muted, oklch(0.65 0.17 160 / 0.25))"
+        />
       </Card>
-
-      <div className="v5-ani" style={{ fontSize: 10, color: 'var(--v5-mut)' }}>
-        Interaktive Charts (uPlot) folgen in separater PR.
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Replace inline-SVG `<rect>` bar charts in **Analytics** with **uPlot** — MIT-licensed canvas charting library (~40KB min / ~22KB gzip, zero runtime deps, ~2-3x Chart.js perf at ~1/5 the bundle).

New `primitives/UPlotChart.tsx` wrapper handles mount/unmount/resize, places `aria-label` on the `<canvas>`, exposes `role=\"img\"` on the host, and disposes the instance on unmount (no leaks). Tokens drive stroke/fill via `--v5-acc` / `--v5-acc-muted`, never hard-coded hex.

## TDD evidence

1. **Feature 1 RED** — `src/design-v5/primitives/UPlotChart.test.tsx`: `Failed to resolve import \"./UPlotChart\"` (wrapper did not exist).
2. **Feature 1 GREEN** — minimal wrapper → 5/5 specs pass (canvas + aria-label, role=img on host, destroy-on-unmount, ctor receives aligned data, empty-data placeholder).
3. **Feature 2 RED** — `Analytics.test.tsx`: `expected 0 to be greater than or equal to 2` (no canvas was mounted while SVG was still in place).
4. **Feature 2 GREEN** — refactor Analytics to render via UPlotChart → 5/5 Analytics specs pass.
5. **Regression gate** — `npx vitest --run src/design-v5` → **233/233**; full `npx vitest --run` → **2356/2356**.

## Bundle

- `uplot@1.6.32` pinned **exact** (no `^`) — commercial-safe ✓.
- uPlot standalone: 40KB min / **22KB gzip** (`node_modules/uplot/dist/uPlot.iife.min.js`).
- v5 Analytics chunk still code-splits via Astro; uPlot imports are only in the v5 chart path.
- Baseline-delta build on fresh clone hit `/tmp` disk quota — left as follow-up measurement; standalone 22KB gzip is the canonical lower bound for the added weight.

## Tech debt / fallbacks

- Used raw `npm install uplot@1.6.32` + `npx vitest --run` + `npm run build`: fop has no `fop build` path for parkhub-web (web-astro) and `fop test` does not cover vitest frontend; escalate as fop-adoption debt.
- Installed `uplot` in worktree only; package-lock reflects this commit.

## Test plan

- [x] `npx vitest --run src/design-v5/primitives/UPlotChart` → 5/5
- [x] `npx vitest --run src/design-v5/screens/Analytics` → 5/5
- [x] `npx vitest --run src/design-v5` → 233/233
- [x] `npx vitest --run` full → 2356/2356
- [x] `npm run build` → clean (17s, 2 routes)
- [ ] Post-merge render smoke on https://parkhub-php-demo.onrender.com/

Task: T-1947