### PR TITLE
test(a11y): axe-core audit + WCAG 2.1 AA fixes for v5 (T-1974)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
           trap 'kill "${server_pid}" 2>/dev/null || true' EXIT
 
           ./scripts/ci/wait-for-url.sh http://127.0.0.1:8082/api/v1/health/live 60
-          npx playwright test e2e/api.spec.ts e2e/pages.spec.ts --project=chromium
+          npx playwright test e2e/api.spec.ts e2e/pages.spec.ts e2e/v5-a11y.spec.ts --project=chromium
 
       - name: Upload Playwright report
         if: always()

--- a/e2e/v5-a11y.spec.ts
+++ b/e2e/v5-a11y.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { loginAsAdmin, openV5, V5_SCREENS } from './v5-helpers';
+
+/**
+ * v5 accessibility audit — T-1974.
+ *
+ * One axe-core run per v5 screen (marble_light mode). We assert zero
+ * `serious` + `critical` WCAG 2.1 AA violations. `minor` / `moderate`
+ * findings are reported by the playwright HTML report but do not fail
+ * the suite — pragmatic cut-off, mirrors the existing root `a11y.spec.ts`
+ * contract.
+ *
+ * `color-contrast` is disabled: v5 drives colour tokens via CSS custom
+ * properties + OKLCH gradients, and the marble/void palettes were
+ * hand-tuned in the design phase. Contrast is re-audited manually via
+ * the design-system tooling, not axe DOM inspection.
+ *
+ * The spec runs under the chromium project only — mobile-chrome baselines
+ * will land with the v5 responsive refactor (see v5-visual.spec.ts header).
+ */
+
+test.describe('v5 a11y — WCAG 2.1 AA', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'chromium',
+      'v5 a11y audit pinned to chromium — mobile variants land with the responsive refactor',
+    );
+    await loginAsAdmin(page);
+  });
+
+  for (const screen of V5_SCREENS) {
+    test(`@a11y ${screen}: no serious or critical axe violations`, async ({ page }) => {
+      await openV5(page, screen);
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .disableRules(['color-contrast'])
+        .analyze();
+
+      const blockers = results.violations.filter(
+        (v) => v.impact === 'serious' || v.impact === 'critical',
+      );
+      expect(
+        blockers,
+        // Stringify for readable failure output — shows rule id,
+        // impact, and affected selectors per violation.
+        JSON.stringify(blockers, null, 2),
+      ).toEqual([]);
+    });
+  }
+});

--- a/parkhub-web/src/design-v5/screens/Dashboard.tsx
+++ b/parkhub-web/src/design-v5/screens/Dashboard.tsx
@@ -289,8 +289,12 @@ export function DashboardV5({ navigate }: { navigate: (id: ScreenId) => void }) 
           von {creditsMax} · kein Ablauf
         </div>
         <div
-          style={{ height: 3, background: 'var(--v5-bor)', borderRadius: 3 }}
+          role="progressbar"
           aria-label={`${credits} von ${creditsMax} Credits`}
+          aria-valuenow={credits}
+          aria-valuemin={0}
+          aria-valuemax={creditsMax}
+          style={{ height: 3, background: 'var(--v5-bor)', borderRadius: 3 }}
         >
           <div
             style={{

--- a/parkhub-web/src/design-v5/screens/Einchecken.tsx
+++ b/parkhub-web/src/design-v5/screens/Einchecken.tsx
@@ -153,7 +153,12 @@ export function EincheckenV5({ navigate }: { navigate: (id: ScreenId) => void })
   const isActing = checkInMutation.isPending || checkOutMutation.isPending;
 
   return (
-    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+    <div
+      role="region"
+      aria-label="Einchecken"
+      tabIndex={0}
+      style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}
+    >
       <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Einchecken</span>
         <Badge variant={isCheckedIn ? 'success' : 'gray'} dot>

--- a/parkhub-web/src/design-v5/screens/Kalender.tsx
+++ b/parkhub-web/src/design-v5/screens/Kalender.tsx
@@ -175,102 +175,117 @@ export function KalenderV5({ navigate }: { navigate: (id: ScreenId) => void }) {
 
       <div className="v5-ani" style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 280px', gap: 12, animationDelay: '0.12s' }}>
         <Card style={{ overflow: 'hidden', padding: 0 }}>
-          <div
-            role="grid"
-            aria-label={`Kalender ${monthLabel}`}
-            style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', borderBottom: '1px solid var(--v5-bor)' }}
-          >
-            {WEEKDAYS.map((label) => (
-              <div
-                key={label}
-                role="columnheader"
-                className="v5-mono"
-                style={{ padding: '10px 0', fontSize: 10, letterSpacing: 1.2, textTransform: 'uppercase', textAlign: 'center', color: 'var(--v5-mut)' }}
-              >
-                {label}
-              </div>
-            ))}
-          </div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' }}>
-            {days.map((day, idx) => {
-              const inMonth = isSameMonth(day, currentMonth);
-              const isToday = isSameDay(day, today);
-              const selected = !!(selectedDate && isSameDay(day, selectedDate));
-              const dayEvents = eventsByDay.get(formatDateKey(day)) ?? [];
-              return (
-                <button
-                  key={idx}
-                  type="button"
-                  data-testid="kalender-day"
-                  aria-label={day.toLocaleDateString('de-DE', { weekday: 'long', day: 'numeric', month: 'long' })}
-                  aria-pressed={selected}
-                  onClick={() => setSelectedDate(day)}
-                  style={{
-                    minHeight: 82,
-                    padding: 6,
-                    background: selected ? 'var(--v5-acc-muted)' : 'transparent',
-                    border: 'none',
-                    borderRight: (idx + 1) % 7 === 0 ? 'none' : '1px solid var(--v5-bor)',
-                    borderBottom: idx < days.length - 7 ? '1px solid var(--v5-bor)' : 'none',
-                    textAlign: 'left',
-                    cursor: 'pointer',
-                    opacity: inMonth ? 1 : 0.4,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 4,
-                    fontFamily: 'inherit',
-                    color: 'inherit',
-                  }}
+          {/* WCAG `role="grid"` requires `role="row"` children, which in turn
+              wrap `role="columnheader"` and `role="gridcell"` (axe rules
+              aria-required-children / aria-required-parent). We keep the CSS
+              grid layout for visuals and add the ARIA row wrappers so the
+              semantics match the WAI-ARIA grid pattern. */}
+          <div role="grid" aria-label={`Kalender ${monthLabel}`}>
+            <div
+              role="row"
+              style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', borderBottom: '1px solid var(--v5-bor)' }}
+            >
+              {WEEKDAYS.map((label) => (
+                <div
+                  key={label}
+                  role="columnheader"
+                  className="v5-mono"
+                  style={{ padding: '10px 0', fontSize: 10, letterSpacing: 1.2, textTransform: 'uppercase', textAlign: 'center', color: 'var(--v5-mut)' }}
                 >
-                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                    <span
-                      className="v5-mono"
-                      style={{
-                        fontSize: 11,
-                        fontWeight: isToday ? 700 : 500,
-                        color: isToday ? 'var(--v5-accent-fg)' : selected ? 'var(--v5-acc)' : 'var(--v5-txt)',
-                        background: isToday ? 'var(--v5-acc)' : 'transparent',
-                        padding: isToday ? '2px 6px' : 0,
-                        borderRadius: isToday ? 999 : 0,
-                        minWidth: 18,
-                        textAlign: 'center',
-                      }}
-                    >
-                      {day.getDate()}
-                    </span>
-                    {dayEvents.length > 0 && (
-                      <span className="v5-mono" style={{ fontSize: 9, color: 'var(--v5-mut)' }}>
-                        {dayEvents.length}
-                      </span>
-                    )}
-                  </div>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                    {dayEvents.slice(0, 2).map((e) => (
-                      <div
-                        key={e.id}
-                        title={`${e.title} (${e.status})`}
+                  {label}
+                </div>
+              ))}
+            </div>
+            {Array.from({ length: Math.ceil(days.length / 7) }).map((_, weekIdx) => (
+              <div
+                key={`week-${weekIdx}`}
+                role="row"
+                style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' }}
+              >
+                {days.slice(weekIdx * 7, weekIdx * 7 + 7).map((day, localIdx) => {
+                  const idx = weekIdx * 7 + localIdx;
+                  const inMonth = isSameMonth(day, currentMonth);
+                  const isToday = isSameDay(day, today);
+                  const selected = !!(selectedDate && isSameDay(day, selectedDate));
+                  const dayEvents = eventsByDay.get(formatDateKey(day)) ?? [];
+                  return (
+                    <div role="gridcell" key={idx} style={{ display: 'flex' }}>
+                      <button
+                        type="button"
+                        data-testid="kalender-day"
+                        aria-label={day.toLocaleDateString('de-DE', { weekday: 'long', day: 'numeric', month: 'long' })}
+                        aria-pressed={selected}
+                        onClick={() => setSelectedDate(day)}
                         style={{
+                          minHeight: 82,
+                          width: '100%',
+                          padding: 6,
+                          background: selected ? 'var(--v5-acc-muted)' : 'transparent',
+                          border: 'none',
+                          borderRight: (localIdx + 1) % 7 === 0 ? 'none' : '1px solid var(--v5-bor)',
+                          borderBottom: idx < days.length - 7 ? '1px solid var(--v5-bor)' : 'none',
+                          textAlign: 'left',
+                          cursor: 'pointer',
+                          opacity: inMonth ? 1 : 0.4,
                           display: 'flex',
-                          alignItems: 'center',
+                          flexDirection: 'column',
                           gap: 4,
-                          fontSize: 10,
-                          color: 'var(--v5-txt)',
-                          background: 'var(--v5-sur2)',
-                          borderRadius: 5,
-                          padding: '2px 5px',
+                          fontFamily: 'inherit',
+                          color: 'inherit',
                         }}
                       >
-                        <span style={{ width: 5, height: 5, borderRadius: '50%', background: statusColor(e.status), flexShrink: 0 }} />
-                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.title}</span>
-                      </div>
-                    ))}
-                    {dayEvents.length > 2 && (
-                      <div style={{ fontSize: 9, color: 'var(--v5-mut)' }}>+{dayEvents.length - 2}</div>
-                    )}
-                  </div>
-                </button>
-              );
-            })}
+                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                          <span
+                            className="v5-mono"
+                            style={{
+                              fontSize: 11,
+                              fontWeight: isToday ? 700 : 500,
+                              color: isToday ? 'var(--v5-accent-fg)' : selected ? 'var(--v5-acc)' : 'var(--v5-txt)',
+                              background: isToday ? 'var(--v5-acc)' : 'transparent',
+                              padding: isToday ? '2px 6px' : 0,
+                              borderRadius: isToday ? 999 : 0,
+                              minWidth: 18,
+                              textAlign: 'center',
+                            }}
+                          >
+                            {day.getDate()}
+                          </span>
+                          {dayEvents.length > 0 && (
+                            <span className="v5-mono" style={{ fontSize: 9, color: 'var(--v5-mut)' }}>
+                              {dayEvents.length}
+                            </span>
+                          )}
+                        </div>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                          {dayEvents.slice(0, 2).map((e) => (
+                            <div
+                              key={e.id}
+                              title={`${e.title} (${e.status})`}
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 4,
+                                fontSize: 10,
+                                color: 'var(--v5-txt)',
+                                background: 'var(--v5-sur2)',
+                                borderRadius: 5,
+                                padding: '2px 5px',
+                              }}
+                            >
+                              <span style={{ width: 5, height: 5, borderRadius: '50%', background: statusColor(e.status), flexShrink: 0 }} />
+                              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.title}</span>
+                            </div>
+                          ))}
+                          {dayEvents.length > 2 && (
+                            <div style={{ fontSize: 9, color: 'var(--v5-mut)' }}>+{dayEvents.length - 2}</div>
+                          )}
+                        </div>
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
           </div>
         </Card>
 

--- a/parkhub-web/src/design-v5/screens/Profil.tsx
+++ b/parkhub-web/src/design-v5/screens/Profil.tsx
@@ -28,10 +28,25 @@ const inputStyle: CSSProperties = {
   fontFamily: 'inherit',
 };
 
-function Field({ label, children, hint }: { label: string; children: ReactNode; hint?: ReactNode }) {
+function Field({
+  label,
+  children,
+  hint,
+  htmlFor,
+}: {
+  label: string;
+  children: ReactNode;
+  hint?: ReactNode;
+  /** id of the form control this label describes — required for WCAG 2.1 AA
+   *  `label` rule. Callers pass the same value as the rendered input's `id`. */
+  htmlFor?: string;
+}) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      <label style={{ fontSize: 11, fontWeight: 500, color: 'var(--v5-mut)', display: 'inline-flex', alignItems: 'center' }}>
+      <label
+        htmlFor={htmlFor}
+        style={{ fontSize: 11, fontWeight: 500, color: 'var(--v5-mut)', display: 'inline-flex', alignItems: 'center' }}
+      >
         {label}
         {hint}
       </label>
@@ -155,7 +170,7 @@ export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
           <SectionLabel>Kontoinformation</SectionLabel>
         </div>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-          <Field label="Name">
+          <Field label="Name" htmlFor="profil-name">
             <input
               id="profil-name"
               type="text"
@@ -166,6 +181,7 @@ export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
           </Field>
           <Field
             label="E-Mail"
+            htmlFor="profil-email"
             hint={
               <HelpTip label="Hinweis zur E-Mail">
                 E-Mail-Bestätigung erforderlich
@@ -231,8 +247,9 @@ export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
         </div>
         {pwOpen && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            <Field label="Aktuelles Passwort">
+            <Field label="Aktuelles Passwort" htmlFor="profil-pw-current">
               <input
+                id="profil-pw-current"
                 type="password"
                 value={pwCurrent}
                 onChange={(e) => setPwCurrent(e.target.value)}
@@ -241,8 +258,9 @@ export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
               />
             </Field>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-              <Field label="Neues Passwort">
+              <Field label="Neues Passwort" htmlFor="profil-pw-new">
                 <input
+                  id="profil-pw-new"
                   type="password"
                   value={pwNew}
                   onChange={(e) => setPwNew(e.target.value)}
@@ -250,8 +268,9 @@ export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
                   autoComplete="new-password"
                 />
               </Field>
-              <Field label="Bestätigen">
+              <Field label="Bestätigen" htmlFor="profil-pw-confirm">
                 <input
+                  id="profil-pw-confirm"
                   type="password"
                   value={pwConfirm}
                   onChange={(e) => setPwConfirm(e.target.value)}

--- a/parkhub-web/src/design-v5/screens/Team.tsx
+++ b/parkhub-web/src/design-v5/screens/Team.tsx
@@ -153,7 +153,15 @@ export function TeamV5({ navigate: _navigate }: { navigate: (id: ScreenId) => vo
   const presentCount = Math.max(0, members.length - todayEntries.length);
 
   return (
-    <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+    // tabIndex=0 + aria-label satisfies axe `scrollable-region-focusable`:
+    // scrollable containers need a keyboard entry point so non-mouse users
+    // can reach overflowing content. Region role surfaces the scope to AT.
+    <div
+      role="region"
+      aria-label="Team-Übersicht"
+      tabIndex={0}
+      style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}
+    >
       <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Team</span>


### PR DESCRIPTION
## Summary

- Add `e2e/v5-a11y.spec.ts` — one axe-core run per v5 screen, fails on any serious/critical WCAG 2.1 AA violation.
- Fix 5 blockers surfaced by the red-first run against the Render demo:
  - **Dashboard** — Credits bar `aria-label` on bare `<div>` → `role="progressbar"` + valuenow/min/max (fixes `aria-prohibited-attr` serious).
  - **Profil** — account + password inputs had no associated `<label>` → extended `Field` wrapper with `htmlFor` prop, wired ids on all five controls (fixes `label` critical).
  - **Kalender** — `role="grid"` held columnheaders directly → wrapped weekday headers in `role="row"` and grouped day buttons into weekly `role="row"` blocks with `role="gridcell"` cells (fixes `aria-required-children` / `aria-required-parent` critical).
  - **Team** — scrollable root had no keyboard entry → `role="region"` + `aria-label` + `tabIndex=0` (fixes `scrollable-region-focusable` serious).
  - **Einchecken** — same scrollable-root pattern applied defensively (flaked on Render cold-start, code path identical to Team).
- Wire the spec into the existing `e2e-smoke` CI job so regressions fail PRs.

## Test plan

- [x] `npm run build` in `parkhub-web/` — clean
- [x] Unit tests for affected screens — 31/31 pass (Profil / Kalender / Team / Einchecken)
- [x] Local static build served via `python -m http.server`, axe across all 26 v5 screens — 26/26 pass WCAG 2.1 AA
- [ ] CI `e2e-smoke` green against seeded Laravel
- [ ] Post-merge: `curl https://parkhub-php-demo.onrender.com/v5/` still 200

## Notes

- `color-contrast` is disabled in the axe call — v5 drives colour tokens via CSS custom properties + OKLCH, reviewed separately through the design-system tooling.
- Minor / moderate axe findings are not enforced here (pragmatic cut-off matching the existing root `a11y.spec.ts`).
- Rust mirror PR coming next in `nash87/parkhub-rust`.