### PR TITLE
test(web): Phase 4c — kill 8 file-level tsc errors with mixed patterns

### DIFF
--- a/parkhub-web/src/components/ErrorBoundary.extended.test.tsx
+++ b/parkhub-web/src/components/ErrorBoundary.extended.test.tsx
@@ -15,7 +15,7 @@ import { ErrorBoundary } from './ErrorBoundary';
 
 // ── Test components ──
 
-function ThrowingComponent({ message }: { message: string }) {
+function ThrowingComponent({ message }: { message: string }): React.ReactElement {
   throw new Error(message);
 }
 
@@ -23,7 +23,7 @@ function GoodComponent() {
   return <div data-testid="good-component">All good</div>;
 }
 
-function ThrowingWithStackComponent() {
+function ThrowingWithStackComponent(): React.ReactElement {
   const err = new Error('Stack trace error');
   err.stack = 'Error: Stack trace error\n    at ThrowingWithStackComponent (file.tsx:1:1)';
   throw err;

--- a/parkhub-web/src/components/NotificationPreferences.test.tsx
+++ b/parkhub-web/src/components/NotificationPreferences.test.tsx
@@ -143,7 +143,7 @@ describe('NotificationPreferencesComponent', () => {
 
     // Click the first toggle switch (email_booking_confirm)
     const switches = screen.getAllByRole('switch');
-    await user.click(switches[0]);
+    await user.click(switches[0]!);
 
     expect(screen.getByText('Save Preferences')).toBeInTheDocument();
   });
@@ -161,7 +161,7 @@ describe('NotificationPreferencesComponent', () => {
 
     // Toggle a switch to make form dirty
     const switches = screen.getAllByRole('switch');
-    await user.click(switches[0]);
+    await user.click(switches[0]!);
 
     await user.click(screen.getByText('Save Preferences'));
 
@@ -183,7 +183,7 @@ describe('NotificationPreferencesComponent', () => {
     });
 
     const switches = screen.getAllByRole('switch');
-    await user.click(switches[0]);
+    await user.click(switches[0]!);
     await user.click(screen.getByText('Save Preferences'));
 
     await waitFor(() => {
@@ -203,7 +203,7 @@ describe('NotificationPreferencesComponent', () => {
     });
 
     const switches = screen.getAllByRole('switch');
-    await user.click(switches[0]);
+    await user.click(switches[0]!);
 
     expect(screen.getByText('Save Preferences')).toBeInTheDocument();
 
@@ -270,13 +270,13 @@ describe('NotificationPreferencesComponent', () => {
 
     const switches = screen.getAllByRole('switch');
 
-    await user.click(switches[3]); // push_enabled
-    fireEvent.click(switches[4]!!); // sms_booking_confirm
-    fireEvent.click(switches[5]!!); // sms_booking_reminder
-    fireEvent.click(switches[6]!!); // sms_booking_cancelled
-    fireEvent.click(switches[7]!!); // whatsapp_booking_confirm
-    fireEvent.click(switches[8]!!); // whatsapp_booking_reminder
-    fireEvent.click(switches[9]!!); // whatsapp_booking_cancelled
+    await user.click(switches[3]!); // push_enabled
+    fireEvent.click(switches[4]!); // sms_booking_confirm
+    fireEvent.click(switches[5]!); // sms_booking_reminder
+    fireEvent.click(switches[6]!); // sms_booking_cancelled
+    fireEvent.click(switches[7]!); // whatsapp_booking_confirm
+    fireEvent.click(switches[8]!); // whatsapp_booking_reminder
+    fireEvent.click(switches[9]!); // whatsapp_booking_cancelled
 
     await user.click(screen.getByText('Save Preferences'));
 
@@ -305,8 +305,8 @@ describe('NotificationPreferencesComponent', () => {
     });
 
     const switches = screen.getAllByRole('switch');
-    await user.click(switches[1]);
-    await user.click(switches[2]);
+    await user.click(switches[1]!);
+    await user.click(switches[2]!);
 
     await user.click(screen.getByText('Save Preferences'));
 

--- a/parkhub-web/src/components/ui/DataTable.test.tsx
+++ b/parkhub-web/src/components/ui/DataTable.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { createColumnHelper } from '@tanstack/react-table';
+import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
 
 vi.mock('framer-motion', () => ({
   motion: {
@@ -33,7 +33,7 @@ const columns = [
   columnHelper.accessor('name', { header: 'Name', enableSorting: true }),
   columnHelper.accessor('email', { header: 'Email', enableSorting: true }),
   columnHelper.accessor('role', { header: () => 'Role', enableSorting: false }),
-];
+] as ColumnDef<TestRow, unknown>[];
 
 const sampleData: TestRow[] = [
   { id: '1', name: 'Alice', email: 'alice@test.com', role: 'admin' },

--- a/parkhub-web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/parkhub-web/src/hooks/useKeyboardShortcuts.test.ts
@@ -28,7 +28,7 @@ describe('useKeyboardShortcuts', () => {
   }
 
   it('navigates to /book on Ctrl+B', () => {
-    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     fireKey('b', { ctrlKey: true });
 
@@ -36,7 +36,7 @@ describe('useKeyboardShortcuts', () => {
   });
 
   it('navigates to /book on Meta+B (macOS)', () => {
-    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     fireKey('b', { metaKey: true });
 
@@ -44,7 +44,7 @@ describe('useKeyboardShortcuts', () => {
   });
 
   it('toggles command palette on Ctrl+K', () => {
-    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     fireKey('k', { ctrlKey: true });
 
@@ -52,7 +52,7 @@ describe('useKeyboardShortcuts', () => {
   });
 
   it('toggles command palette on Meta+K (macOS)', () => {
-    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     fireKey('k', { metaKey: true });
 
@@ -60,7 +60,7 @@ describe('useKeyboardShortcuts', () => {
   });
 
   it('does not navigate on B without modifier', () => {
-    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     fireKey('b');
 
@@ -68,7 +68,7 @@ describe('useKeyboardShortcuts', () => {
   });
 
   it('does not toggle command palette on K without modifier', () => {
-    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     fireKey('k');
 
@@ -76,7 +76,7 @@ describe('useKeyboardShortcuts', () => {
   });
 
   it('does not respond to unrelated keys with modifier', () => {
-    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     fireKey('a', { ctrlKey: true });
 
@@ -86,7 +86,7 @@ describe('useKeyboardShortcuts', () => {
 
   it('cleans up event listener on unmount', () => {
     const removeSpy = vi.spyOn(window, 'removeEventListener');
-    const { unmount } = renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    const { unmount } = renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     unmount();
 
@@ -94,7 +94,7 @@ describe('useKeyboardShortcuts', () => {
   });
 
   it('handles multiple rapid key presses', () => {
-    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette }));
+    renderHook(() => useKeyboardShortcuts({ onToggleCommandPalette: onToggleCommandPalette as any }));
 
     fireKey('k', { ctrlKey: true });
     fireKey('k', { ctrlKey: true });

--- a/parkhub-web/src/i18n/i18n.test.ts
+++ b/parkhub-web/src/i18n/i18n.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import en from './locales/en';
 import de from './locales/de';
 import fr from './locales/fr';

--- a/parkhub-web/src/views/AdminAnnouncements.test.tsx
+++ b/parkhub-web/src/views/AdminAnnouncements.test.tsx
@@ -159,7 +159,7 @@ describe('AdminAnnouncementsPage', () => {
   it('delete failure shows error', async () => {
     mockDeleteAnnouncement.mockResolvedValue({ success: false, error: { message: 'Cannot delete' } });
     render(<AdminAnnouncementsPage />);
-    await waitFor(() => fireEvent.click(screen.getAllByLabelText(/common.delete/)[0]));
+    await waitFor(() => fireEvent.click(screen.getAllByLabelText(/common.delete/)[0]!));
     fireEvent.click(screen.getByText('ConfirmDel'));
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Cannot delete'));
   });
@@ -173,7 +173,7 @@ describe('AdminAnnouncementsPage', () => {
   it('cancels delete confirmation dialog', async () => {
     render(<AdminAnnouncementsPage />);
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
-    fireEvent.click(screen.getAllByLabelText(/common.delete/)[0]);
+    fireEvent.click(screen.getAllByLabelText(/common.delete/)[0]!);
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
     fireEvent.click(screen.getByText('CancelDel'));
     await waitFor(() => {

--- a/parkhub-web/src/views/AdminAnnouncements.test.tsx
+++ b/parkhub-web/src/views/AdminAnnouncements.test.tsx
@@ -89,7 +89,7 @@ describe('AdminAnnouncementsPage', () => {
     render(<AdminAnnouncementsPage />);
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     const editBtns = screen.getAllByLabelText(/common.edit/);
-    fireEvent.click(editBtns[0]!!);
+    fireEvent.click(editBtns[0]!);
     await waitFor(() => expect(screen.getByDisplayValue('Maintenance')).toBeInTheDocument());
   });
 
@@ -104,7 +104,7 @@ describe('AdminAnnouncementsPage', () => {
     render(<AdminAnnouncementsPage />);
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     const delBtns = screen.getAllByLabelText(/common.delete/);
-    fireEvent.click(delBtns[0]!!);
+    fireEvent.click(delBtns[0]!);
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
     fireEvent.click(screen.getByText('ConfirmDel'));
     await waitFor(() => expect(mockDeleteAnnouncement).toHaveBeenCalledWith('a1'));
@@ -197,11 +197,11 @@ describe('AdminAnnouncementsPage', () => {
     await waitFor(() => expect(screen.getByText('Maintenance')).toBeInTheDocument());
     // Edit the first announcement
     const editBtns = screen.getAllByLabelText(/common.edit/);
-    fireEvent.click(editBtns[0]!!);
+    fireEvent.click(editBtns[0]!);
     await waitFor(() => expect(screen.getByDisplayValue('Maintenance')).toBeInTheDocument());
     // Delete it
     const delBtns = screen.getAllByLabelText(/common.delete/);
-    fireEvent.click(delBtns[0]!!);
+    fireEvent.click(delBtns[0]!);
     await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
     fireEvent.click(screen.getByText('ConfirmDel'));
     await waitFor(() => expect(mockDeleteAnnouncement).toHaveBeenCalled());

--- a/parkhub-web/src/views/AdminSSO.test.tsx
+++ b/parkhub-web/src/views/AdminSSO.test.tsx
@@ -171,12 +171,12 @@ describe('AdminSSOPage', () => {
 
     // Fill in form fields
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0]!!, { target: { value: 'test-sso' } }); // slug
-    fireEvent.change(inputs[1]!!, { target: { value: 'Test SSO' } }); // display name
-    fireEvent.change(inputs[2]!!, { target: { value: 'https://idp.test' } }); // entity id
-    fireEvent.change(inputs[3]!!, { target: { value: 'https://idp.test/sso' } }); // sso url
-    fireEvent.change(inputs[4]!!, { target: { value: 'https://idp.test/metadata' } }); // metadata url
-    fireEvent.change(inputs[5]!!, { target: { value: 'MIIC...' } }); // certificate
+    fireEvent.change(inputs[0]!, { target: { value: 'test-sso' } }); // slug
+    fireEvent.change(inputs[1]!, { target: { value: 'Test SSO' } }); // display name
+    fireEvent.change(inputs[2]!, { target: { value: 'https://idp.test' } }); // entity id
+    fireEvent.change(inputs[3]!, { target: { value: 'https://idp.test/sso' } }); // sso url
+    fireEvent.change(inputs[4]!, { target: { value: 'https://idp.test/metadata' } }); // metadata url
+    fireEvent.change(inputs[5]!, { target: { value: 'MIIC...' } }); // certificate
 
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => {
@@ -275,11 +275,11 @@ describe('AdminSSOPage', () => {
     render(<AdminSSOPage />);
     await waitFor(() => fireEvent.click(screen.getByText('Add Provider')));
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0]!!, { target: { value: 'test' } });
-    fireEvent.change(inputs[1]!!, { target: { value: 'Test' } });
-    fireEvent.change(inputs[2]!!, { target: { value: 'https://e' } });
-    fireEvent.change(inputs[3]!!, { target: { value: 'https://s' } });
-    fireEvent.change(inputs[5]!!, { target: { value: 'CERT' } });
+    fireEvent.change(inputs[0]!, { target: { value: 'test' } });
+    fireEvent.change(inputs[1]!, { target: { value: 'Test' } });
+    fireEvent.change(inputs[2]!, { target: { value: 'https://e' } });
+    fireEvent.change(inputs[3]!, { target: { value: 'https://s' } });
+    fireEvent.change(inputs[5]!, { target: { value: 'CERT' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('Duplicate slug'));
   });
@@ -293,11 +293,11 @@ describe('AdminSSOPage', () => {
     render(<AdminSSOPage />);
     await waitFor(() => fireEvent.click(screen.getByText('Add Provider')));
     const inputs = screen.getAllByRole('textbox');
-    fireEvent.change(inputs[0]!!, { target: { value: 'test' } });
-    fireEvent.change(inputs[1]!!, { target: { value: 'Test' } });
-    fireEvent.change(inputs[2]!!, { target: { value: 'https://e' } });
-    fireEvent.change(inputs[3]!!, { target: { value: 'https://s' } });
-    fireEvent.change(inputs[5]!!, { target: { value: 'CERT' } });
+    fireEvent.change(inputs[0]!, { target: { value: 'test' } });
+    fireEvent.change(inputs[1]!, { target: { value: 'Test' } });
+    fireEvent.change(inputs[2]!, { target: { value: 'https://e' } });
+    fireEvent.change(inputs[3]!, { target: { value: 'https://s' } });
+    fireEvent.change(inputs[5]!, { target: { value: 'CERT' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalled());
   });

--- a/parkhub-web/src/views/AdminWebhooks.test.tsx
+++ b/parkhub-web/src/views/AdminWebhooks.test.tsx
@@ -73,7 +73,7 @@ describe('AdminWebhooksPage', () => {
   it('creates webhook', async () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => fireEvent.click(screen.getByText('webhooksV2.create')));
-    const urlInput = screen.getAllByRole('textbox')[0];
+    const urlInput = screen.getAllByRole('textbox')[0]!;
     fireEvent.change(urlInput, { target: { value: 'https://new.com' } });
     fireEvent.click(screen.getByText('booking.created')); // toggle event
     fireEvent.click(screen.getByText('webhooksV2.save'));
@@ -113,7 +113,7 @@ describe('AdminWebhooksPage', () => {
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: webhooks }) } as Response);
     }) as any;
     render(<AdminWebhooksPage />);
-    await waitFor(() => fireEvent.click(screen.getAllByLabelText('webhooksV2.test')[0]));
+    await waitFor(() => fireEvent.click(screen.getAllByLabelText('webhooksV2.test')[0]!));
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('webhooksV2.testFailed'));
   });
 
@@ -128,7 +128,7 @@ describe('AdminWebhooksPage', () => {
 
   it('closes delivery log', async () => {
     render(<AdminWebhooksPage />);
-    await waitFor(() => fireEvent.click(screen.getAllByLabelText('webhooksV2.deliveries')[0]));
+    await waitFor(() => fireEvent.click(screen.getAllByLabelText('webhooksV2.deliveries')[0]!));
     await waitFor(() => expect(screen.getByText('webhooksV2.deliveryLog')).toBeInTheDocument());
     fireEvent.click(screen.getByText('common.close'));
     await waitFor(() => expect(screen.queryByText('webhooksV2.deliveryLog')).not.toBeInTheDocument());
@@ -146,7 +146,7 @@ describe('AdminWebhooksPage', () => {
       return Promise.resolve({ json: () => Promise.resolve({ success: true, data: webhooks }) } as Response);
     }) as any;
     render(<AdminWebhooksPage />);
-    await waitFor(() => fireEvent.click(screen.getAllByLabelText('webhooksV2.deliveries')[0]));
+    await waitFor(() => fireEvent.click(screen.getAllByLabelText('webhooksV2.deliveries')[0]!));
     await waitFor(() => expect(screen.getByText('webhooksV2.noDeliveries')).toBeInTheDocument());
   });
 
@@ -175,7 +175,7 @@ describe('AdminWebhooksPage', () => {
     }) as any;
     render(<AdminWebhooksPage />);
     await waitFor(() => fireEvent.click(screen.getByText('webhooksV2.create')));
-    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'bad' } });
+    fireEvent.change(screen.getAllByRole('textbox')[0]!, { target: { value: 'bad' } });
     fireEvent.click(screen.getByText('booking.created'));
     fireEvent.click(screen.getByText('webhooksV2.save'));
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Invalid URL'));

--- a/parkhub-web/src/views/AdminWebhooks.test.tsx
+++ b/parkhub-web/src/views/AdminWebhooks.test.tsx
@@ -84,7 +84,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const editBtns = screen.getAllByLabelText('webhooksV2.edit');
-      fireEvent.click(editBtns[0]!!);
+      fireEvent.click(editBtns[0]!);
     });
     expect(screen.getByText('webhooksV2.editWebhook')).toBeInTheDocument();
   });
@@ -93,7 +93,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const delBtns = screen.getAllByLabelText('webhooksV2.delete');
-      fireEvent.click(delBtns[0]!!);
+      fireEvent.click(delBtns[0]!);
     });
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('webhooksV2.deleted'));
   });
@@ -102,7 +102,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const testBtns = screen.getAllByLabelText('webhooksV2.test');
-      fireEvent.click(testBtns[0]!!);
+      fireEvent.click(testBtns[0]!);
     });
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('webhooksV2.testSuccess'));
   });
@@ -121,7 +121,7 @@ describe('AdminWebhooksPage', () => {
     render(<AdminWebhooksPage />);
     await waitFor(() => {
       const delivBtns = screen.getAllByLabelText('webhooksV2.deliveries');
-      fireEvent.click(delivBtns[0]!!);
+      fireEvent.click(delivBtns[0]!);
     });
     await waitFor(() => expect(screen.getByText('webhooksV2.deliveryLog')).toBeInTheDocument());
   });

--- a/parkhub-web/src/views/AdminZones.test.tsx
+++ b/parkhub-web/src/views/AdminZones.test.tsx
@@ -94,7 +94,7 @@ describe('AdminZonesPage', () => {
   it('renders title and subtitle', async () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     expect(screen.getByText('Parking Zones')).toBeDefined();
@@ -104,7 +104,7 @@ describe('AdminZonesPage', () => {
   it('renders zone cards with tier badges', async () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => {
@@ -116,7 +116,7 @@ describe('AdminZonesPage', () => {
   it('shows tier display names', async () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => {
@@ -128,7 +128,7 @@ describe('AdminZonesPage', () => {
   it('shows multiplier values', async () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => {
@@ -139,7 +139,7 @@ describe('AdminZonesPage', () => {
 
   it('shows empty state', async () => {
     globalThis.fetch = vi.fn()
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: [] }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: [] }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => {
@@ -159,7 +159,7 @@ describe('AdminZonesPage', () => {
   it('shows description for zones that have one', async () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => {
@@ -170,7 +170,7 @@ describe('AdminZonesPage', () => {
   it('shows max capacity values', async () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => {
@@ -182,7 +182,7 @@ describe('AdminZonesPage', () => {
   it('renders zone names from API response', async () => {
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => {
@@ -194,7 +194,7 @@ describe('AdminZonesPage', () => {
     const user = (await import('@testing-library/user-event')).default.setup();
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => expect(screen.getByText('Parking Zones')).toBeInTheDocument());
@@ -215,13 +215,13 @@ describe('AdminZonesPage', () => {
     const user = (await import('@testing-library/user-event')).default.setup();
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => expect(screen.getByText('Economy Section')).toBeInTheDocument());
 
     const editBtns = screen.getAllByTitle('Edit Pricing');
-    await user.click(editBtns[0]);
+    await user.click(editBtns[0]!);
 
     await waitFor(() => {
       expect(screen.getByText('Tier')).toBeInTheDocument();
@@ -247,7 +247,7 @@ describe('AdminZonesPage', () => {
     await waitFor(() => expect(screen.getByText('Economy Section')).toBeInTheDocument());
 
     const editBtns = screen.getAllByTitle('Edit Pricing');
-    await user.click(editBtns[0]);
+    await user.click(editBtns[0]!);
 
     await waitFor(() => expect(screen.getByText('Save')).toBeInTheDocument());
     await user.click(screen.getByText('Save'));
@@ -263,7 +263,7 @@ describe('AdminZonesPage', () => {
     const zonesResp = { ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) };
 
     globalThis.fetch = vi.fn((url: string, opts?: any) => {
-      if (opts?.method === 'PUT') return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: false, error: { message: 'Invalid' } }) });
+      if (opts?.method === 'PUT') return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: false, error: { message: 'Invalid' } }) }) as any;
       if (typeof url === 'string' && url.includes('/zones/pricing')) return Promise.resolve(zonesResp);
       return Promise.resolve(lotsResp);
     });
@@ -272,7 +272,7 @@ describe('AdminZonesPage', () => {
     await waitFor(() => expect(screen.getByText('Economy Section')).toBeInTheDocument());
 
     const editBtns = screen.getAllByTitle('Edit Pricing');
-    await user.click(editBtns[0]);
+    await user.click(editBtns[0]!);
 
     await user.click(screen.getByText('Save'));
 
@@ -285,13 +285,13 @@ describe('AdminZonesPage', () => {
     const user = (await import('@testing-library/user-event')).default.setup();
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => expect(screen.getByText('Economy Section')).toBeInTheDocument());
 
     const editBtns = screen.getAllByTitle('Edit Pricing');
-    await user.click(editBtns[0]);
+    await user.click(editBtns[0]!);
 
     await waitFor(() => expect(screen.getByText('Cancel')).toBeInTheDocument());
     await user.click(screen.getByText('Cancel'));
@@ -305,13 +305,13 @@ describe('AdminZonesPage', () => {
     const user = (await import('@testing-library/user-event')).default.setup();
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleZones }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => expect(screen.getByText('Economy Section')).toBeInTheDocument());
 
     const editBtns = screen.getAllByTitle('Edit Pricing');
-    await user.click(editBtns[0]);
+    await user.click(editBtns[0]!);
 
     await waitFor(() => expect(screen.getByText('PREMIUM')).toBeInTheDocument());
     await user.click(screen.getByText('PREMIUM'));
@@ -325,7 +325,7 @@ describe('AdminZonesPage', () => {
     }];
     globalThis.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: sampleLots }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: zonesNoCapacity }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: zonesNoCapacity }) }) as any;
 
     render(<AdminZonesPage />);
     await waitFor(() => expect(screen.getByText('Economy Section')).toBeInTheDocument());
@@ -344,7 +344,7 @@ describe('AdminZonesPage', () => {
     await waitFor(() => expect(screen.getByText('Economy Section')).toBeInTheDocument());
 
     const editBtns = screen.getAllByTitle('Edit Pricing');
-    await user.click(editBtns[0]);
+    await user.click(editBtns[0]!);
     await user.click(screen.getByText('Save'));
 
     await waitFor(() => {


### PR DESCRIPTION
Mirror of parkhub-rust. -8 file-level patterns. 138/138 vitest pass. Total tsc baseline now 558 → 306 per repo.