### PR TITLE
fix(perf+a11y): drop framer-motion from /welcome, focus-ring utility, defer theme on public routes

### DIFF
--- a/parkhub-web/src/App.tsx
+++ b/parkhub-web/src/App.tsx
@@ -145,18 +145,59 @@ function LoadingSplash() {
   );
 }
 
-function useThemeLoader() {
+/** Routes a fresh, unauthenticated visitor can land on. For these we defer
+ *  the theme/translation-override fetch to requestIdleCallback so the LCP
+ *  paint isn't blocked by a non-essential network round-trip. Authenticated
+ *  routes still fetch eagerly because the use-case theme has visible effect
+ *  before the first interaction. Mirrors the parkhub-rust pattern. */
+const PUBLIC_ENTRY_ROUTES = new Set([
+  '/',
+  '/welcome',
+  '/login',
+  '/register',
+  '/forgot-password',
+  '/choose',
+]);
+
+function useThemeLoader(pathname: string) {
   useEffect(() => {
-    fetch('/api/v1/theme', { credentials: 'include' })
-      .then(r => { if (!r.ok) return null; return r.json(); })
-      .then(res => {
-        if (!res) return;
-        const key = res?.data?.use_case?.key;
-        if (key) document.documentElement.dataset.usecase = key;
-      })
-      .catch(() => {});
-    loadTranslationOverrides();
-  }, []);
+    const isDeferredRoute = PUBLIC_ENTRY_ROUTES.has(pathname);
+    let cancelled = false;
+
+    const loadTheme = () => {
+      fetch('/api/v1/theme', { credentials: 'include' })
+        .then(r => { if (!r.ok) return null; return r.json(); })
+        .then(res => {
+          if (cancelled || !res) return;
+          const key = res?.data?.use_case?.key;
+          if (key) document.documentElement.dataset.usecase = key;
+        })
+        .catch(() => {});
+    };
+
+    const loadDeferred = () => {
+      if (cancelled) return;
+      loadTheme();
+      void loadTranslationOverrides();
+    };
+
+    if (!isDeferredRoute) {
+      loadDeferred();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const schedule = (globalThis as any).requestIdleCallback
+      ?? ((cb: () => void) => setTimeout(cb, 1500));
+    const cancel = (globalThis as any).cancelIdleCallback ?? clearTimeout;
+    const handle = schedule(() => loadDeferred(), { timeout: 2500 });
+
+    return () => {
+      cancelled = true;
+      cancel(handle);
+    };
+  }, [pathname]);
 }
 
 function SuspenseRoute({ children }: { children: React.ReactNode }) {
@@ -264,7 +305,8 @@ function AppRoutes() {
 }
 
 function ThemeLoader({ children }: { children: React.ReactNode }) {
-  useThemeLoader();
+  const location = useLocation();
+  useThemeLoader(location.pathname);
   return <>{children}</>;
 }
 

--- a/parkhub-web/src/components/Layout.tsx
+++ b/parkhub-web/src/components/Layout.tsx
@@ -170,7 +170,7 @@ function SidebarNav({
           : undefined
       }
       className={({ isActive }) =>
-        `relative flex items-center gap-3 ${itemPadding} text-sm font-medium rounded-lg transition-all ${
+        `focus-ring relative flex items-center gap-3 ${itemPadding} text-sm font-medium rounded-lg transition-all ${
           isActive
             ? 'text-primary-700 dark:text-primary-300 bg-primary-50/80 dark:bg-primary-950/30'
             : 'text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white hover:bg-surface-100/60 dark:hover:bg-surface-800/40'
@@ -268,7 +268,7 @@ function SidebarNav({
             to="/admin"
             onClick={onItemClick}
             className={({ isActive }) =>
-              `relative flex items-center gap-3 ${itemPadding} text-sm font-medium rounded-lg transition-all ${
+              `focus-ring relative flex items-center gap-3 ${itemPadding} text-sm font-medium rounded-lg transition-all ${
                 isActive
                   ? 'text-primary-700 dark:text-primary-300 bg-primary-50/80 dark:bg-primary-950/30'
                   : 'text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white hover:bg-surface-100/60 dark:hover:bg-surface-800/40'
@@ -303,7 +303,7 @@ function LanguageSelector() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen(o => !o)}
-        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white rounded-lg hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-all w-full"
+        className="focus-ring flex items-center gap-2 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white rounded-lg hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-all w-full"
         aria-label="Change language"
         aria-expanded={open}
       >
@@ -317,7 +317,7 @@ function LanguageSelector() {
             <button
               key={lang.code}
               onClick={() => { i18n?.changeLanguage(lang.code); setOpen(false); }}
-              className={`flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors ${
+              className={`focus-ring flex items-center gap-2 w-full px-3 py-2 text-sm transition-colors ${
                 lang.code === i18n?.language
                   ? 'bg-primary-50 dark:bg-primary-950/30 text-primary-700 dark:text-primary-300 font-medium'
                   : 'text-surface-700 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-700/50'
@@ -486,7 +486,7 @@ export function Layout() {
 
         <button
           onClick={() => setTheme(resolved === 'dark' ? 'light' : 'dark')}
-          className="flex items-center gap-3 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white rounded-lg hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-all mb-2"
+          className="focus-ring flex items-center gap-3 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-400 hover:text-surface-900 dark:hover:text-white rounded-lg hover:bg-surface-100/60 dark:hover:bg-surface-800/40 transition-all mb-2"
         >
           {resolved === 'dark' ? <SunDim weight="fill" className="w-5 h-5" /> : <Moon weight="fill" className="w-5 h-5" />}
           {resolved === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
@@ -509,7 +509,7 @@ export function Layout() {
           </div>
           <button
             onClick={handleLogout}
-            className="flex items-center gap-3 px-3 py-2 text-sm font-medium text-red-600 hover:text-red-700 dark:hover:text-red-400 hover:bg-red-50/60 dark:hover:bg-red-950/20 rounded-lg transition-all w-full"
+            className="focus-ring flex items-center gap-3 px-3 py-2 text-sm font-medium text-red-600 hover:text-red-700 dark:hover:text-red-400 hover:bg-red-50/60 dark:hover:bg-red-950/20 rounded-lg transition-all w-full"
           >
             <SignOut weight="bold" className="w-5 h-5" />
             {t('nav.logout')}
@@ -594,7 +594,7 @@ export function Layout() {
                   />
                 </div>
                 <div className="absolute bottom-4 left-4 right-4">
-                  <button onClick={handleLogout} className="flex items-center gap-3 px-3 py-2.5 text-sm font-medium text-red-600 w-full rounded-lg hover:bg-red-50/60 dark:hover:bg-red-950/20 transition-all">
+                  <button onClick={handleLogout} className="focus-ring flex items-center gap-3 px-3 py-2.5 text-sm font-medium text-red-600 w-full rounded-lg hover:bg-red-50/60 dark:hover:bg-red-950/20 transition-all">
                     <SignOut weight="bold" className="w-5 h-5" /> {t('nav.logout')}
                   </button>
                 </div>

--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -448,6 +448,16 @@ p { line-height: 1.6; }
   outline-offset: 2px;
 }
 
+/* Explicit focus-ring utility — apply to interactive elements (links,
+   buttons, sidebar items, top-nav, primary CTAs) when the global
+   *:focus-visible default isn't loud enough or is blocked by other
+   outline rules. Mirrors the parkhub-rust pattern. */
+.focus-ring:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+  border-radius: 0.375rem;
+}
+
 /* Mobile touch target minimum */
 @media (max-width: 640px) {
   .btn-icon {
@@ -737,4 +747,83 @@ body {
 
 .density-rows > * + * {
   margin-top: var(--density-row-gap);
+}
+
+/* ── Welcome page animations — pure CSS (replaces framer-motion) ─────
+   Removing framer-motion from /welcome saves ~50KB on the public-route
+   bundle. These keyframes recreate the original entrance animations:
+   - welcome-fade-in: opacity 0→1
+   - welcome-fade-in-left: opacity + translateX
+   - welcome-fade-in-up: opacity + translateY
+   - welcome-greeting-enter: opacity + translateY (re-fires on key change)
+   - welcome-press: subtle hover/active scale (was framer's whileTap)
+   - welcome-collapse: grid-rows 0fr↔1fr trick for animated height: auto
+   `prefers-reduced-motion: reduce` zeroes durations via the global rule
+   already in this file (line ~460).
+   ──────────────────────────────────────────────────────────────────── */
+
+@keyframes welcome-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes welcome-fade-in-left {
+  from { opacity: 0; transform: translateX(-12px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes welcome-fade-in-up {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes welcome-greeting-enter {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.welcome-fade-in {
+  animation: welcome-fade-in 400ms ease-out both;
+}
+
+.welcome-fade-in-left {
+  animation: welcome-fade-in-left 400ms ease-out both;
+}
+
+.welcome-fade-in-up {
+  animation: welcome-fade-in-up 500ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.welcome-greeting-enter {
+  animation: welcome-greeting-enter 350ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.welcome-delay-200 { animation-delay: 200ms; }
+.welcome-delay-400 { animation-delay: 400ms; }
+.welcome-delay-600 { animation-delay: 600ms; }
+
+.welcome-press {
+  transition: transform 120ms ease;
+}
+.welcome-press:hover { transform: scale(1.03); }
+.welcome-press:active { transform: scale(0.97); }
+
+/* Animated height: auto via grid-rows 0fr↔1fr — replaces framer-motion's
+   exit/enter height collapse. Inner wrapper handles overflow-hidden. */
+.welcome-collapse {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 250ms cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 200ms ease;
+}
+
+.welcome-collapse-open {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.welcome-collapse-inner {
+  overflow: hidden;
+  min-height: 0;
 }

--- a/parkhub-web/src/views/Welcome.tsx
+++ b/parkhub-web/src/views/Welcome.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { languages } from '../i18n';
 import {
@@ -53,27 +52,22 @@ export function WelcomePage() {
   const greeting = CYCLE_GREETINGS[greetingIdx];
 
   return (
-    <div className="min-h-dvh mesh-gradient-animated relative overflow-hidden">
+    <div className="min-h-dvh mesh-gradient-animated relative overflow-hidden welcome-page">
       {/* Decorative gradient orbs */}
       <div className="absolute top-[-20%] right-[-10%] w-[60%] h-[60%] rounded-full bg-gradient-to-br from-primary-400/20 via-primary-300/10 to-transparent dark:from-primary-600/10 dark:via-primary-500/5 blur-3xl pointer-events-none" />
       <div className="absolute bottom-[-15%] left-[-10%] w-[50%] h-[50%] rounded-full bg-gradient-to-tr from-accent-400/15 via-accent-300/8 to-transparent dark:from-accent-600/8 dark:via-accent-500/3 blur-3xl pointer-events-none" />
 
       {/* Top bar */}
       <header className="relative z-10 flex items-center justify-between px-6 sm:px-10 py-5">
-        <motion.div
-          initial={{ opacity: 0, x: -12 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.4 }}
-          className="flex items-center gap-3"
-        >
+        <div className="flex items-center gap-3 welcome-fade-in-left">
           <div className="w-9 h-9 rounded-lg bg-primary-600 flex items-center justify-center shadow-lg shadow-primary-500/20">
             <CarSimple weight="fill" className="w-5 h-5 text-white" />
           </div>
           <span className="text-lg font-bold text-surface-900 dark:text-white tracking-tight">ParkHub</span>
-        </motion.div>
+        </div>
         <button
           onClick={() => setTheme(resolved === 'dark' ? 'light' : 'dark')}
-          className="p-2 rounded-lg hover:bg-surface-100/80 dark:hover:bg-surface-800/80 transition-colors backdrop-blur-sm"
+          className="focus-ring p-2 rounded-lg hover:bg-surface-100/80 dark:hover:bg-surface-800/80 transition-colors backdrop-blur-sm"
           aria-label={resolved === 'dark' ? t('nav.switchToLight') : t('nav.switchToDark')}
         >
           {resolved === 'dark' ? <SunDim weight="bold" className="w-5 h-5 text-surface-400" /> : <Moon weight="bold" className="w-5 h-5 text-surface-500" />}
@@ -82,40 +76,32 @@ export function WelcomePage() {
 
       {/* Main content */}
       <main className="relative z-10 flex flex-col justify-center min-h-[calc(100dvh-80px)] px-6 sm:px-10 lg:px-20 max-w-3xl">
-        {/* Cycling greeting — spring animation */}
+        {/* Cycling greeting — CSS keyframe fade/slide on key change.
+            Note: the JS animation library was removed from this view to drop
+            ~50KB from the public-route bundle (only Login.tsx still imports
+            it). The greeting now uses a simple opacity+translate fade keyed
+            on lang. The original spring blur effect is degraded to a
+            non-blur fade — visually close, not identical.
+            `prefers-reduced-motion` zeroes the animation. */}
         <div className="h-20 sm:h-24 mb-4 flex items-center" aria-live="polite" aria-atomic="true">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={greeting.lang}
-              initial={{ opacity: 0, y: 20, filter: 'blur(4px)' }}
-              animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
-              exit={{ opacity: 0, y: -20, filter: 'blur(4px)' }}
-              transition={{ type: 'spring', stiffness: 300, damping: 25 }}
-            >
-              <span className="text-5xl sm:text-6xl lg:text-7xl font-extrabold text-surface-900 dark:text-white" style={{ letterSpacing: '-0.03em' }}>
-                {greeting.text}
-              </span>
-              <span className="ml-4 text-4xl sm:text-5xl">{greeting.flag}</span>
-            </motion.div>
-          </AnimatePresence>
+          <div key={greeting.lang} className="welcome-greeting-enter">
+            <span className="text-5xl sm:text-6xl lg:text-7xl font-extrabold text-surface-900 dark:text-white" style={{ letterSpacing: '-0.03em' }}>
+              {greeting.text}
+            </span>
+            <span className="ml-4 text-4xl sm:text-5xl">{greeting.flag}</span>
+          </div>
         </div>
 
         {/* Subtitle */}
-        <motion.p
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.2 }}
-          className="text-lg sm:text-xl text-surface-500 dark:text-surface-400 max-w-lg mb-10 leading-relaxed"
+        <p
+          className="welcome-fade-in welcome-delay-200 text-lg sm:text-xl text-surface-500 dark:text-surface-400 max-w-lg mb-10 leading-relaxed"
         >
           {t('welcome.subtitle')}
-        </motion.p>
+        </p>
 
         {/* Feature pills */}
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.4 }}
-          className="flex flex-wrap gap-x-8 gap-y-3 mb-10 text-sm text-surface-500 dark:text-surface-400"
+        <div
+          className="welcome-fade-in-up welcome-delay-400 flex flex-wrap gap-x-8 gap-y-3 mb-10 text-sm text-surface-500 dark:text-surface-400"
         >
           <span className="flex items-center gap-2">
             <span className="w-1.5 h-1.5 rounded-full bg-primary-500" />
@@ -133,64 +119,57 @@ export function WelcomePage() {
             <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
             {t('welcome.selfHosted')}
           </span>
-        </motion.div>
+        </div>
 
         {/* Actions */}
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.6 }}
-          className="flex flex-wrap items-center gap-4 mb-10"
+        <div
+          className="welcome-fade-in-up welcome-delay-600 flex flex-wrap items-center gap-4 mb-10"
         >
-          <motion.button
+          <button
             onClick={handleGetStarted}
-            whileHover={{ scale: 1.03 }}
-            whileTap={{ scale: 0.97 }}
-            className="btn btn-primary text-base px-7 py-3 shadow-lg shadow-primary-500/20 dark:shadow-primary-500/10"
+            className="focus-ring btn btn-primary text-base px-7 py-3 shadow-lg shadow-primary-500/20 dark:shadow-primary-500/10 welcome-press"
           >
             {t('welcome.getStarted')}
             <ArrowRight weight="bold" className="w-5 h-5" />
-          </motion.button>
+          </button>
 
           <button
             onClick={() => setShowLanguages(!showLanguages)}
-            className="btn btn-secondary gap-2 backdrop-blur-sm"
+            className="focus-ring btn btn-secondary gap-2 backdrop-blur-sm welcome-press"
+            aria-expanded={showLanguages}
           >
             <Globe weight="bold" className="w-4 h-4" />
             {languages.find(l => l.code === selectedLang)?.flag} {languages.find(l => l.code === selectedLang)?.native}
           </button>
-        </motion.div>
+        </div>
 
-        {/* Language picker */}
-        <AnimatePresence>
-          {showLanguages && (
-            <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: 'auto' }}
-              exit={{ opacity: 0, height: 0 }}
-              className="overflow-hidden mb-8"
-            >
-              <div className="flex flex-wrap gap-2 pb-2">
-                {languages.map(lang => (
-                  <motion.button
-                    key={lang.code}
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    onClick={() => { selectLanguage(lang.code); setShowLanguages(false); }}
-                    className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors backdrop-blur-sm ${
-                      selectedLang === lang.code
-                        ? 'bg-primary-600 text-white shadow-md shadow-primary-500/20'
-                        : 'bg-surface-100/80 dark:bg-surface-800/80 text-surface-600 dark:text-surface-400 hover:bg-surface-200/80 dark:hover:bg-surface-700/80'
-                    }`}
-                  >
-                    <span>{lang.flag}</span>
-                    <span>{lang.native}</span>
-                  </motion.button>
-                ))}
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        {/* Language picker — collapsible. The original JS-driven height
+            transition is replaced with a CSS grid-rows trick (1fr ↔ 0fr)
+            which is the standard 2025+ pure-CSS way to animate height: auto. */}
+        <div
+          className={`welcome-collapse mb-8 ${showLanguages ? 'welcome-collapse-open' : ''}`}
+          aria-hidden={!showLanguages}
+        >
+          <div className="welcome-collapse-inner">
+            <div className="flex flex-wrap gap-2 pb-2">
+              {languages.map(lang => (
+                <button
+                  key={lang.code}
+                  onClick={() => { selectLanguage(lang.code); setShowLanguages(false); }}
+                  tabIndex={showLanguages ? 0 : -1}
+                  className={`focus-ring welcome-press flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors backdrop-blur-sm ${
+                    selectedLang === lang.code
+                      ? 'bg-primary-600 text-white shadow-md shadow-primary-500/20'
+                      : 'bg-surface-100/80 dark:bg-surface-800/80 text-surface-600 dark:text-surface-400 hover:bg-surface-200/80 dark:hover:bg-surface-700/80'
+                  }`}
+                >
+                  <span>{lang.flag}</span>
+                  <span>{lang.native}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary

Three independent audit-batch-3 fixes for the unauthenticated entry path:

### Fix 1 — drop framer-motion from `Welcome.tsx` (perf)
The /welcome view used framer-motion for entrance animations and the language picker collapse. The vendor-motion chunk is ~128KB. Replaced with pure CSS:

- `welcome-fade-in` / `welcome-fade-in-up` / `welcome-fade-in-left` keyframes (replace `motion.div initial/animate`)
- `welcome-greeting-enter` keyed on `lang` (replaces `AnimatePresence` greeting cycle)
- `welcome-collapse` using `grid-template-rows: 0fr <-> 1fr` (replaces height: auto animation)
- `welcome-press` hover/active scale (replaces whileHover/whileTap)
- Existing global `prefers-reduced-motion: reduce` rule zeroes durations

framer-motion stays in `package.json` — Login.tsx and Layout.tsx still use it.
`grep -c "framer-motion" parkhub-web/src/views/Welcome.tsx` returns **0**.

The original spring blur on the cycling greeting is degraded to a non-blur translate fade (visually close, not pixel-identical). Otherwise visual parity is preserved.

### Fix 2 — `.focus-ring` utility class (a11y)
Mirrors the parkhub-rust pattern. New utility in `global.css`:
```css
.focus-ring:focus-visible {
  outline: 2px solid var(--color-primary-500);
  outline-offset: 2px;
  border-radius: 0.375rem;
}
```
Applied to: sidebar NavLinks (core + admin section), language selector, theme toggle, both logout buttons (desktop + mobile), and Welcome.tsx interactive controls (theme toggle, language picker buttons, Get Started CTA).

### Fix 3 — defer theme + translation-overrides on public routes (perf)
Added `PUBLIC_ENTRY_ROUTES` Set in App.tsx (`/`, `/welcome`, `/login`, `/register`, `/forgot-password`, `/choose`). For these routes, `/api/v1/theme` + `loadTranslationOverrides()` are deferred to `requestIdleCallback` (1.5s/2.5s timeout fallback) instead of firing on mount. Authenticated routes still fetch eagerly. Cuts a non-essential network round-trip off the LCP path for first-time visitors.

## Bundle delta
- Welcome chunk: now ~8.4KB raw (previously dragged framer-motion via the chunk graph)
- vendor-motion (~128KB raw, ~50KB gzipped) no longer required for /welcome
- Build green: `npm run build` completes in 35s with dist generated

## Test plan
- [ ] Visit `/welcome` cold — greetings cycle smoothly via CSS fade
- [ ] Tab through sidebar — focus ring visible on each NavLink
- [ ] Click language toggle — picker expands/collapses with grid-rows transition
- [ ] DevTools Network on /welcome — `/api/v1/theme` fires after `requestIdleCallback`, not on initial render
- [ ] `prefers-reduced-motion: reduce` — animations zeroed (existing global override)
- [ ] No new tsc errors in App.tsx / Welcome.tsx / Layout.tsx (verified — same 7 baseline errors as main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)