### PR TITLE
fix(modules): restore PHP modules info alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ resources/js/src.bak/
 /public/og-image.svg
 /public/favicon.ico
 /public/favicon.svg
+/public/icons/icon-*.png
 
 # Claude Code
 /.claude/

--- a/app/Http/Controllers/Api/ModuleController.php
+++ b/app/Http/Controllers/Api/ModuleController.php
@@ -65,6 +65,28 @@ class ModuleController extends Controller
     }
 
     /**
+     * GET /api/v1/modules/info
+     *
+     * Legacy Rust-compatible alias consumed by older shared parkhub-web
+     * builds. It keeps `modules` / `module_info` at the top level while also
+     * exposing `data` as the ModuleInfo array for the shared React view.
+     */
+    public function info(): JsonResponse
+    {
+        $moduleInfo = ModuleRegistry::all();
+
+        return response()->json([
+            'success' => true,
+            'data' => $moduleInfo,
+            'modules' => ModuleRegistry::enabledMap(),
+            'module_info' => $moduleInfo,
+            'version' => SystemController::appVersion(),
+            'error' => null,
+            'meta' => null,
+        ]);
+    }
+
+    /**
      * GET /api/v1/modules/{name}
      *
      * Returns the single ModuleInfo-shaped record or a 404 when the

--- a/docs/openapi/php.json
+++ b/docs/openapi/php.json
@@ -30839,6 +30839,65 @@
         ]
       }
     },
+    "/v1/modules/info": {
+      "get": {
+        "description": "Legacy Rust-compatible alias consumed by older shared parkhub-web\nbuilds. It keeps `modules` / `module_info` at the top level while also\nexposing `data` as the ModuleInfo array for the shared React view.",
+        "operationId": "module.info",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "error": {
+                      "type": "null"
+                    },
+                    "meta": {
+                      "type": "null"
+                    },
+                    "module_info": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "modules": {
+                      "additionalProperties": {
+                        "type": "boolean"
+                      },
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "modules",
+                    "module_info",
+                    "version",
+                    "error",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "GET /api/v1/modules/info",
+        "tags": [
+          "Module"
+        ]
+      }
+    },
     "/v1/modules/{name}": {
       "get": {
         "description": "Returns the single ModuleInfo-shaped record or a 404 when the\nslug is unknown.",

--- a/parkhub-web/src/views/AdminModules.test.tsx
+++ b/parkhub-web/src/views/AdminModules.test.tsx
@@ -143,6 +143,26 @@ describe('AdminModulesPage', () => {
     expect(screen.getByText(/2\s*\/\s*3\s*active/)).toBeInTheDocument();
   });
 
+  it('normalizes PHP title-case category values before grouping', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          mkModule({ name: 'bookings', category: 'Core' }),
+          mkModule({ name: 'absences', category: 'Booking' }),
+          mkModule({ name: 'stripe', category: 'Payment' }),
+        ],
+      }),
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId('module-card-bookings')).toBeInTheDocument();
+    expect(screen.getByTestId('module-card-absences')).toBeInTheDocument();
+    expect(screen.getByTestId('module-card-stripe')).toBeInTheDocument();
+    expect(screen.queryByText('No modules match your filters.')).not.toBeInTheDocument();
+  });
+
   it('surfaces fetch errors without crashing', async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 500 });
     renderPage();

--- a/parkhub-web/src/views/AdminModules.tsx
+++ b/parkhub-web/src/views/AdminModules.tsx
@@ -43,6 +43,10 @@ function categoryLabel(t: (k: string, d?: string) => string, cat: string): strin
   return t(`admin.modules.category.${cat}`, cat.charAt(0).toUpperCase() + cat.slice(1));
 }
 
+function categoryKey(category: string): string {
+  return category.trim().toLowerCase();
+}
+
 /** Status pill reflects runtime_enabled (green), runtime off (amber), or compile-time off (gray). */
 function StatusDot({ m }: { m: ModuleInfo }) {
   const runtime = m.runtime_enabled ?? m.enabled;
@@ -258,7 +262,7 @@ export function AdminModulesPage() {
     if (!modules) return [];
     const q = query.trim().toLowerCase();
     return modules.filter((m) => {
-      if (filter !== 'all' && m.category !== filter) return false;
+      if (filter !== 'all' && categoryKey(m.category) !== filter) return false;
       if (hideDisabled && !(m.runtime_enabled ?? m.enabled)) return false;
       if (!q) return true;
       return (
@@ -272,8 +276,9 @@ export function AdminModulesPage() {
   const grouped = useMemo(() => {
     const by = new Map<string, ModuleInfo[]>();
     for (const m of filtered) {
-      if (!by.has(m.category)) by.set(m.category, []);
-      by.get(m.category)!.push(m);
+      const cat = categoryKey(m.category);
+      if (!by.has(cat)) by.set(cat, []);
+      by.get(cat)!.push(m);
     }
     return CATEGORY_ORDER.map((c) => ({ cat: c, mods: by.get(c) ?? [] })).filter(
       (g) => g.mods.length > 0,

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -78,6 +78,7 @@ Route::get('/translations/overrides', [TranslationController::class, 'overrides'
 
 // Modules endpoint (public — frontend uses this to discover available features)
 Route::get('/modules', [ModuleController::class, 'index']);
+Route::get('/modules/info', [ModuleController::class, 'info']);
 Route::get('/modules/{name}', [ModuleController::class, 'show']);
 
 // Discovery / handshake endpoint (public)

--- a/tests/Feature/Api/ModuleControllerTest.php
+++ b/tests/Feature/Api/ModuleControllerTest.php
@@ -102,6 +102,22 @@ class ModuleControllerTest extends TestCase
         }
     }
 
+    public function test_info_alias_returns_rust_compatible_top_level_module_registry(): void
+    {
+        $response = $this->getJson('/api/v1/modules/info');
+
+        $response->assertOk();
+
+        $modules = $response->json('modules');
+        $moduleInfo = $response->json('module_info');
+
+        $this->assertIsArray($modules);
+        $this->assertIsArray($moduleInfo);
+        $this->assertNotEmpty($moduleInfo);
+        $this->assertArrayHasKey('bookings', $modules);
+        $this->assertContains('bookings', array_column($moduleInfo, 'name'));
+    }
+
     public function test_index_uses_canonical_product_slugs_in_public_payloads(): void
     {
         $response = $this->getJson('/api/v1/modules');

--- a/tests/Feature/Api/ModuleControllerTest.php
+++ b/tests/Feature/Api/ModuleControllerTest.php
@@ -110,10 +110,17 @@ class ModuleControllerTest extends TestCase
 
         $modules = $response->json('modules');
         $moduleInfo = $response->json('module_info');
+        $data = $response->json('data');
+        $version = $response->json('version');
 
+        $this->assertTrue($response->json('success'));
         $this->assertIsArray($modules);
         $this->assertIsArray($moduleInfo);
+        $this->assertIsArray($data);
         $this->assertNotEmpty($moduleInfo);
+        $this->assertSame($moduleInfo, $data);
+        $this->assertIsString($version);
+        $this->assertNotSame('', $version);
         $this->assertArrayHasKey('bookings', $modules);
         $this->assertContains('bookings', array_column($moduleInfo, 'name'));
     }


### PR DESCRIPTION
## Summary
- restore the Rust-compatible /api/v1/modules/info alias in PHP
- normalize shared admin modules category casing so PHP module cards render
- add backend/frontend regression coverage and regenerate OpenAPI

## Verification
- fop build --backend local . --preset custom -- bash -lc "DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter ModuleControllerTest"
- fop build --backend local . --preset custom -- bash -lc "cd parkhub-web && npm run test -- --run src/views/AdminModules.test.tsx"
- fop build --backend local . --preset custom -- bash -lc "./scripts/dump-openapi.sh && git diff --exit-code docs/openapi/php.json"
- pre-push local CI completed backend/frontend/security gates and only blocked on OpenAPI drift before this amend
- live smoke: http://parkhub-php.test/admin/modules renders module cards without the load error