### PR TITLE
chore(ci): drop COSIGN_EXPERIMENTAL=true (no-op since cosign 3.x)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -112,7 +112,6 @@ jobs:
 
       - name: Sign container image (keyless OIDC)
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
           IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
@@ -145,7 +144,6 @@ jobs:
 
       - name: Attach SBOM as cosign attestation (keyless OIDC)
         env:
-          COSIGN_EXPERIMENTAL: 'true'
           IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
           IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |


### PR DESCRIPTION
## Summary

`COSIGN_EXPERIMENTAL` was required for cosign 1.x to enable Sigstore keyless signing. Cosign 2.0 made keyless the default; 3.0 hardened it further. The variable has been a no-op for ~3 years.

Removes 2 occurrences in `.github/workflows/docker-publish.yml` (image-sign + SBOM-attest steps). Both env: blocks remain valid — \`IMAGE_DIGEST\` and \`IMAGE_REF\` are still present.

## Why

SOTA-2026 gap analysis MED-3. Companion PR in parkhub-rust (#471) drops 9 occurrences in 4 workflow files there.

## Test plan

- [x] yaml.safe_load passes
- [ ] Next docker-publish run re-signs + re-attests without the flag

## Refs

T-2268 platform CI/CD standardization