### PR TITLE
fix(ci): fop-local-ci.sh auto-fallback to direct mode when fop missing

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -171,7 +171,10 @@ run_step() {
     printf 'DRY-RUN: %s\n' "$command"
     return 0
   fi
-  if [[ "${FOP_LOCAL_CI_DIRECT:-0}" == "1" ]]; then
+  if [[ "${FOP_LOCAL_CI_DIRECT:-0}" == "1" ]] || ! command -v fop >/dev/null 2>&1; then
+    # Direct mode (no fop queue): explicit opt-in OR fop binary not on
+    # PATH (GitHub Actions runners, fresh contributor boxes). The kernel
+    # + earlyoom handle resource pressure when fop isn't available.
     bash -euo pipefail -c "$command"
     return 0
   fi
@@ -186,7 +189,7 @@ run_step_heavy() {
     printf 'DRY-RUN: %s\n' "$command"
     return 0
   fi
-  if [[ "${FOP_LOCAL_CI_DIRECT:-0}" == "1" ]]; then
+  if [[ "${FOP_LOCAL_CI_DIRECT:-0}" == "1" ]] || ! command -v fop >/dev/null 2>&1; then
     bash -euo pipefail -c "$command"
     return 0
   fi


### PR DESCRIPTION
## Summary
Mirrors parkhub-rust PR #440 — local-CI script auto-detects missing `fop` binary on GitHub-hosted runners and falls back to direct mode (`bash -c …`) instead of exiting 127.

## Why
GitHub Actions runners don't ship `fop`. Without this fallback, `make ci` aborts on `command not found` and the GHA-side local-ci-attestation gate can never see the post-attestation status. The fallback keeps the gate path identical between the developer's host (`fop build`/`fop test` queued) and GHA (direct invocation).

## Test plan
- [x] Local push from this machine still routes through fop queue (validated by lefthook clean run on chore/release-5.0.3 push)
- [ ] Verify GHA `make ci` invocation in a future CI run no longer 127s