### PR TITLE
fix(v5): lazy-load UPlotChart (mirror #379 fix)

### DIFF
--- a/parkhub-web/src/design-v5/primitives/index.tsx
+++ b/parkhub-web/src/design-v5/primitives/index.tsx
@@ -1,7 +1,12 @@
 import { type CSSProperties, type ReactNode } from 'react';
 import { icons, type IconKey } from '../icons';
 
-export { UPlotChart, type UPlotChartProps } from './UPlotChart';
+// UPlotChart is deliberately NOT re-exported here: pulling it through the
+// barrel drags the uplot runtime (~40KB gz) into every screen's module
+// graph, which tanks LCP on non-admin routes. Admin screens that need the
+// chart must deep-import from './UPlotChart' directly (and preferably via
+// React.lazy) — see screens/Analytics.tsx for the canonical pattern.
+export type { UPlotChartProps } from './UPlotChart';
 
 /* ═════════════════════════════════════════════════════════════
    v5 Primitives — thin, tokenized, composable

--- a/parkhub-web/src/design-v5/screens/Analytics.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Analytics.test.tsx
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -29,6 +32,10 @@ vi.mock('uplot', () => {
 vi.mock('uplot/dist/uPlot.min.css', () => ({}));
 
 import { AnalyticsV5 } from './Analytics';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ANALYTICS_SRC = readFileSync(resolve(HERE, 'Analytics.tsx'), 'utf8');
+const PRIMITIVES_SRC = readFileSync(resolve(HERE, '../primitives/index.tsx'), 'utf8');
 
 const STATS = {
   total_users: 42,
@@ -93,5 +100,40 @@ describe('AnalyticsV5', () => {
     mockStats.mockResolvedValue({ success: true, data: STATS });
     renderScreen();
     await waitFor(() => expect(screen.getByText('Analytics')).toBeInTheDocument());
+  });
+});
+
+describe('AnalyticsV5 — Lighthouse LCP budget (lazy uPlot)', () => {
+  it('Analytics.tsx dynamically imports UPlotChart via React.lazy', () => {
+    // Eager imports of UPlotChart bloat the initial JS bundle (+~40KB uPlot)
+    // and push LCP past the Lighthouse budget. The screen must instead use
+    // React.lazy so uPlot lands in its own chunk loaded only for admins.
+    expect(ANALYTICS_SRC).toMatch(
+      /lazy\(\s*\(\)\s*=>\s*import\(\s*['"]\.\.\/primitives\/UPlotChart['"]\s*\)/,
+    );
+    // No eager `UPlotChart` import from '../primitives' barrel either.
+    expect(ANALYTICS_SRC).not.toMatch(
+      /import\s*{[^}]*\bUPlotChart\b[^}]*}\s*from\s*['"]\.\.\/primitives['"]/,
+    );
+  });
+
+  it('Analytics.tsx wraps charts in <Suspense> with a skeleton fallback', () => {
+    // The lazy chunk needs a Suspense boundary to avoid the whole app
+    // collapsing while uPlot is in flight. Skeleton keeps LCP stable.
+    expect(ANALYTICS_SRC).toMatch(/\bSuspense\b/);
+    expect(ANALYTICS_SRC).toMatch(/ChartSkeleton/);
+  });
+
+  it('primitives barrel does NOT re-export UPlotChart as a runtime binding', () => {
+    // 20+ screens import from the primitives barrel; re-exporting UPlotChart
+    // there drags uPlot into every screen's module graph, defeating the
+    // whole lazy-load. Screens that actually need the chart must deep-import.
+    // Type-only re-exports (`export type { ... }`) are fine — they're erased.
+    expect(PRIMITIVES_SRC).not.toMatch(
+      /export\s*{[^}]*\bUPlotChart\b(?![A-Za-z])[^}]*}\s*from\s*['"]\.\/UPlotChart['"]/,
+    );
+    expect(PRIMITIVES_SRC).not.toMatch(
+      /import\s*{[^}]*\bUPlotChart\b(?![A-Za-z])[^}]*}\s*from\s*['"]\.\/UPlotChart['"]/,
+    );
   });
 });

--- a/parkhub-web/src/design-v5/screens/Analytics.tsx
+++ b/parkhub-web/src/design-v5/screens/Analytics.tsx
@@ -1,11 +1,39 @@
 import NumberFlow from '@number-flow/react';
-import { useMemo } from 'react';
+import { lazy, Suspense, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Card, SectionLabel, StatCard, UPlotChart, V5NamedIcon } from '../primitives';
+import { Card, SectionLabel, StatCard, V5NamedIcon } from '../primitives';
 import { api } from '../../api/client';
 import type { ScreenId } from '../nav';
 
+/* ───────────────────────────────────────────────────────────────────
+   uPlot (~40KB gz) is loaded lazily so non-admin routes never pay
+   its cost — keeps LCP inside the Lighthouse budget. Admin-only
+   Analytics screen is the sole consumer; the chunk materialises on
+   mount and is replayed from the HTTP cache on subsequent visits.
+   ─────────────────────────────────────────────────────────────────── */
+const UPlotChart = lazy(() =>
+  import('../primitives/UPlotChart').then((m) => ({ default: m.UPlotChart })),
+);
+
 const DAY_LABELS = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+
+/** Skeleton placeholder matching UPlotChart's visual height (140) while the
+ *  lazy chunk streams in. Reuses the same ph-v5-pulse keyframe the screen's
+ *  loading-state skeleton blocks use, so fallback feels native. */
+function ChartSkeleton({ ariaLabel }: { ariaLabel: string }) {
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      style={{
+        height: 140,
+        borderRadius: 10,
+        background: 'var(--v5-sur2)',
+        animation: 'ph-v5-pulse 1.6s ease infinite',
+      }}
+    />
+  );
+}
 
 /** Canvas-rendered chart block backed by uPlot (MIT, ~40KB). */
 function ChartBlock({
@@ -23,6 +51,68 @@ function ChartBlock({
   stroke?: string;
   fill?: string;
 }) {
+  // Memoize data + options so the UPlotChart effect doesn't tear down
+  // and rebuild the canvas on every parent re-render (e.g. query status
+  // flips, layout toggles). Stable references → stable uPlot instance.
+  // Hooks MUST run unconditionally — the empty-data branch just skips render.
+  const data = useMemo<[number[], number[]]>(() => [xs, ys], [xs, ys]);
+  const options = useMemo<Partial<import('uplot').Options>>(
+    () => ({
+      series: [
+        {},
+        {
+          stroke,
+          fill,
+          width: 2,
+          paths: (u, sidx, i0, i1) => {
+            // Bar-style paths via uPlot's built-in bars plugin-style drawing.
+            const { ctx } = u;
+            const xVals = u.data[0] as number[];
+            const yVals = u.data[sidx] as number[];
+            const path = new Path2D();
+            const n = xVals.length;
+            if (n === 0) return null;
+            const span = n > 1 ? xVals[1]! - xVals[0]! : 1;
+            const barW = Math.max(2, u.valToPos(span, 'x', true) - u.valToPos(0, 'x', true) - 4);
+            const zeroY = u.valToPos(0, 'y', true);
+            for (let i = i0; i <= i1; i++) {
+              const cx = u.valToPos(xVals[i]!, 'x', true);
+              const cy = u.valToPos(yVals[i]!, 'y', true);
+              const h = zeroY - cy;
+              path.rect(cx - barW / 2, cy, barW, h);
+            }
+            ctx.save();
+            ctx.fillStyle = typeof fill === 'string' ? fill : 'currentColor';
+            ctx.fill(path);
+            ctx.restore();
+            return null;
+          },
+          points: { show: false },
+        },
+      ],
+      axes: [
+        {
+          stroke: 'var(--v5-mut)',
+          grid: { show: false },
+          ticks: { show: false },
+          values: (_u, splits) => splits.map((v) => tickLabels[Math.round(v)] ?? ''),
+          size: 22,
+        },
+        {
+          stroke: 'var(--v5-mut)',
+          grid: { stroke: 'var(--v5-bord)', width: 1 },
+          ticks: { show: false },
+          size: 32,
+        },
+      ],
+      scales: {
+        x: { time: false, range: [xs[0]! - 0.5, xs[xs.length - 1]! + 0.5] },
+        y: { range: (_u, _dMin, dMax) => [0, Math.max(dMax, 1) * 1.1] },
+      },
+    }),
+    [stroke, fill, tickLabels, xs],
+  );
+
   if (xs.length === 0) {
     return (
       <div>
@@ -38,64 +128,12 @@ function ChartBlock({
     );
   }
 
-  const options: Partial<import('uplot').Options> = {
-    series: [
-      {},
-      {
-        stroke,
-        fill,
-        width: 2,
-        paths: (u, sidx, i0, i1) => {
-          // Bar-style paths via uPlot's built-in bars plugin-style drawing.
-          const { ctx } = u;
-          const xVals = u.data[0] as number[];
-          const yVals = u.data[sidx] as number[];
-          const path = new Path2D();
-          const n = xVals.length;
-          if (n === 0) return null;
-          const span = n > 1 ? xVals[1]! - xVals[0]! : 1;
-          const barW = Math.max(2, u.valToPos(span, 'x', true) - u.valToPos(0, 'x', true) - 4);
-          const zeroY = u.valToPos(0, 'y', true);
-          for (let i = i0; i <= i1; i++) {
-            const cx = u.valToPos(xVals[i]!, 'x', true);
-            const cy = u.valToPos(yVals[i]!, 'y', true);
-            const h = zeroY - cy;
-            path.rect(cx - barW / 2, cy, barW, h);
-          }
-          ctx.save();
-          ctx.fillStyle = typeof fill === 'string' ? fill : 'currentColor';
-          ctx.fill(path);
-          ctx.restore();
-          return null;
-        },
-        points: { show: false },
-      },
-    ],
-    axes: [
-      {
-        stroke: 'var(--v5-mut)',
-        grid: { show: false },
-        ticks: { show: false },
-        values: (_u, splits) => splits.map((v) => tickLabels[Math.round(v)] ?? ''),
-        size: 22,
-      },
-      {
-        stroke: 'var(--v5-mut)',
-        grid: { stroke: 'var(--v5-bord)', width: 1 },
-        ticks: { show: false },
-        size: 32,
-      },
-    ],
-    scales: {
-      x: { time: false, range: [xs[0]! - 0.5, xs[xs.length - 1]! + 0.5] },
-      y: { range: (_u, _dMin, dMax) => [0, Math.max(dMax, 1) * 1.1] },
-    },
-  };
-
   return (
     <div>
       <SectionLabel>{label}</SectionLabel>
-      <UPlotChart data={[xs, ys]} options={options} ariaLabel={label} height={140} />
+      <Suspense fallback={<ChartSkeleton ariaLabel={label} />}>
+        <UPlotChart data={data} options={options} ariaLabel={label} height={140} />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Mirror of nash87/parkhub-rust#379 follow-up fix. PR #339 landed uPlot for Analytics canvas charts but re-exported `UPlotChart` from the `primitives` barrel, dragging ~40KB of uplot runtime into every screen's module graph — lands inside `tokens.*.js` which is modulepreloaded on every route.

- Drop the runtime re-export from `primitives/index.tsx`; keep only `export type { UPlotChartProps }` (erased at build time).
- `Analytics.tsx` loads `UPlotChart` via `React.lazy(() => import('../primitives/UPlotChart'))` wrapped in `<Suspense fallback={<ChartSkeleton />}>`.
- Memoize the `[xs, ys]` data tuple and uPlot options so unrelated parent re-renders don't tear down the canvas (addresses codex P2 feedback from the rust PR).

## Bundle delta

| Chunk | Baseline | Fixed | Δ |
|---|---:|---:|---:|
| `v5.astro_*.js` | 341,727 | 341,125 | -602 |
| `index.astro_*.js` | 125,329 | 124,084 | -1,245 |
| `tokens.*.js` | 130,427 | 79,040 | **-51,387** |
| `UPlotChart.*.js` (new lazy) | — | 53,734 | +53,734 |
| **Eager total** | **597,483** | **544,249** | **-53,234 (-8.9%)** |

`UPlotChart.js` is only fetched when an admin opens `/analytics` — no `modulepreload` on `/` or `/v5/` entry HTML.

## Test plan

- [x] RED first: 3 new assertions in `Analytics.test.tsx` fail on unfixed source (lazy-import regex, Suspense+ChartSkeleton regex, primitives-barrel-free-of-UPlotChart regex).
- [x] GREEN after fix: `npm run test` → **2359 / 2359** pass.
- [x] `npm run build` confirms standalone `UPlotChart.*.js` chunk, no uplot refs in preloaded entry chunks.
- [ ] Lighthouse Audit CI passes on this PR.
- [ ] Render preview renders `/v5/analytics` correctly with Suspense fallback visible during chunk load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)