### PR TITLE
fix(v5/policies): only re-init draft on activeId change

### DIFF
--- a/parkhub-web/src/design-v5/screens/Policies.tsx
+++ b/parkhub-web/src/design-v5/screens/Policies.tsx
@@ -36,8 +36,12 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
   const active = policies.find((p) => p.id === activeId) ?? null;
 
   useEffect(() => {
-    if (active) { setDraft(active.body); setPreview(false); }
-  }, [active]);
+    const p = policies.find((x) => x.id === activeId);
+    if (p) { setDraft(p.body); setPreview(false); }
+    // Only depend on activeId: refetches produce a new policies array, which
+    // would otherwise clobber the user's in-flight draft on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeId]);
 
   const save = useMutation({
     mutationFn: async (payload: { id: string; body: string }) => {


### PR DESCRIPTION
## Root cause

`Policies.tsx` hydrated the editor from `active.body` via `useEffect(..., [active])`,
where `active = policies.find(...)` returns a fresh object reference on every render.
Any re-render (toast, refetch, mutation settle) re-fired the effect and clobbered
in-flight user edits — the editor snapped back to the server value, `isDirty`
became false, and the save button stuck disabled.

This is the bug behind the frontend test failures we'd otherwise hit when adding
new mutation tests against this screen.

## Fix

Depend on `activeId` only. Refetches still update the underlying policy in the
background, but they no longer reset the user's draft.

## Verification

```
$ npx vitest run src/design-v5/screens/Policies.test.tsx
Test Files  1 passed (1)
     Tests  7 passed (7)
```

Mirror of parkhub-rust#407.