### PR TITLE
fix(ci): define skip_step in fop-local-ci.sh (was undefined → exit 127 on GHA)

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -209,6 +209,17 @@ run_direct() {
   bash -euo pipefail -c "$command"
 }
 
+# `skip_step` records a skipped optional gate (advisory; tool not on PATH).
+# Used by Trivy/zizmor/OSV-Scanner/Grype branches when contributors don't
+# have the binary installed locally. Without this, calling skip_step blew
+# up with `command not found` → exit 127 → make: Error 127 → release-yml
+# Pre-release tests failure.
+skip_step() {
+  local name="$1"
+  local reason="${2:-skipped}"
+  printf '\n==> %s (skipped)\n%s\n' "$name" "$reason"
+}
+
 mark_failure() {
   local line="$1"
   # Best-effort report + status post: never let the failure handler


### PR DESCRIPTION
## Summary
v5.0.3 release pipeline failed at `Pre-release tests` with `make: *** [Makefile:84: ci] Error 127` because `skip_step` is called from 4 conditional branches (trivy/zizmor/osv-scanner/grype not on PATH) but the function was never defined. Locally these tools are all installed; on GHA-hosted Ubuntu 24.04 runners they aren't, so the first `skip_step "trivy filesystem scan" …` call exits 127.

## Repro
Run #25091219970 → Pre-release tests job → final lines:
```
==> local security audit passed
.github/scripts/fop-local-ci.sh: line 319: skip_step: command not found
make: *** [Makefile:84: ci] Error 127
```

## Fix
Add a minimal `skip_step` function next to `run_direct` (mirrors the pattern in parkhub-rust's `fop-local-ci.sh` which already has it).

## Test plan
- [x] `bash -n .github/scripts/fop-local-ci.sh` syntax-clean
- [x] `grep -n 'skip_step' …` shows definition + 4 call sites
- [ ] After merge: re-tag `v5.0.3` to new HEAD → release pipeline completes → GH release v5.0.3 published with PHP container