### PR TITLE
fix(ci): shellcheck SC2016+SC2018+SC2019+SC2034 cleanup on attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,11 @@ jobs:
           # statuses that the REST commit-status endpoint hides for the
           # workflow-installation token.
           for attempt in $(seq 1 "${attempts}"); do
-            api_err=""
             status="$(
               gh api "repos/${REPO}/commits/${SHA}/status" \
                 --jq ".statuses[] | select(.context == \"${CONTEXT}\") | .state" \
                 2> >(while read -r line ; do
                   printf '::warning::commits/status fallback: %s\n' "$line"
-                  api_err="$line"
                 done) \
                 | head -n 1
             )"
@@ -147,7 +145,7 @@ jobs:
                   -F oid="${SHA}" -F owner="$(echo "${REPO}" | cut -d/ -f1)" -F name="$(echo "${REPO}" | cut -d/ -f2)" \
                   --jq '.data.repository.object.statusCheckRollup.contexts.nodes[]? | select(.context == "'"${CONTEXT}"'") | .state' 2>/dev/null \
                   | head -n 1 \
-                  | tr 'A-Z' 'a-z'
+                  | tr '[:upper:]' '[:lower:]'
               )"
             fi
             if [[ "$status" == "success" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,10 @@ jobs:
           REPO: ${{ github.repository }}
           CONTEXT: fop/local-ci/pr
         run: |
+          # shellcheck disable=SC2016
+          # Single-quoted GraphQL queries pass $oid/$owner/$name to the gh api
+          # CLI as GraphQL variables (substituted via -F flags), not shell vars.
+          # SC2016 falsely flags these as missed shell expansions.
           live_sha="$(
             gh pr view "${PR_NUMBER}" --repo "${REPO}" --json headRefOid --jq .headRefOid 2>/dev/null || true
           )"


### PR DESCRIPTION
Combines #415 (open) + new SC2016 disable. Closes the lint-induced Workflow & manifest hygiene fail on main caused by #414 patch.