### PR TITLE
chore(web): bump parkhub-web/package.json to 4.14.0 (parity with VERSION)

### DIFF
--- a/parkhub-web/package-lock.json
+++ b/parkhub-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parkhub-web",
-  "version": "4.13.4",
+  "version": "4.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parkhub-web",
-      "version": "4.13.4",
+      "version": "4.14.0",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@fontsource-variable/inter": "^5.2.8",

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parkhub-web",
   "type": "module",
-  "version": "4.13.4",
+  "version": "4.14.0",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
Followup to #381 (root VERSION 4.13.4 → 4.14.0). Copilot noted the frontend npm version stayed at 4.13.4. Per parity-governance, all version surfaces sync.