### PR TITLE
fix(v5/analytics): wait for lazy UPlotChart canvases (mirrors parkhub-rust)

### DIFF
--- a/parkhub-web/src/design-v5/screens/Analytics.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Analytics.test.tsx
@@ -82,8 +82,13 @@ describe('AnalyticsV5', () => {
       expect(screen.getByRole('img', { name: /Auslastung nach Stunde/ })).toBeInTheDocument(),
     );
     expect(screen.getByRole('img', { name: /Auslastung nach Wochentag/ })).toBeInTheDocument();
+    // UPlotChart is lazy()-loaded and the Suspense fallback shares the
+    // aria-label, so the role match alone can land on the placeholder.
+    // Wait for the actual canvases to ensure the chunk has resolved.
     // uPlot renders canvas, not inline-SVG <rect>s — guard the regression.
-    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(2);
+    await waitFor(() =>
+      expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(2),
+    );
     expect(container.querySelectorAll('[data-testid="analytics-chart"] rect').length).toBe(0);
   });
 


### PR DESCRIPTION
Mirror of parkhub-rust fix. `UPlotChart` is `lazy()`-loaded; Suspense fallback shares the chart's aria-label, so `getByRole('img', {name})` matches the placeholder before the lazy chunk loads → `querySelectorAll('canvas').length = 0`. Wrap the count assertion in `waitFor`.

Verified: `npx vitest run` 11/11 pass.