### PR TITLE
ci(deps): pin past tailwind 4.2.4 vite regression

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,15 @@ updates:
       npm-tooling-deps:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # tailwindcss 4.2.4 / @tailwindcss/vite 4.2.4 ship a vite build
+      # regression: "Missing field tsconfigPaths on
+      # BindingViteResolvePluginConfig.resolveOptions". Pin past it
+      # until 4.2.5+ is released. Drop these entries once upstream ships.
+      - dependency-name: "tailwindcss"
+        versions: ["4.2.4"]
+      - dependency-name: "@tailwindcss/vite"
+        versions: ["4.2.4"]
     labels: ["dependencies", "ci"]
     open-pull-requests-limit: 5
 
@@ -36,6 +45,15 @@ updates:
       npm-deps:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # tailwindcss 4.2.4 / @tailwindcss/vite 4.2.4 ship a vite build
+      # regression: "Missing field tsconfigPaths on
+      # BindingViteResolvePluginConfig.resolveOptions". Pin past it
+      # until 4.2.5+ is released. Drop these entries once upstream ships.
+      - dependency-name: "tailwindcss"
+        versions: ["4.2.4"]
+      - dependency-name: "@tailwindcss/vite"
+        versions: ["4.2.4"]
     labels: ["dependencies", "frontend"]
     open-pull-requests-limit: 5
 


### PR DESCRIPTION
## Summary

`tailwindcss@4.2.4` and `@tailwindcss/vite@4.2.4` ship a vite build regression:

> Missing field `tsconfigPaths` on `BindingViteResolvePluginConfig.resolveOptions`

This breaks vite builds. Pin past it via dependabot `ignore` on **both** npm ecosystem entries (root tooling at `/` and `/parkhub-web` frontend) until 4.2.5+ is released.

## What changes

Adds an `ignore` block to both `npm` ecosystem entries:

```yaml
ignore:
  - dependency-name: "tailwindcss"
    versions: ["4.2.4"]
  - dependency-name: "@tailwindcss/vite"
    versions: ["4.2.4"]
```

(The root `package.json` currently only has `@tailwindcss/vite` and `tailwindcss@^3.4.19`, so the 4.2.4 pin on `tailwindcss` at root is a no-op today, but kept for symmetry / future-proof if root gets bumped to v4.)

## Follow-up

Once upstream ships 4.2.5+ (or a 4.3.x line), remove the `ignore` entries so dependabot can resume normal bumps.

## Test plan

- [ ] dependabot.yml parses (Dependabot validates on next scheduled run)
- [ ] Future tailwind 4.2.5+ PRs are still proposed (4.2.4 is the only blocked version)