### PR TITLE
fix(test): bump waitFor timeout for deferred theme fetch (post-#406) — green main

### DIFF
--- a/parkhub-web/src/App.test.tsx
+++ b/parkhub-web/src/App.test.tsx
@@ -421,9 +421,13 @@ describe('App', () => {
 
     render(<App />);
 
+    // Theme fetch is deferred via requestIdleCallback (~1500ms setTimeout
+    // fallback in jsdom + 2500ms idle-timeout) for PUBLIC_ENTRY_ROUTES,
+    // including the default "/" route this test renders on. Bump waitFor
+    // past that envelope so the dataset assignment has time to land.
     await waitFor(() => {
       expect(document.documentElement.dataset.usecase).toBe('corporate');
-    });
+    }, { timeout: 4500 });
 
     // Cleanup
     delete document.documentElement.dataset.usecase;
@@ -440,7 +444,7 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalledWith('/api/v1/theme', expect.objectContaining({ credentials: 'include' }));
-    });
+    }, { timeout: 4500 });
     // Should not crash — no dataset.usecase set when no key returned
     // The dataset may or may not still be set from a prior test in same process,
     // but the key should NOT have been set by this response
@@ -457,7 +461,7 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalled();
-    });
+    }, { timeout: 4500 });
   });
 
   it('handles theme API network failure gracefully', async () => {


### PR DESCRIPTION
## Summary

Cherry-picks `820d4cd` to main. The fix was authored 2026-04-30 03:07Z but never merged — meanwhile #406 deferred-theme refactor has left `parkhub-web/src/App.test.tsx` red on main with 3 failing tests cascade-blocking 5 CI checks (Frontend builds → Required checks → Trivy fs/image → Build-scan-publish image).

## Root cause

#406 deferred `/api/v1/theme` via `requestIdleCallback` for `PUBLIC_ENTRY_ROUTES`. In jsdom the schedule falls back to `setTimeout(1500ms)`, and `waitFor`'s default 1000ms timeout fires BEFORE the deferred fetch lands. Three tests started failing on every PR push since #406:

- `handles theme API returning no use_case key`
- `handles theme API returning null response`
- `handles theme API network failure gracefully`

## Fix

Bump `waitFor` timeout to **4500ms** on those three tests. The setTimeout fallback (1500ms) + idle-callback timeout (2500ms) gives a comfortable ceiling while still bounding the test.

## Verification

```
$ cd parkhub-web && npx vitest run src/App.test.tsx
 Test Files  1 passed (1)
      Tests  76 passed (76)
```

Was 73/76 on main, now 76/76.

## Test plan

- [x] Local: `cd parkhub-web && npx vitest run src/App.test.tsx` — 76/76 passed (23s)
- [ ] CI: Frontend builds passes → Required checks passes → main goes green → cascade unblocks Trivy + image build