### PR TITLE
chore(attestation): add `--sha` flag + state validation (parity with parkhub-rust)

### DIFF
--- a/scripts/post-attestation-deferred.sh
+++ b/scripts/post-attestation-deferred.sh
@@ -9,20 +9,64 @@
 # every 5s (up to 2.5min) until the SHA shows up, then posts the status.
 # The parent process returns immediately so lefthook isn't blocked.
 #
-# Usage: bash scripts/post-attestation-deferred.sh [success|failure] [description]
+# Usage:
+#   bash scripts/post-attestation-deferred.sh [state] [description]
+#   bash scripts/post-attestation-deferred.sh --sha <sha> [state] [description]
+#
+# By default the SHA comes from `git rev-parse HEAD` (the lefthook
+# pre-push case). Use `--sha <sha>` to manually re-post against a
+# different commit (e.g. when an earlier post failed and the PR is
+# stuck on `fop/local-ci/pr` PENDING). Short SHAs are accepted and
+# expanded via `git rev-parse --verify '<sha>^{commit}'` since the
+# GitHub statuses API rejects abbreviated forms with HTTP 422.
+#
+# Mirrors the parkhub-rust v5.0.9 attestation-script-sha-flag patch.
 #
 # Skips cleanly if `gh` isn't on PATH or no GitHub remote is configured.
 
 set -euo pipefail
 
+sha=""
+if [ "${1:-}" = "--sha" ]; then
+  sha="${2:-}"
+  if [ -z "$sha" ]; then
+    echo "ERROR: --sha requires a SHA argument" >&2
+    exit 2
+  fi
+  shift 2
+fi
+
 state="${1:-success}"
 description="${2:-Local-first attestation: lefthook pre-push gates clean}"
+
+# Validate state — GitHub statuses API rejects anything outside this set.
+case "$state" in
+  success|failure|pending|error) ;;
+  *)
+    echo "ERROR: state must be one of: success failure pending error (got: $state)" >&2
+    exit 2
+    ;;
+esac
 
 if ! command -v gh >/dev/null 2>&1; then
   exit 0
 fi
 
-sha="$(git rev-parse HEAD)"
+if [ -z "$sha" ]; then
+  sha="$(git rev-parse HEAD)"
+else
+  # Expand short / abbreviated SHAs to the full 40-char form.
+  # GitHub's POST /repos/.../statuses/{sha} endpoint rejects anything
+  # shorter with HTTP 422 "Sha must be a valid hex object ID", even
+  # though GET /commits/{sha} accepts the prefix. Fail loudly if the
+  # SHA isn't resolvable locally.
+  expanded="$(git rev-parse --verify "${sha}^{commit}" 2>/dev/null || true)"
+  if [ -z "$expanded" ]; then
+    echo "ERROR: --sha '$sha' is not a valid commit in this repo" >&2
+    exit 2
+  fi
+  sha="$expanded"
+fi
 repo=""
 for remote in github upstream origin; do
   url="$(git remote get-url "$remote" 2>/dev/null || true)"


### PR DESCRIPTION
Mirrors **parkhub-rust PRs #582 + #583** shipped today.

Three QoL improvements that prevent silent attestation-poster failures:

1. **`--sha <sha>` flag** — manual re-post against a specific commit without detaching HEAD.
2. **State validation** — reject anything outside `success|failure|pending|error` with a clear ERROR + `exit 2`.
3. **Short-SHA expansion** — abbreviated SHAs (8-12 chars) expand via `git rev-parse --verify '<sha>^{commit}'` before hitting GitHub (which rejects them with HTTP 422 silently in the nohup subshell).

Encountered today during the **parkhub-php v5.0.4 release** (PR #437): manual attestation re-post needed the full 40-char SHA, the abbreviated form silently failed, the PR sat BLOCKED until I worked around with a direct `gh api` call.

Lefthook callsite (`bash scripts/post-attestation-deferred.sh success "..."`) is unchanged — backwards-compatible.

🤖 Autonomous parkhub loop tick 2026-05-03.