### PR TITLE
ci(codeql): add actions language analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - language: actions
+            build-mode: none
           - language: javascript-typescript
             build-mode: none
 


### PR DESCRIPTION
Mirror of parkhub-rust #402. Closes the actions configuration error in code-scanning UI.