### PR TITLE
fix(deps): override uuid to ^14.0.0 (close GHSA-w5hq-g745-h8pq)

### DIFF
--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -15536,13 +15536,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "node": ">=22.12.0"
   },
+  "overrides": {
+    "uuid": "^14.0.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
Closes the open Dependabot alert via npm `overrides`. uuid 8.3.2 was transitive (storybook test-runner, istanbul, jest-junit) — dev/test only, no real exposure. Override forces all transitive resolutions to ^14.0.0. Verified: `npm install --package-lock-only` reports '0 vulnerabilities'.