### PR TITLE
ci(deps): Dependabot cooldown + tailwind 4.2.3 ignore + align github-actions group with rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,21 @@
 version: 2
 updates:
-  # GitHub Actions — group all action bumps into one PR
+  # GitHub Actions — group all minor + patch action bumps. Major bumps
+  # remain individual so workflow YAML can be reviewed action-by-action.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     groups:
-      actions:
+      github-actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "ci"]
     open-pull-requests-limit: 5
 
@@ -24,14 +31,19 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
     ignore:
-      # tailwindcss 4.2.4 / @tailwindcss/vite 4.2.4 ship a vite build
+      # tailwindcss + @tailwindcss/vite 4.2.3 and 4.2.4 ship a vite build
       # regression: "Missing field tsconfigPaths on
-      # BindingViteResolvePluginConfig.resolveOptions". Pin past it
-      # until 4.2.5+ is released. Drop these entries once upstream ships.
+      # BindingViteResolvePluginConfig.resolveOptions". Pin past them
+      # until 4.2.5+ is verified green. Drop once upstream ships fix.
       - dependency-name: "tailwindcss"
-        versions: ["4.2.4"]
+        versions: [">=4.2.3 <4.2.5"]
       - dependency-name: "@tailwindcss/vite"
-        versions: ["4.2.4"]
+        versions: [">=4.2.3 <4.2.5"]
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "ci"]
     open-pull-requests-limit: 5
 
@@ -46,14 +58,19 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
     ignore:
-      # tailwindcss 4.2.4 / @tailwindcss/vite 4.2.4 ship a vite build
+      # tailwindcss + @tailwindcss/vite 4.2.3 and 4.2.4 ship a vite build
       # regression: "Missing field tsconfigPaths on
-      # BindingViteResolvePluginConfig.resolveOptions". Pin past it
-      # until 4.2.5+ is released. Drop these entries once upstream ships.
+      # BindingViteResolvePluginConfig.resolveOptions". Pin past them
+      # until 4.2.5+ is verified green. Drop once upstream ships fix.
       - dependency-name: "tailwindcss"
-        versions: ["4.2.4"]
+        versions: [">=4.2.3 <4.2.5"]
       - dependency-name: "@tailwindcss/vite"
-        versions: ["4.2.4"]
+        versions: [">=4.2.3 <4.2.5"]
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "frontend"]
     open-pull-requests-limit: 5
 
@@ -67,6 +84,11 @@ updates:
       composer-deps:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "php"]
     open-pull-requests-limit: 5
 
@@ -75,5 +97,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     labels: ["dependencies", "docker"]
     open-pull-requests-limit: 5


### PR DESCRIPTION
Mirror of nash87/parkhub-rust#409 plus a small alignment fix.

## 1. cooldown (NEW since 2025-07)

5/10/15-day delays for patch/minor/major bumps respectively. Stops same-day-released-then-broken patches from landing in our PR queue. Security advisories ignore cooldown, so no patch-window risk.

## 2. Tailwind ignore range

Was: `versions: ["4.2.4"]` discrete. Now: `versions: [">=4.2.3 <4.2.5"]` range. Same effect, less maintenance — applied to both npm sections (root tooling + parkhub-web).

## 3. github-actions section aligned with parkhub-rust

- group renamed from `actions` → `github-actions` (parity)
- added `update-types: ["minor", "patch"]` filter so major action bumps get individual review

## Sources
- https://github.blog/changelog/2025-07-29-dependabot-expanded-cooldown-and-package-manager-support/