### PR TITLE
docs: post-merge-train drift cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **Playwright `mobile-chrome` project**: `parkhub-web/playwright.config.ts` now registers a Pixel-5 viewport project so v5 specs can opt into mobile runs via `--project=mobile-chrome`, matching the parkhub-rust config.
+- **Customization Framework v5** — settings, sidebar variants, density, fonts, feature toggles, `deepLinking` gate (#353).
+- **Branding alignment** — user-facing v5 strings switched from "KI"/"AI" to "Assistent" (#355).
+- **CI security swap** — trufflehog (AGPL) replaced by gitleaks binary direct (MIT) (#365).
+- **CodeQL** — actions language analysis split into its own job (#364).
+- **uuid override** — pinned to ^14 to close GHSA-w5hq-g745-h8pq (#367).
+- **Deps** — tailwind pinned past 4.2.4 vite regression (#366).
+- **Policies fix** — `Policies.tsx` draft effect re-keyed on `activeId` only; previous dependency on the `active` object reference clobbered in-flight edits on every render (#370).
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -159,8 +159,9 @@ primitives ([docs.github.com/en/actions](https://docs.github.com/en/actions)):
 - **CodeQL** — `codeql.yml` currently scans the JS/TS surfaces on every PR.
 - **Dependency review** — PRs run `actions/dependency-review-action`, and the
   result is now folded into the main `required` gate in `ci.yml`.
-- **Secret scan** — trufflehog (`security.yml`) on every PR; composer audit
-  weekly; Trivy FS + image scan on every Dockerfile change.
+- **Secret scan** — `gitleaks` (MIT) binary direct in `security.yml` on every
+  PR over the full git history; replaced trufflehog (AGPL) on 2026-04-25 (#365).
+  Composer audit weekly; Trivy FS + image scan on every Dockerfile change.
 - **Artifact attestations** — `docker/build-push-action@v7` chains
   `actions/attest-build-provenance@v4` to publish SLSA v1 provenance for every
   pushed image. See

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/nash87/parkhub-php/actions/workflows/ci.yml"><img src="https://github.com/nash87/parkhub-php/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v4.13.0-brightgreen.svg?style=flat-square" alt="v4.13.0"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/Release-v4.13.4-brightgreen.svg?style=flat-square" alt="v4.13.4"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License"></a>
   <a href="https://www.php.net/"><img src="https://img.shields.io/badge/PHP-8.4-777BB4.svg?style=flat-square&logo=php&logoColor=white" alt="PHP 8.4"></a>
   <a href="https://laravel.com/"><img src="https://img.shields.io/badge/Laravel-13-FF2D20.svg?style=flat-square&logo=laravel&logoColor=white" alt="Laravel 13"></a>
@@ -68,7 +68,7 @@
 | **Themes** | OKLCH tokens across `marble_light`, `marble_dark`, `void`; self-hosted Inter-Variable keeps the LCP budget green. |
 | **Command Palette** | cmdk-powered, mounted globally, reachable from every route with `Cmd+K` / `Ctrl+K`. |
 | **Onboarding** | 3-step `/tour` wizard (Privacy -> Toggles -> Trust) guides first-time users before the Laravel app shell mounts. |
-| **Accessibility** | axe-core runs in CI on the v5 surfaces; keyboard-only nav verified for the full shell + AI panel. |
+| **Accessibility** | axe-core runs in CI on the v5 surfaces; keyboard-only nav verified for the full shell + Assistent panel. |
 | **Mobile** | Playwright now ships a `mobile-chrome` (Pixel 5) project so v5 specs can opt into mobile viewports on CI. |
 
 Live demo: <https://parkhub-php-demo.onrender.com>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -115,7 +115,7 @@ matrix + verification commands.
 - **`npm audit --omit=dev`** runs nightly; production JS dependencies are kept on known-clean versions.
 - **`roave/security-advisories`** is a `require-dev` dependency, which blocks `composer install` from bringing in a Composer package that has a published CVE.
 - **Trivy** filesystem scan (`vuln,misconfig`) runs on every push and nightly, uploading SARIF to the GitHub Security tab.
-- **`trufflehog`** secret scan runs on every push over the full git history; it reports only verified/unknown credentials to keep false positives low.
+- **`gitleaks`** (MIT) secret scan runs on every push over the full git history. Replaced trufflehog (AGPL) on 2026-04-25 (#365) — invoked as the upstream binary directly (gitleaks-action wrapper switched to a proprietary EULA in v2).
 - **Docker images** are built with `provenance: mode=max, sbom: true` and signed via `actions/attest-build-provenance`, giving SLSA L3 attestations downloadable from the release assets.
 
 ## Full Security Documentation


### PR DESCRIPTION
Five doc fixes flagged by audit after today's merge train.

- **README.md** badge: v4.13.0 → v4.13.4 (matches VERSION file)
- **README.md** Accessibility row: "AI panel" → "Assistent panel" (#355)
- **SECURITY.md** secret-scan section: gitleaks binary direct, not trufflehog (#365)
- **DEVELOPMENT.md** same trufflehog→gitleaks update
- **CHANGELOG.md** `[Unreleased]` gains 7 entries for #353 / #355 / #365 / #364 / #367 / #366 / #370

Doc-only, zero code changes. Mirror of nash87/parkhub-rust#410.