### PR TITLE
refactor(web): mirror useDraftFromActive hook (parkhub-rust parity)

### DIFF
--- a/parkhub-web/src/design-v5/screens/Policies.tsx
+++ b/parkhub-web/src/design-v5/screens/Policies.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Card, SectionLabel, V5NamedIcon } from '../primitives';
 import { useV5Toast } from '../Toast';
 import { api, type Policy } from '../../api/client';
+import { useDraftFromActive } from '../../hooks/useDraftFromActive';
 import type { ScreenId } from '../nav';
 
 function formatWhen(iso: string): string {
@@ -16,7 +17,6 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
   const toast = useV5Toast();
   const qc = useQueryClient();
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [draft, setDraft] = useState('');
   const [preview, setPreview] = useState(false);
 
   const { data: policies = [], isLoading, isError } = useQuery({
@@ -35,13 +35,16 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
 
   const active = policies.find((p) => p.id === activeId) ?? null;
 
+  const [draftBody, setDraft, { isDirty: draftIsDirty }] = useDraftFromActive(
+    active,
+    { derive: (p: Policy) => p.body },
+  );
+  // Reset preview-mode whenever the user switches active id; the hook handles
+  // the draft itself.
   useEffect(() => {
-    const p = policies.find((x) => x.id === activeId);
-    if (p) { setDraft(p.body); setPreview(false); }
-    // Only depend on activeId: refetches produce a new policies array, which
-    // would otherwise clobber the user's in-flight draft on every render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setPreview(false);
   }, [activeId]);
+  const draft = draftBody ?? '';
 
   const save = useMutation({
     mutationFn: async (payload: { id: string; body: string }) => {
@@ -75,7 +78,7 @@ export function PoliciesV5({ navigate: _navigate }: { navigate: (id: ScreenId) =
     );
   }
 
-  const isDirty = active && draft !== active.body;
+  const isDirty = !!active && draftIsDirty;
 
   return (
     <div style={{ padding: 16, flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 12 }}>

--- a/parkhub-web/src/hooks/__tests__/useDraftFromActive.test.ts
+++ b/parkhub-web/src/hooks/__tests__/useDraftFromActive.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useDraftFromActive } from '../useDraftFromActive';
+
+interface Policy {
+  id: string;
+  title: string;
+  body: string;
+}
+
+const P1: Policy = { id: 'p1', title: 'AGB', body: 'Alter Text' };
+const P1_REFETCH: Policy = { id: 'p1', title: 'AGB', body: 'Alter Text' }; // same id, new ref
+const P1_UPSTREAM_EDIT: Policy = { id: 'p1', title: 'AGB', body: 'Server schreibt drüber' };
+const P2: Policy = { id: 'p2', title: 'Datenschutz', body: 'DSGVO' };
+
+describe('useDraftFromActive', () => {
+  it('seeds draft from active on initial mount', () => {
+    const { result } = renderHook(() =>
+      useDraftFromActive<Policy, string>(P1, { derive: (p) => p.body }),
+    );
+    const [draft] = result.current;
+    expect(draft).toBe('Alter Text');
+  });
+
+  it('initial mount with undefined active yields undefined draft', () => {
+    const { result } = renderHook(() =>
+      useDraftFromActive<Policy, string>(undefined, { derive: (p) => p.body }),
+    );
+    const [draft] = result.current;
+    expect(draft).toBeUndefined();
+  });
+
+  it('does NOT reset draft when parent rerenders with same id (regression guard)', () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: P1 } },
+    );
+
+    act(() => {
+      const [, setDraft] = result.current;
+      setDraft('User-Edit unterwegs');
+    });
+    expect(result.current[0]).toBe('User-Edit unterwegs');
+
+    // Simulate react-query refetch: same id, brand-new array → new object ref.
+    rerender({ active: P1_REFETCH });
+    expect(result.current[0]).toBe('User-Edit unterwegs');
+
+    // Even an upstream body mutation on the SAME id should not clobber the draft.
+    rerender({ active: P1_UPSTREAM_EDIT });
+    expect(result.current[0]).toBe('User-Edit unterwegs');
+  });
+
+  it('persists user edits via setDraft', () => {
+    const { result } = renderHook(() =>
+      useDraftFromActive<Policy, string>(P1, { derive: (p) => p.body }),
+    );
+    act(() => {
+      const [, setDraft] = result.current;
+      setDraft('Neuer Inhalt');
+    });
+    expect(result.current[0]).toBe('Neuer Inhalt');
+  });
+
+  it('re-initialises draft from new active when id changes', () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: P1 } },
+    );
+    act(() => {
+      const [, setDraft] = result.current;
+      setDraft('In-flight edit on P1');
+    });
+
+    rerender({ active: P2 });
+    expect(result.current[0]).toBe('DSGVO');
+  });
+
+  it('clears draft when active becomes undefined', () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy | undefined }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: P1 as Policy | undefined } },
+    );
+    expect(result.current[0]).toBe('Alter Text');
+    rerender({ active: undefined });
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('re-seeds when going from undefined → defined', () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy | undefined }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: undefined as Policy | undefined } },
+    );
+    expect(result.current[0]).toBeUndefined();
+    rerender({ active: P2 });
+    expect(result.current[0]).toBe('DSGVO');
+  });
+
+  it('default derive snapshots the whole active object', () => {
+    const { result } = renderHook(() => useDraftFromActive<Policy>(P1));
+    const [draft] = result.current;
+    expect(draft).toEqual(P1);
+    // Shallow clone — separate identity so caller can mutate without leaking.
+    expect(draft).not.toBe(P1);
+  });
+
+  it('respects custom idKey', () => {
+    interface BySlug { slug: string; body: string }
+    const a: BySlug = { slug: 'agb', body: 'one' };
+    const a2: BySlug = { slug: 'agb', body: 'server-edit' }; // same slug
+    const b: BySlug = { slug: 'dsg', body: 'two' };
+
+    const { result, rerender } = renderHook(
+      ({ active }: { active: BySlug }) =>
+        useDraftFromActive<BySlug, string, 'slug'>(active, {
+          idKey: 'slug',
+          derive: (p) => p.body,
+        }),
+      { initialProps: { active: a } },
+    );
+    act(() => result.current[1]('user typed'));
+    rerender({ active: a2 });
+    expect(result.current[0]).toBe('user typed');
+    rerender({ active: b });
+    expect(result.current[0]).toBe('two');
+  });
+
+  it('exposes isDirty + reset meta', () => {
+    const { result } = renderHook(() =>
+      useDraftFromActive<Policy, string>(P1, { derive: (p) => p.body }),
+    );
+    expect(result.current[2].isDirty).toBe(false);
+    expect(result.current[2].pristine).toBe('Alter Text');
+
+    act(() => result.current[1]('changed'));
+    expect(result.current[2].isDirty).toBe(true);
+
+    act(() => result.current[2].reset());
+    expect(result.current[0]).toBe('Alter Text');
+    expect(result.current[2].isDirty).toBe(false);
+  });
+
+  // ─── Hardening (PR #424 follow-up: copilot review edge cases) ───
+
+  it('default derive handles arrays via spread (not object-spread)', () => {
+    // Object-spread on an array would produce { '0': 'a', '1': 'b' } silently.
+    const arr: { id: string; tags: string[] } = { id: 'x', tags: ['a', 'b'] };
+    const { result } = renderHook(() => useDraftFromActive(arr, { derive: (p) => p.tags }));
+    const [draft] = result.current;
+    expect(Array.isArray(draft)).toBe(true);
+    expect(draft).toEqual(['a', 'b']);
+  });
+
+  it('falls back to reference equality when active has no id and no idKey', () => {
+    // Use objects without an `id` field — the hook must not seed-loop on the
+    // same reference when the parent rerenders.
+    interface Anon { kind: 'anon'; body: string }
+    const a: Anon = { kind: 'anon', body: 'one' };
+    const b: Anon = { kind: 'anon', body: 'two' };
+
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Anon }) =>
+        useDraftFromActive<Anon, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: a } },
+    );
+    act(() => result.current[1]('user typed'));
+    // Rerender with the SAME reference — should not clobber edit.
+    rerender({ active: a });
+    expect(result.current[0]).toBe('user typed');
+    // New reference — should re-seed.
+    rerender({ active: b });
+    expect(result.current[0]).toBe('two');
+  });
+
+  it('isDirty stays false when active is undefined (seeded sentinel)', () => {
+    // Without the `seededRef`, `pristineRef.current === undefined` would be
+    // ambiguous: was the draft never seeded, or seeded with undefined?
+    const { result, rerender } = renderHook(
+      ({ active }: { active: Policy | undefined }) =>
+        useDraftFromActive<Policy, string>(active, { derive: (p) => p.body }),
+      { initialProps: { active: undefined as Policy | undefined } },
+    );
+    expect(result.current[2].isDirty).toBe(false);
+
+    rerender({ active: P1 });
+    expect(result.current[2].isDirty).toBe(false);
+    expect(result.current[2].pristine).toBe('Alter Text');
+
+    act(() => result.current[1]('edited'));
+    expect(result.current[2].isDirty).toBe(true);
+
+    rerender({ active: undefined });
+    // Cleared back to unseeded — isDirty false even though draft is undefined.
+    expect(result.current[2].isDirty).toBe(false);
+    expect(result.current[2].pristine).toBeUndefined();
+  });
+});

--- a/parkhub-web/src/hooks/useDraftFromActive.ts
+++ b/parkhub-web/src/hooks/useDraftFromActive.ts
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Hook helpers for {@link useDraftFromActive}.
+ *
+ * Most callers only care about the `[draft, setDraft]` tuple, but `meta`
+ * exposes derived state (`isDirty`) and a manual `reset` so screens can offer
+ * "Discard changes" affordances without re-implementing the comparison.
+ */
+export interface UseDraftFromActiveMeta<TDraft> {
+  /** True when the draft has been seeded AND differs from the snapshot. */
+  isDirty: boolean;
+  /** Re-snapshot the draft from `active` (or clear it if `active` is undefined). */
+  reset: () => void;
+  /** The exact draft value last seeded from `active` (the "pristine" baseline). */
+  pristine: TDraft | undefined;
+}
+
+export interface UseDraftFromActiveOptions<TActive, TDraft, TKey extends keyof TActive> {
+  /**
+   * Property used as the active item's stable discriminator.
+   *
+   * When omitted, the hook tries `active.id` if present, then falls back to
+   * reference equality (`Object.is(active, last)`). Reference fallback is
+   * correct when callers always pass a stable object reference for the same
+   * logical item — typical for state that lives in a parent ref or selector.
+   */
+  idKey?: TKey;
+  /**
+   * Project the active item into the draft shape. Defaults to a shallow copy
+   * — `[...arr]` for arrays, `{ ...obj }` for objects, `value` for primitives.
+   * Override when the draft only mirrors a subset of the active item
+   * (e.g. `(p) => p.body`).
+   *
+   * MUST be stable across renders (wrap in `useCallback` upstream). The hook
+   * does not memoise it for you.
+   */
+  derive?: (active: TActive) => TDraft;
+}
+
+export type UseDraftFromActiveResult<TDraft> = [
+  TDraft | undefined,
+  React.Dispatch<React.SetStateAction<TDraft | undefined>>,
+  UseDraftFromActiveMeta<TDraft>,
+];
+
+function defaultDerive<TActive, TDraft>(active: TActive): TDraft {
+  // Arrays must be cloned with [...arr] — object spread on an array produces
+  // `{ '0': ..., '1': ... }` which is silently wrong.
+  if (Array.isArray(active)) {
+    return [...active] as unknown as TDraft;
+  }
+  if (active !== null && typeof active === 'object') {
+    return { ...(active as object) } as unknown as TDraft;
+  }
+  // Primitives pass through verbatim.
+  return active as unknown as TDraft;
+}
+
+/**
+ * Track a draft mirror of an "active" item without clobbering in-flight edits.
+ *
+ * The naive shape (`useEffect(() => setDraft(active.body), [active])`) re-seeds
+ * the draft every time the parent rerenders the same active object — which is
+ * exactly what happens when react-query refetches the list and produces a new
+ * array. The classic workaround is `[activeId]` plus an
+ * `eslint-disable-next-line react-hooks/exhaustive-deps`, which silences the
+ * linter but loses the dependency-tracking guarantee.
+ *
+ * This hook keeps the lint rule honest: it depends on the full `active`
+ * reference, but uses a ref-tracked id to bail out when the discriminator has
+ * not actually changed. Switching ids snapshots `derive(active)`; same id +
+ * parent rerender leaves the draft alone; `active === undefined` clears the
+ * draft.
+ *
+ * Generic over the discriminator key so callers using `slug`, `uuid`, etc.
+ * can plug in without falling back to `any`. When the type has neither `id`
+ * nor a custom `idKey`, the hook falls back to reference equality.
+ *
+ * @example Mirror a string body (the Policies screen)
+ * ```ts
+ * const [draft, setDraft] = useDraftFromActive(active, {
+ *   derive: (p) => p.body,
+ * });
+ * ```
+ *
+ * @example Snapshot the whole record (default)
+ * ```ts
+ * const [draft, setDraft, { isDirty, reset }] = useDraftFromActive(active);
+ * ```
+ *
+ * @example Custom discriminator
+ * ```ts
+ * useDraftFromActive(active, { idKey: 'slug', derive: (p) => p.body });
+ * ```
+ */
+export function useDraftFromActive<
+  TActive extends object,
+  TDraft = TActive,
+  TKey extends keyof TActive = keyof TActive,
+>(
+  active: TActive | null | undefined,
+  options?: UseDraftFromActiveOptions<TActive, TDraft, TKey>,
+): UseDraftFromActiveResult<TDraft> {
+  const idKey = options?.idKey;
+  const derive = options?.derive ?? (defaultDerive as (a: TActive) => TDraft);
+
+  // Discriminator strategy:
+  //   1. Explicit `idKey` → read that property.
+  //   2. No `idKey` but `active.id` exists at runtime → use it.
+  //   3. Neither → reference equality on `active` itself (correct when the
+  //      caller passes a stable parent-owned reference per logical item).
+  const readId = useCallback(
+    (a: TActive): unknown => {
+      if (idKey !== undefined) {
+        return (a as unknown as Record<string, unknown>)[idKey as string];
+      }
+      const maybeId = (a as unknown as { id?: unknown }).id;
+      return maybeId !== undefined ? maybeId : a;
+    },
+    [idKey],
+  );
+
+  // `seededRef` distinguishes "never seeded" from "seeded with a value that
+  // happens to be undefined" — `pristineRef.current === undefined` alone is
+  // ambiguous when the draft is intentionally undefined.
+  const seededRef = useRef(false);
+  const pristineRef = useRef<TDraft | undefined>(undefined);
+  const lastIdRef = useRef<unknown>(undefined);
+
+  const [draft, setDraft] = useState<TDraft | undefined>(() => {
+    if (active != null) {
+      const seed = derive(active);
+      pristineRef.current = seed;
+      lastIdRef.current = readId(active);
+      seededRef.current = true;
+      return seed;
+    }
+    return undefined;
+  });
+
+  useEffect(() => {
+    const nextId: unknown = active != null ? readId(active) : undefined;
+    if (lastIdRef.current === nextId && seededRef.current === (active != null)) {
+      // Same id (or both null) AND seeding state matches: preserve in-flight edits.
+      return;
+    }
+    lastIdRef.current = nextId;
+    if (active == null) {
+      pristineRef.current = undefined;
+      seededRef.current = false;
+      setDraft(undefined);
+      return;
+    }
+    const seed = derive(active);
+    pristineRef.current = seed;
+    seededRef.current = true;
+    setDraft(seed);
+  }, [active, derive, readId]);
+
+  const reset = useCallback(() => {
+    if (active == null) {
+      pristineRef.current = undefined;
+      seededRef.current = false;
+      setDraft(undefined);
+      return;
+    }
+    const seed = derive(active);
+    pristineRef.current = seed;
+    seededRef.current = true;
+    setDraft(seed);
+  }, [active, derive]);
+
+  const isDirty = seededRef.current && !Object.is(draft, pristineRef.current);
+
+  return [draft, setDraft, { isDirty, reset, pristine: pristineRef.current }];
+}


### PR DESCRIPTION
## Summary

Mirrors the hardened \`useDraftFromActive\` hook from parkhub-rust (post-#424 + #426) into parkhub-php. Refactors the Policies admin screen to use the hook instead of the inline \`useEffect([activeId])\` + \`// eslint-disable-next-line\` pattern.

## Why

PR rust #424 introduced the hook with the eslint-disable smell, then rust #426 hardened it with three edge-case fixes (defaultDerive arrays, idKey runtime fallback, seededRef sentinel). This PR brings parkhub-php to functional parity and removes the parallel eslint-disable on the php Policies screen.

## Files

- **NEW** \`parkhub-web/src/hooks/useDraftFromActive.ts\` (177 lines, identical to rust main)
- **NEW** \`parkhub-web/src/hooks/__tests__/useDraftFromActive.test.ts\` (202 lines, 13 vitest cases)
- **REFACTOR** \`parkhub-web/src/design-v5/screens/Policies.tsx\`:
  - dropped \`useState('')\` + eslint-disable useEffect
  - calls \`useDraftFromActive(active, { derive: (p) => p.body })\`
  - tiny \`useEffect(() => setPreview(false), [activeId])\` for preview-mode reset (split out of the original combined effect)
  - \`isDirty = !!active && draftIsDirty\` from the hook's seeded-sentinel comparison

## Verification

- [x] \`./node_modules/.bin/astro sync\` clean (167ms)
- [x] \`./node_modules/.bin/tsc --noEmit\` introduces no NEW errors (pre-existing \`policies[0].id\` possibly-undefined error on Policies.tsx:33 remains, queued for Phase 5 differential cleanup; tsc is advisory on parkhub-php's pr profile)
- [x] vitest run for hook + Policies screen: **20/20 green**
- [x] Local-first CI: \`./.github/scripts/fop-local-ci.sh --profile pr --post-status\` (exit 0; ran with --resource-profile interactive-small for frontend, fast)
- [x] OpenAPI drift bootstrap (\`php artisan migrate --graceful --force\`) — known php-side gotcha for fresh worktrees, sub-agent's deferred followup tracked separately

## Follow-ups

- Wave 5 backports parkhub-php's \`--resource-profile interactive-small/batch-medium\` to parkhub-rust's local-CI script (Task #10 in claude1's tracker)
- Lefthook openapi-drift hook needs a graceful migrate bootstrap on fresh worktrees (sub-agent's deferred followup from #385)