### PR TITLE
ci(supply-chain): add cosign-verify workflow for PR/push parity with parkhub-rust

### DIFF
--- a/.github/workflows/cosign-verify.yml
+++ b/.github/workflows/cosign-verify.yml
@@ -1,0 +1,123 @@
+name: Cosign Verify
+
+# Verify the most recently published main-branch image carries a valid
+# Sigstore signature AND a SPDX SBOM attestation, both produced by
+# `.github/workflows/docker-publish.yml`. Runs on PR + push so
+# regressions in the supply-chain wiring surface before tag time.
+#
+# First-PR caveat: when no `:latest` exists yet, the verify steps log a
+# notice and exit 0 — they only fail if an image exists but lacks a
+# signature/attestation matching the expected identity.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: cosign-verify-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify cosign signature + SBOM attestation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read   # checkout
+      packages: read   # pull image manifest + signatures from GHCR
+    env:
+      IMAGE_REF: ghcr.io/${{ github.repository }}:latest
+      # Identity expected for keyless cosign signatures: the docker-publish
+      # workflow on the main branch of this repository, signed via the
+      # GitHub-hosted Sigstore Fulcio issuer.
+      EXPECTED_IDENTITY_REGEX: ^https://github.com/${{ github.repository }}/.github/workflows/docker-publish.yml@refs/(heads|tags)/.+$
+      EXPECTED_OIDC_ISSUER: https://token.actions.githubusercontent.com
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Log in to GHCR (read-only)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: 'v3.0.6'
+
+      - name: Resolve image digest
+        id: digest
+        env:
+          IMAGE: ${{ env.IMAGE_REF }}
+        run: |
+          set -euo pipefail
+          # Skip cleanly when no image has been published yet (first PR on a
+          # fresh repo): cosign verify against a missing tag would otherwise
+          # block the PR with a confusing "manifest unknown" error.
+          if ! digest=$(docker buildx imagetools inspect --format '{{json .Manifest.Digest}}' "${IMAGE}" 2>/dev/null | tr -d '"'); then
+            echo "::notice::No image at ${IMAGE} yet — skipping cosign verify."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${digest}" ] || [ "${digest}" = "null" ]; then
+            echo "::notice::Could not resolve digest for ${IMAGE} — skipping cosign verify."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Verify cosign signature (keyless)
+        if: steps.digest.outputs.skip != 'true'
+        env:
+          COSIGN_EXPERIMENTAL: 'true'
+          IMAGE: ${{ env.IMAGE_REF }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
+          IDENTITY_REGEX: ${{ env.EXPECTED_IDENTITY_REGEX }}
+          ISSUER: ${{ env.EXPECTED_OIDC_ISSUER }}
+        run: |
+          set -euo pipefail
+          # Strip image tag (we pin to the resolved digest below).
+          repo="${IMAGE%:*}"
+          cosign verify \
+            --certificate-identity-regexp "${IDENTITY_REGEX}" \
+            --certificate-oidc-issuer "${ISSUER}" \
+            "${repo}@${DIGEST}"
+
+      - name: Verify SPDX SBOM attestation (keyless, advisory until first signed)
+        # Advisory: the SBOM attestation step in docker-publish.yml was only
+        # added in this PR — the existing :latest image was published before
+        # SBOM signing was wired, so the attestation won't exist on the
+        # current image. Once a fresh image is built post-merge with SBOM
+        # signing enabled, this step will start passing and can be promoted
+        # to required (drop continue-on-error).
+        if: steps.digest.outputs.skip != 'true'
+        continue-on-error: true
+        env:
+          COSIGN_EXPERIMENTAL: 'true'
+          IMAGE: ${{ env.IMAGE_REF }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
+          IDENTITY_REGEX: ${{ env.EXPECTED_IDENTITY_REGEX }}
+          ISSUER: ${{ env.EXPECTED_OIDC_ISSUER }}
+        run: |
+          set -euo pipefail
+          repo="${IMAGE%:*}"
+          if ! cosign verify-attestation \
+            --type spdxjson \
+            --certificate-identity-regexp "${IDENTITY_REGEX}" \
+            --certificate-oidc-issuer "${ISSUER}" \
+            "${repo}@${DIGEST}" 2>&1; then
+            echo "::notice::SBOM attestation not yet present (advisory). First image built after merge will produce it."
+          fi

--- a/.github/workflows/cosign-verify.yml
+++ b/.github/workflows/cosign-verify.yml
@@ -66,10 +66,20 @@ jobs:
           # Skip cleanly when no image has been published yet (first PR on a
           # fresh repo): cosign verify against a missing tag would otherwise
           # block the PR with a confusing "manifest unknown" error.
-          if ! digest=$(docker buildx imagetools inspect --format '{{json .Manifest.Digest}}' "${IMAGE}" 2>/dev/null | tr -d '"'); then
-            echo "::notice::No image at ${IMAGE} yet — skipping cosign verify."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          err_file="$(mktemp)"
+          trap 'rm -f "${err_file}"' EXIT
+          if ! digest=$(docker buildx imagetools inspect --format '{{json .Manifest.Digest}}' "${IMAGE}" 2>"${err_file}" | tr -d '"'); then
+            err_output="$(cat "${err_file}")"
+            if printf '%s' "${err_output}" | grep -Eiq 'manifest unknown|no such manifest|not found|name unknown'; then
+              echo "::notice::No image at ${IMAGE} yet — skipping cosign verify."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::Failed to resolve digest for ${IMAGE}."
+            if [ -n "${err_output}" ]; then
+              printf '%s\n' "${err_output}"
+            fi
+            exit 1
           fi
           if [ -z "${digest}" ] || [ "${digest}" = "null" ]; then
             echo "::notice::Could not resolve digest for ${IMAGE} — skipping cosign verify."
@@ -82,7 +92,6 @@ jobs:
       - name: Verify cosign signature (keyless)
         if: steps.digest.outputs.skip != 'true'
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE: ${{ env.IMAGE_REF }}
           DIGEST: ${{ steps.digest.outputs.digest }}
           IDENTITY_REGEX: ${{ env.EXPECTED_IDENTITY_REGEX }}
@@ -96,17 +105,15 @@ jobs:
             --certificate-oidc-issuer "${ISSUER}" \
             "${repo}@${DIGEST}"
 
-      - name: Verify SPDX SBOM attestation (keyless, advisory until first signed)
-        # Advisory: the SBOM attestation step in docker-publish.yml was only
-        # added in this PR — the existing :latest image was published before
-        # SBOM signing was wired, so the attestation won't exist on the
-        # current image. Once a fresh image is built post-merge with SBOM
-        # signing enabled, this step will start passing and can be promoted
-        # to required (drop continue-on-error).
+      - name: Verify SPDX SBOM attestation (keyless)
+        # Require an SPDX SBOM attestation for any resolved image digest.
+        # docker-publish.yml is expected to generate and attach this
+        # attestation, so verification should fail if an existing image
+        # lacks a matching keyless attestation from the expected workflow
+        # identity. The `skip` guard above still handles the no-image-yet
+        # case without failing the job.
         if: steps.digest.outputs.skip != 'true'
-        continue-on-error: true
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE: ${{ env.IMAGE_REF }}
           DIGEST: ${{ steps.digest.outputs.digest }}
           IDENTITY_REGEX: ${{ env.EXPECTED_IDENTITY_REGEX }}
@@ -114,10 +121,8 @@ jobs:
         run: |
           set -euo pipefail
           repo="${IMAGE%:*}"
-          if ! cosign verify-attestation \
+          cosign verify-attestation \
             --type spdxjson \
             --certificate-identity-regexp "${IDENTITY_REGEX}" \
             --certificate-oidc-issuer "${ISSUER}" \
-            "${repo}@${DIGEST}" 2>&1; then
-            echo "::notice::SBOM attestation not yet present (advisory). First image built after merge will produce it."
-          fi
+            "${repo}@${DIGEST}"


### PR DESCRIPTION
## Summary

Mirrors parkhub-rust's `cosign-verify.yml` workflow into parkhub-php. Every PR and push to main now re-verifies that the most recently published `:latest` GHCR image carries:

- a valid **keyless Sigstore signature** (Fulcio OIDC, GitHub Actions issuer)
- a valid **SPDX-JSON SBOM attestation**

both produced by `docker-publish.yml`.

Closes a real supply-chain blind spot: until now, regressions in the signing wiring would only surface at tag time. With this workflow, they surface on the originating PR.

## Two adjustments vs the rust copy

- `--type spdxjson` (not `--type spdx`). The rust copy was using the tag-value text shortname; that has been silently failing-as-advisory ever since cosign 3.x hardened in-toto predicate validation. PHP's copy is correct on first PR; the rust patch is the companion (parkhub-rust PR #468).
- Identity regex uses `\${{ github.repository }}` so the same file works in both repos with zero per-repo edits — that's the T-2268 standardization payoff.

## First-PR caveat

When no `:latest` image exists yet (fresh repo), both verify steps log a notice and exit 0. Only fails when an image exists but lacks the expected signature/attestation chain.

## Test plan

- [x] Workflow YAML syntax valid
- [ ] First run on this PR: skip-or-pass against existing `:latest` (sig already present from prior runs)
- [ ] Once merged: scheduled Monday cron continues verification
- [ ] Future regressions in `docker-publish.yml` signing chain caught at PR time

## Refs

T-2268 platform CI/CD standardization. Companion PR for the rust `--type spdx` → `--type spdxjson` fix: parkhub-rust#468.