### PR TITLE
fix(a11y): wire aria-invalid + aria-describedby on 2FA failure

### DIFF
--- a/parkhub-web/src/design-v5/screens/Policies.test.tsx
+++ b/parkhub-web/src/design-v5/screens/Policies.test.tsx
@@ -64,8 +64,9 @@ describe('PoliciesV5', () => {
     mockList.mockResolvedValue({ success: true, data: [P1] });
     mockUpdate.mockResolvedValue({ success: true, data: { ...P1, body: 'Neu' } });
     renderScreen();
-    await waitFor(() => expect(screen.getByTestId('policies-editor')).toBeInTheDocument());
-    fireEvent.change(screen.getByTestId('policies-editor'), { target: { value: 'Neu' } });
+    const editor = await screen.findByTestId('policies-editor');
+    await waitFor(() => expect(editor).toHaveValue('Alter Text'));
+    fireEvent.change(editor, { target: { value: 'Neu' } });
     await waitFor(() => expect(screen.getByTestId('policies-save')).not.toBeDisabled());
     fireEvent.click(screen.getByTestId('policies-save'));
     await waitFor(() => {
@@ -78,8 +79,9 @@ describe('PoliciesV5', () => {
     mockList.mockResolvedValue({ success: true, data: [P1] });
     mockUpdate.mockResolvedValue({ success: false, data: null, error: { code: 'X', message: 'denied' } });
     renderScreen();
-    await waitFor(() => expect(screen.getByTestId('policies-editor')).toBeInTheDocument());
-    fireEvent.change(screen.getByTestId('policies-editor'), { target: { value: 'Neu' } });
+    const editor = await screen.findByTestId('policies-editor');
+    await waitFor(() => expect(editor).toHaveValue('Alter Text'));
+    fireEvent.change(editor, { target: { value: 'Neu' } });
     await waitFor(() => expect(screen.getByTestId('policies-save')).not.toBeDisabled());
     fireEvent.click(screen.getByTestId('policies-save'));
     await waitFor(() => expect(mockToast).toHaveBeenCalledWith('denied', 'error'));

--- a/parkhub-web/src/views/Login.test.tsx
+++ b/parkhub-web/src/views/Login.test.tsx
@@ -87,7 +87,7 @@ import { LoginPage } from './Login';
 describe('LoginPage', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
-    mockLogin.mockClear();
+    mockLogin.mockReset();
   });
 
   afterEach(() => {
@@ -183,6 +183,34 @@ describe('LoginPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials');
     });
+  });
+
+  it('links two-factor server errors to the code input', async () => {
+    mockLogin
+      .mockResolvedValueOnce({ success: false, requires2fa: true })
+      .mockResolvedValueOnce({ success: false, error: 'Invalid two-factor code' });
+    const user = userEvent.setup();
+
+    render(<LoginPage />);
+
+    await user.type(screen.getByLabelText('Email'), 'admin');
+    await user.type(screen.getByLabelText('Password'), 'demo');
+    await user.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    const codeInput = await screen.findByLabelText('Two-factor authentication code');
+    expect(codeInput).toHaveAttribute('aria-describedby', 'two-factor-hint');
+    expect(codeInput).not.toHaveAttribute('aria-errormessage');
+
+    await user.type(codeInput, '123456');
+    await user.click(screen.getByRole('button', { name: 'Verify code' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Invalid two-factor code');
+    });
+
+    expect(codeInput).toHaveAttribute('aria-invalid', 'true');
+    expect(codeInput).toHaveAttribute('aria-describedby', 'two-factor-hint two-factor-error');
+    expect(codeInput).toHaveAttribute('aria-errormessage', 'two-factor-error');
   });
 
   it('falls back to translated error when login returns no error string', async () => {

--- a/parkhub-web/src/views/Login.tsx
+++ b/parkhub-web/src/views/Login.tsx
@@ -217,7 +217,9 @@ export function LoginPage() {
                   onChange={(e) => setTwoFactorCode(e.target.value.replace(/\D/g, ''))}
                   className="input"
                   placeholder="123456"
-                  aria-describedby="two-factor-hint"
+                  aria-invalid={!!serverError}
+                  aria-describedby={serverError ? 'two-factor-hint two-factor-error' : 'two-factor-hint'}
+                  aria-errormessage={serverError ? 'two-factor-error' : undefined}
                 />
                 <p id="two-factor-hint" className="text-xs text-surface-500 dark:text-surface-400">
                   {t('auth.twoFactorHint', 'Enter the 6-digit code from your authenticator app.')}
@@ -227,6 +229,7 @@ export function LoginPage() {
 
             {serverError && (
               <motion.p
+                id="two-factor-error"
                 initial={{ opacity: 0, y: -4 }}
                 animate={{ opacity: 1, y: 0 }}
                 className="text-sm text-red-600 dark:text-red-400"


### PR DESCRIPTION
## Summary

Login.tsx 2FA input now flips into screen-reader error state when the verify step fails.

- `aria-invalid={!!serverError}` on the OTP input — only set when an actual error landed
- `aria-describedby` chains the new `id=\"two-factor-error\"` after the existing `two-factor-hint` so the alert text is also referenced from the input itself
- The serverError `<p>` already had `role=\"alert\"` so the announcement still fires immediately on render

## Why

When 2FA verify fails, screen-reader users hear the alert once but get no error state on the input itself when focus returns. axe-core flagged this as a missing `aria-invalid`/`aria-errormessage` pairing.

## Test plan

- [x] `tsc --noEmit` clean (no new errors; pre-existing Welcome.tsx + Visitors.test.tsx errors are unrelated)
- [ ] axe-core run on `/login` after a deliberately wrong 2FA code
- [ ] Manual NVDA / VoiceOver pass

## Audit context

From web-design-guidelines audit (audit-batch-2). Other PHP-side audit findings (drop framer-motion in Welcome.tsx, port `PUBLIC_ENTRY_ROUTES` deferral, focus-visible utility) deferred — Welcome.tsx already uses `<main>` landmark, Dockerfile already exposes only PORT 10000 (no spurious EXPOSE 80).