### PR TITLE
ci: repin git-cliff changelog action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run git-cliff
         # MIT/Apache-2.0 — orhun/git-cliff. Reads cliff.toml at repo root.
-        uses: orhun/git-cliff-action@4a4a951bc43fafe41cd2348e181853f7f939bf3a # v4.6.0
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
           args: --output CHANGELOG.md


### PR DESCRIPTION
## Summary
- repin orhun/git-cliff-action from the invalid SHA used by main to the valid v4.8.0 commit
- unblock the post-merge Changelog workflow

## Verification
- actionlint .github/workflows/changelog.yml
- git diff --check