### PR TITLE
ci(release): require CD preflight before publish

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         **STOP** — If this is a security vulnerability that could be exploited, please use
-        [GitHub Security Advisories](https://github.com/nash87/parkhub-rust/security/advisories/new)
+        [GitHub Security Advisories](https://github.com/nash87/parkhub-php/security/advisories/new)
         instead. This form creates a **public** issue.
 
         Use this form only for security-related improvements that are not exploitable vulnerabilities

--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -312,7 +312,7 @@ if [[ "$profile" == "full" || "$profile" == "cd" ]]; then
 
   run_step_heavy "infection mutation testing" "./vendor/bin/infection --threads=4 --no-progress"
 
-  run_step_heavy "playwright chromium e2e" "./scripts/ci/bootstrap-laravel.sh && npm run build:php --prefix parkhub-web && pid=''; cleanup() { if [[ -n \"\${pid:-}\" ]]; then kill \"\$pid\" 2>/dev/null || true; fi; }; trap cleanup EXIT; { DEMO_MODE=true PARKHUB_ADMIN_PASSWORD=demo PARKHUB_DISABLE_RATE_LIMITS=true php artisan serve --host=127.0.0.1 --port=8082 >/tmp/parkhub-e2e.log 2>&1 & pid=\$!; }; ./scripts/ci/wait-for-url.sh http://127.0.0.1:8082/api/v1/health/live 60 && npx playwright test e2e/api.spec.ts e2e/pages.spec.ts e2e/v5-a11y.spec.ts --project=chromium"
+  run_step_heavy "playwright chromium e2e" "e2e_db=\"\${FOP_LOCAL_CI_E2E_DB:-/tmp/parkhub-e2e-\$\$.sqlite}\"; rm -f \"\$e2e_db\"; export DB_CONNECTION=sqlite DB_DATABASE=\"\$e2e_db\" DEMO_MODE=true PARKHUB_ADMIN_PASSWORD=demo PARKHUB_DISABLE_RATE_LIMITS=true; ./scripts/ci/bootstrap-laravel.sh && php artisan migrate:fresh --seed --force --no-interaction && npm run build:php --prefix parkhub-web && pid=''; cleanup() { if [[ -n \"\${pid:-}\" ]]; then kill \"\$pid\" 2>/dev/null || true; fi; rm -f \"\$e2e_db\"; }; trap cleanup EXIT; { php artisan serve --host=127.0.0.1 --port=8082 >/tmp/parkhub-e2e.log 2>&1 & pid=\$!; }; ./scripts/ci/wait-for-url.sh http://127.0.0.1:8082/api/v1/health/live 60 && npx playwright test e2e/api.spec.ts e2e/pages.spec.ts e2e/v5-a11y.spec.ts --project=chromium"
 fi
 
 if [[ "$profile" == "cd" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,14 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 
+      - name: Install Node dependencies for CD preflight
+        run: |
+          npm ci
+          npm ci --prefix parkhub-web
+
+      - name: Install Playwright Chromium for CD preflight
+        run: npx playwright install --with-deps chromium
+
       - name: Run CD pre-release gate
         run: make release-preflight
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
   test:
     name: Pre-release tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs: [validate-tag]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -88,11 +88,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install Trivy for CD preflight
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 
-      - name: Run core pre-release gate
-        run: make ci
+      - name: Run CD pre-release gate
+        run: make release-preflight
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,7 +6,7 @@ name: OpenSSF Scorecard
 #
 # Local run (requires PAT with repo:read):
 #   docker run -e GITHUB_AUTH_TOKEN=$PAT gcr.io/openssf/scorecard:stable \
-#     --repo=github.com/<org>/parkhub-rust --format json
+#     --repo=github.com/<org>/parkhub-php --format json
 
 on:
   push:

--- a/Justfile
+++ b/Justfile
@@ -141,6 +141,12 @@ release-tag VERSION:
       echo "working tree not clean — commit or stash first" >&2
       exit 1
     fi
+    echo "▶ running release preflight (make release-preflight)"
+    make release-preflight
+    if [[ -n "$(git status --porcelain)" ]]; then
+      echo "working tree changed during release preflight — review before tagging" >&2
+      exit 1
+    fi
     echo "▶ bumping versions to {{VERSION}}"
     echo "{{VERSION}}" > VERSION
     jq '.version = "{{VERSION}}"' parkhub-web/package.json > parkhub-web/package.json.tmp && mv parkhub-web/package.json.tmp parkhub-web/package.json
@@ -149,8 +155,8 @@ release-tag VERSION:
     git add VERSION parkhub-web/package.json CHANGELOG.md
     git commit -m "chore(release): v{{VERSION}}"
     git tag -a v{{VERSION}} -m "Release v{{VERSION}}"
-    @echo "✓ tagged v{{VERSION}}. Review: git show v{{VERSION}}"
-    @echo "  Push when ready: git push github main && git push github v{{VERSION}}"
+    echo "✓ tagged v{{VERSION}}. Review: git show v{{VERSION}}"
+    echo "  Push when ready: git push github main && git push github v{{VERSION}}"
 
 # ---------------------------------------------------------------------------
 # Cleanup

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@
 #   make act        # run the actual .github/workflows locally via nektos/act
 #   make pre-push   # alias for ci; run before `git push origin/github`
 #
-# Requires: php 8.4, composer v2, node 22, npm. `act` is optional.
+# Requires: php 8.4, composer v2, node 22, npm. CD/release-preflight also
+# requires Trivy and Playwright Chromium. `act` is optional.
 
 SHELL := bash
 .SHELLFLAGS := -euo pipefail -c

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 #   make ci-post    # fop local PR gate + post fop/local-ci/pr for GitHub
 #   make full       # fop full profile: PR gate + mutation/e2e extras
 #   make cd         # fop CD profile: full + release-oriented scans/smoke
+#   make release-preflight # required gate before cutting/publishing a release
 #   make ci-security # strict local OSS mirror of GitHub/Gitea security gates
 #   make lint       # pint --test + phpstan (backend-quality + static-analysis jobs)
 #   make test       # full backend PHPUnit suite — mirrors backend-tests
@@ -24,7 +25,7 @@ SHELL := bash
 .SHELLFLAGS := -euo pipefail -c
 MAKEFLAGS += --no-print-directory
 
-.PHONY: help ci ci-post full cd ci-security lint test static-analysis drift frontend act pre-push clean
+.PHONY: help ci ci-post full cd release-preflight ci-security lint test static-analysis drift frontend act pre-push clean
 
 help:
 	@echo "parkhub-php local-first CI/CD"
@@ -33,6 +34,7 @@ help:
 	@echo "  make ci-post    — fop local PR gate + post fop/local-ci/pr"
 	@echo "  make full       — fop full profile"
 	@echo "  make cd         — fop CD profile"
+	@echo "  make release-preflight — required release gate (CD profile)"
 	@echo "  make ci-security — strict local OSS security/workflow mirror"
 	@echo "  make lint       — pint --test (backend-quality)"
 	@echo "  make static-analysis — phpstan (static-analysis job)"
@@ -91,6 +93,8 @@ full:
 
 cd:
 	.github/scripts/fop-local-ci.sh --profile cd
+
+release-preflight: cd
 
 ci-security:
 	.github/scripts/fop-local-ci.sh --profile pr --dry-run >/dev/null

--- a/scripts/ci/local-security-audit.sh
+++ b/scripts/ci/local-security-audit.sh
@@ -168,7 +168,7 @@ else
   echo "gitleaks not installed; skipping"
 fi
 
-run_if_available actionlint "workflow lint (actionlint)" actionlint .github/workflows
+run_if_available actionlint "workflow lint (actionlint)" bash -euo pipefail -c "find .github/workflows -maxdepth 1 -type f \\( -name '*.yml' -o -name '*.yaml' \\) -print0 | xargs -0 actionlint"
 run_if_available yamllint "yaml lint" yamllint -c .yamllint.yml .github/workflows .gitea/workflows docker-compose.yml render.yaml koyeb.yaml
 run_required "fly config parse" python3 -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('fly.toml').read_text())"
 run_if_available helm "helm chart render" bash -euo pipefail -c "helm lint ./helm/parkhub --set config.appKey=base64:ci-dummy-app-key && helm template parkhub ./helm/parkhub --set config.appKey=base64:ci-dummy-app-key >/dev/null && helm template parkhub ./helm/parkhub --set config.appKey=base64:ci-dummy-app-key --set grafana.dashboardsEnabled=true >/dev/null && helm template parkhub ./helm/parkhub --set config.appKey=base64:ci-dummy-app-key --set monitoring.serviceMonitor.enabled=true >/dev/null && helm template parkhub ./helm/parkhub --set config.appKey=base64:ci-dummy-app-key --set monitoring.prometheusRule.enabled=true >/dev/null"

--- a/scripts/generate-vex.sh
+++ b/scripts/generate-vex.sh
@@ -16,15 +16,14 @@ set -euo pipefail
 TOOL="${1:-cargo-audit}"
 INPUT="${2:-/dev/stdin}"
 DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-REPO_URL="${GITHUB_SERVER_URL:-https://gitea.test}/${GITHUB_REPOSITORY:-parkhub-rust}"
+REPO_URL="${GITHUB_SERVER_URL:-https://gitea.test}/${GITHUB_REPOSITORY:-parkhub-php}"
 COMMIT="${GITHUB_SHA:-unknown}"
 
 # ── Known accepted vulnerabilities (edit as baseline changes) ──
 declare -A ACCEPTED_RISKS=(
-  # Format: [RUSTSEC-ID]="justification|impact_statement"
-  ["RUSTSEC-2024-0370"]="Wontfix|Transitive dev-dependency only; not reachable in production"
-  ["RUSTSEC-2023-0071"]="Wontfix|Legacy crypto in test fixtures; production uses ring"
-  ["RUSTSEC-2025-0057"]="Wontfix|Windows-only path traversal; we target Linux musl"
+  # Format: [CVE-YYYY-NNNN]="justification|impact_statement"
+  # Keep PHP/Composer/npm accepted risks here. Do not copy RustSec IDs from
+  # parkhub-rust; they describe a different package graph.
 )
 
 cat <<EOF
@@ -50,13 +49,13 @@ cat <<EOF
     "branches": [
       {
         "category": "product_name",
-        "name": "parkhub-rust",
+        "name": "parkhub-php",
         "branches": [
           {
             "category": "product_version",
             "name": "${COMMIT:0:8}",
             "product": {
-              "product_id": "parkhub-rust:${COMMIT:0:8}"
+              "product_id": "parkhub-php:${COMMIT:0:8}"
             }
           }
         ]
@@ -77,7 +76,7 @@ for id in "${!ACCEPTED_RISKS[@]}"; do
     {
       "cve": "${id}",
       "product_status": {
-        "known_not_affected": ["parkhub-rust:${COMMIT:0:8}"]
+        "known_not_affected": ["parkhub-php:${COMMIT:0:8}"]
       },
       "threats": [
         {


### PR DESCRIPTION
## Summary
- make release workflow run `make release-preflight` instead of the PR-only `make ci` gate
- make `just release-tag` run the CD preflight before version bump/tag creation
- fix PHP supply-chain metadata copied from Rust in VEX, Scorecard docs, and security advisory link

## Verification
- `actionlint /var/home/florian/dev/parkhub-php/.github/workflows/release.yml /var/home/florian/dev/parkhub-php/.github/workflows/scorecard.yml`
- `bash -n /var/home/florian/dev/parkhub-php/scripts/generate-vex.sh`
- `make -C /var/home/florian/dev/parkhub-php -n release-preflight`
- `just --unstable --justfile /var/home/florian/dev/parkhub-php/Justfile --working-directory /var/home/florian/dev/parkhub-php --dry-run release-tag 0.0.0`
- `cd /var/home/florian/dev/parkhub-php && fop build --backend local . --preset custom -- bash -lc 'git diff --check && ./.github/scripts/fop-local-ci.sh --profile pr --dry-run'`