### PR TITLE
test(a11y): Dashboard/Profil regression guards + PWA OfflineIndicator wire-up

### DIFF
--- a/parkhub-web/src/App.test.tsx
+++ b/parkhub-web/src/App.test.tsx
@@ -574,4 +574,13 @@ describe('App', () => {
       });
     });
   }
+
+  it('imports OfflineIndicator from components/PWAEnhanced so it can mount at the app shell', async () => {
+    // Direct named-import wiring check: the App module must pull
+    // OfflineIndicator from components/PWAEnhanced. If it does not,
+    // the offline banner never reaches the user when navigator.onLine flips.
+    const appSource = await import('./App?raw');
+    expect(appSource.default).toMatch(/from ['"]\.\/components\/PWAEnhanced['"]/);
+    expect(appSource.default).toMatch(/OfflineIndicator/);
+  });
 });

--- a/parkhub-web/src/App.tsx
+++ b/parkhub-web/src/App.tsx
@@ -20,6 +20,10 @@ import { GlobalCommandPalette } from './design-v5/GlobalCommandPalette';
 // (login, welcome, register) never pay its ~150KB cost in the main chunk.
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { CommandPaletteProvider } from './components/CommandPaletteProvider';
+// PWA offline banner — eager so it can fire the moment connectivity drops.
+// Component is tiny (≈1KB after gzip) and gates on navigator.onLine, so it
+// renders nothing on the happy path.
+import { OfflineIndicator } from './components/PWAEnhanced';
 
 // Lazy helper — wraps named exports for React.lazy and auto-registers
 // the module loader for hover-intent prefetching.
@@ -297,6 +301,9 @@ export function App() {
         <UseCaseProvider>
         <FeaturesProvider>
         <AuthProvider>
+          {/* PWA offline banner — mounted top-level, no idle defer, so the
+              user is told the moment connectivity drops. role="alert". */}
+          <OfflineIndicator />
           <AppRoutes />
           <DeferredOverlays />
           {/* v5 ⌘K palette — mounted globally, works on every route. */}

--- a/parkhub-web/src/design-v5/screens/Dashboard.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Dashboard.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../Toast', () => ({
+  useV5Toast: () => vi.fn(),
+  V5ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@number-flow/react', () => ({
+  default: ({ value }: { value: number | string }) => <span>{value}</span>,
+}));
+
+import { DashboardV5 } from './Dashboard';
+
+describe('DashboardV5 — credits progressbar a11y', () => {
+  it('exposes role=progressbar with aria-label, valuenow, valuemin, valuemax', () => {
+    render(<DashboardV5 navigate={vi.fn()} />);
+    const meter = screen.getByRole('progressbar', { name: /\d+ von \d+ Credits/ });
+    expect(meter).toHaveAttribute('aria-valuenow', '40');
+    expect(meter).toHaveAttribute('aria-valuemin', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '40');
+  });
+});

--- a/parkhub-web/src/design-v5/screens/Profil.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Profil.test.tsx
@@ -172,4 +172,29 @@ describe('ProfilV5', () => {
     });
     expect(mockToast).not.toHaveBeenCalledWith('Passwort geändert', 'success');
   });
+
+  it('associates each Field label with its input via htmlFor + matching id (WCAG 2.1 AA)', async () => {
+    mockMe.mockResolvedValue({ success: true, data: USER });
+    const { container } = renderScreen();
+    await waitFor(() => expect(screen.getByDisplayValue('Florian Kaiser')).toBeInTheDocument());
+    // Open password panel so all 5 form inputs are present
+    fireEvent.click(screen.getByTestId('profil-pw-toggle'));
+    await waitFor(() => {
+      expect(document.querySelectorAll('input[type="password"]').length).toBe(3);
+    });
+
+    const labels = container.querySelectorAll<HTMLLabelElement>('label[for]');
+    expect(labels.length).toBeGreaterThanOrEqual(5);
+    for (const label of labels) {
+      const forId = label.getAttribute('for')!;
+      const input = container.querySelector(`#${forId}`);
+      expect(input, `label[for="${forId}"] must point at a real input`).not.toBeNull();
+      expect(input?.tagName).toBe('INPUT');
+    }
+    // Sanity-check the five expected ids are present
+    for (const id of ['profil-name', 'profil-email', 'profil-pw-current', 'profil-pw-new', 'profil-pw-confirm']) {
+      expect(container.querySelector(`#${id}`), `expected input id "${id}"`).not.toBeNull();
+      expect(container.querySelector(`label[for="${id}"]`), `expected label for "${id}"`).not.toBeNull();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
Consolidates the 2026-04-18 design bundle (parkhub-design-1) against shipped main:

- **Dashboard credits meter** had `role=progressbar` + `aria-value*` attrs landed via PR #346 but no regression test. Adds one.
- **Profil Field helper** had `htmlFor` wired in PR #346 but no test asserting label↔input association. Adds one that walks every `label[for]` and verifies a matching `input#id` exists.
- **PWA OfflineIndicator** (from `components/PWAEnhanced`) was implemented + unit-tested but never imported by `App.tsx`, so the WifiSlash `role=alert` banner never reached users when `navigator.onLine` flipped. Mounted eager (≈1KB gz, gates on `navigator.onLine`, no LCP cost).

TDD verified for all three:
- RED on each fix by temporarily stripping the attribute / removing the import.
- GREEN by restoring.
- 104 tests pass across `App.test`, `Dashboard.test`, `Profil.test`, `PWAEnhanced.test`.

## Test plan
- [x] `vitest run src/design-v5/screens/Dashboard.test.tsx` — 1 pass
- [x] `vitest run src/design-v5/screens/Profil.test.tsx` — 10 pass
- [x] `vitest run src/App.test.tsx` — 76 pass
- [x] `vitest run src/components/PWAEnhanced.test.tsx` — 17 pass
- [ ] Merge → verify on Render that OfflineIndicator banner appears when devtools toggle "offline"
- [ ] Mirror to `parkhub-rust` (follow-up PR same branch name)

Both repos are byte-identical for `Dashboard.tsx`, `Profil.tsx`, `manifest.json`, `sw.js`, `PWAEnhanced.tsx`, and `App.tsx`, so the rust PR is a literal cherry-pick.

T-1999.