### PR TITLE
fix(ci): make release preflight self-contained — install Composer + Node + Playwright

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,17 @@ jobs:
       - name: Install Trivy for CD preflight
         uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
 
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Install Node dependencies for CD preflight
+        run: |
+          npm ci
+          npm ci --prefix parkhub-web
+
+      - name: Install Playwright Chromium for CD preflight
+        run: npx playwright install --with-deps chromium
+
       - name: Run CD pre-release gate
         run: make release-preflight
 


### PR DESCRIPTION
Recovers an unshipped follow-up to PR #420 from local worktree (parkhub-php.ci-pr420 — orphaned after PR #420 squash-merged). Adds 3 install steps to the release CD preflight job before `make release-preflight` runs:

- composer install --prefer-dist --no-interaction --no-progress
- npm ci + npm ci --prefix parkhub-web
- npx playwright install --with-deps chromium

Without these, the release preflight either runs against stale vendor/ + node_modules from a cached runner OR fails when Playwright tests need browser binaries that aren't preinstalled on ubuntu-latest.

Cherry-picked from local commit 3f0c44e (Fri May 1 03:28 CEST). Local CI passed (646s).