### PR TITLE
fix(release): bump helm Chart appVersion 5.0.3 → 5.0.4 (missed in #437)

### DIFF
--- a/helm/parkhub/Chart.yaml
+++ b/helm/parkhub/Chart.yaml
@@ -3,7 +3,7 @@ name: parkhub-php
 description: Self-hosted parking management platform — Laravel + React, Docker-ready
 type: application
 version: 1.0.1
-appVersion: "5.0.3"
+appVersion: "5.0.4"
 home: https://github.com/nash87/parkhub-php
 sources:
   - https://github.com/nash87/parkhub-php


### PR DESCRIPTION
Hotfix for the failed v5.0.4 release pipeline.

## Symptom

`Pre-release tests` job failed at `parkhub-web/src/lib/appVersion.test.ts:19`:
```
AssertionError: expected '5.0.3' to be '5.0.4'
helm Chart appVersion matches /VERSION
```

`Create GitHub Release` job was correctly SKIPPED — no v5.0.4 release was published, just the tag.

## Cause

The drift test enforces 3 version surfaces:
1. `VERSION` ← #437 bumped this ✅
2. `parkhub-web/package.json` ← #437 bumped this ✅
3. `helm/parkhub/Chart.yaml#appVersion` ← #437 missed this ❌

The Rust release.yml only validates 2 surfaces (no helm chart in parkhub-rust), so I was looking at the wrong checklist.

## Fix-forward plan

1. Merge this PR.
2. Move the `v5.0.4` tag to the new HEAD on main:
   ```bash
   git tag -d v5.0.4
   git push github :refs/tags/v5.0.4
   git tag -a v5.0.4 -m "Release v5.0.4 (helm Chart appVersion fix)"
   git push github v5.0.4
   ```
3. `release.yml` re-fires with the corrected tag, pre-flight passes, GitHub Release publishes.

(Holding off on the destructive remote-tag-delete until this PR lands — fix-forward order avoids a stranded tag.)

🤖 Autonomous parkhub loop tick 2026-05-03.