### PR TITLE
ci: refresh PHP Gitea workflow mirror host

### DIFF
--- a/.gitea/workflows/accessibility-insights.yaml
+++ b/.gitea/workflows/accessibility-insights.yaml
@@ -49,7 +49,7 @@ jobs:
     name: Accessibility Insights (FastPass + needs-review)
     runs-on: ubuntu-latest
     container:
-      image: 192.168.178.250:5000/gitea/runner-images:ubuntu-latest
+      image: 192.168.178.250:5000/gitea/runner-images@sha256:056f41b214d06e42289a7b2918950e46e9394e855ca056c88b8131a5f0761557
       options: --add-host=gitea.test:192.168.178.233
     timeout-minutes: 30
     continue-on-error: true # Soft-fail for first month — IGT findings still triaging.
@@ -96,8 +96,8 @@ jobs:
 
       - name: Run Accessibility Insights
         # Reference: https://github.com/microsoft/accessibility-insights-action
-        # MIT license. v3 is the current marketplace tag.
-        uses: microsoft/accessibility-insights-action@v3
+        # MIT license. Pinned from refs/tags/v3 for Gitea mirror hygiene.
+        uses: microsoft/accessibility-insights-action@ecfbbc29c9a7f745ffd7ef8517b4cda6a59d4409
         with:
           # `static-site-dir` makes the action serve the built Astro output
           # (no separate preview server needed) on a localhost port of its
@@ -115,8 +115,8 @@ jobs:
       - name: Upload Accessibility Insights report
         if: always()
         # SOTA-2026 (T-2280): @v4 uses a GHES-incompatible artifact API
-        # not yet served by Gitea Actions. @v3 is the last GHES-compat tag.
-        uses: https://192.168.178.233/actions/upload-artifact@v3
+        # not yet served by Gitea Actions. Pinned to the v3 commit.
+        uses: https://192.168.178.233/actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: accessibility-insights-${{ github.run_number }}
           path: parkhub-web/_accessibility-reports/

--- a/.gitea/workflows/accessibility-insights.yaml
+++ b/.gitea/workflows/accessibility-insights.yaml
@@ -50,16 +50,16 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: 192.168.178.250:5000/gitea/runner-images:ubuntu-latest
-      options: --add-host=gitea.test:192.168.178.212
+      options: --add-host=gitea.test:192.168.178.233
     timeout-minutes: 30
     continue-on-error: true # Soft-fail for first month — IGT findings still triaging.
     defaults:
       run:
         working-directory: parkhub-web
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@v4
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: http://192.168.178.212:3000/actions/setup-node@v4
+      - uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -116,7 +116,7 @@ jobs:
         if: always()
         # SOTA-2026 (T-2280): @v4 uses a GHES-incompatible artifact API
         # not yet served by Gitea Actions. @v3 is the last GHES-compat tag.
-        uses: http://192.168.178.212:3000/actions/upload-artifact@v3
+        uses: https://192.168.178.233/actions/upload-artifact@v3
         with:
           name: accessibility-insights-${{ github.run_number }}
           path: parkhub-web/_accessibility-reports/

--- a/.gitea/workflows/auto-merge.yaml
+++ b/.gitea/workflows/auto-merge.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/auto-merge.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/auto-merge.yml as source-of-truth, then re-mirror.
 
 name: Auto-merge on label

--- a/.gitea/workflows/ci.yaml
+++ b/.gitea/workflows/ci.yaml
@@ -1,5 +1,5 @@
 # Internal full CI for the Gitea Actions runner.
-# Action refs are rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs are rewritten to https://192.168.178.233/actions/* where mirrored.
 #
 # GitHub same-repo PRs are intentionally local-first: they require the
 # `fop/local-ci/pr` commit status posted by `make ci-post` and skip most heavy
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Lint GitHub Actions workflows
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
@@ -71,10 +71,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review dependencies
-        uses: http://192.168.178.212:3000/actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: https://192.168.178.233/actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0
@@ -86,8 +86,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # TODO(gitea-mirror): No mirror at http://192.168.178.212:3000/shivammathur/setup-php yet.
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/shivammathur/setup-php yet.
       # Pin upstream until we mirror; revisit when Gitea mirror lands.
 
       - name: Set up PHP
@@ -99,7 +99,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -124,7 +124,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -135,7 +135,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -160,10 +160,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -201,14 +201,14 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Set up Node.js
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -217,7 +217,7 @@ jobs:
             parkhub-web/package-lock.json
 
       - name: Cache Playwright browsers
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -261,7 +261,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: playwright-report/
@@ -269,7 +269,7 @@ jobs:
 
       - name: Upload Laravel server log
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-server-log
           path: /tmp/parkhub-e2e.log
@@ -282,7 +282,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -304,7 +304,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -315,7 +315,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -343,7 +343,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -353,7 +353,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -389,7 +389,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -400,7 +400,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.gitea/workflows/docker-publish.yaml
+++ b/.gitea/workflows/docker-publish.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/docker-publish.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/docker-publish.yml as source-of-truth, then re-mirror.
 
 name: Release Container
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4

--- a/.gitea/workflows/helm.yaml
+++ b/.gitea/workflows/helm.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/helm.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/helm.yml as source-of-truth, then re-mirror.
 
 name: Helm Chart
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: 'v3.16.4'

--- a/.gitea/workflows/infection.yaml
+++ b/.gitea/workflows/infection.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/infection.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/infection.yml as source-of-truth, then re-mirror.
 
 name: Infection (mutation testing)
@@ -26,7 +26,7 @@ jobs:
     # phase. Do NOT gate merges on this; watch the nightly trend instead.
     continue-on-error: true
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up PHP (xdebug for coverage)
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -36,7 +36,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache composer
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: vendor
           key: composer-${{ hashFiles('composer.lock') }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload infection report
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: infection-report
           path: .infection/

--- a/.gitea/workflows/install-smoke.yaml
+++ b/.gitea/workflows/install-smoke.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/install-smoke.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/install-smoke.yml as source-of-truth, then re-mirror.
 
 name: Install Smoke
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Cold clone
         run: |
           git clone --depth 1 https://github.com/nash87/parkhub-php.git /tmp/smoke

--- a/.gitea/workflows/lighthouse.yaml
+++ b/.gitea/workflows/lighthouse.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/lighthouse.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/lighthouse.yml as source-of-truth, then re-mirror.
 
 name: Lighthouse CI
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.gitea/workflows/lost-pixel.yaml
+++ b/.gitea/workflows/lost-pixel.yaml
@@ -37,7 +37,7 @@ jobs:
     name: Lost Pixel (pages + Storybook)
     runs-on: ubuntu-latest
     container:
-      image: 192.168.178.250:5000/gitea/runner-images:ubuntu-latest
+      image: 192.168.178.250:5000/gitea/runner-images@sha256:056f41b214d06e42289a7b2918950e46e9394e855ca056c88b8131a5f0761557
       options: --add-host=gitea.test:192.168.178.233
     timeout-minutes: 30
     continue-on-error: true # Diffs surface as artefacts, never block.
@@ -95,8 +95,8 @@ jobs:
         if: always()
         working-directory: ${{ github.workspace }}
         # SOTA-2026 (T-2280): @v4 uses a GHES-incompatible artifact API
-        # not yet served by Gitea Actions. @v3 is the last GHES-compat tag.
-        uses: https://192.168.178.233/actions/upload-artifact@v3
+        # not yet served by Gitea Actions. Pinned to the v3 commit.
+        uses: https://192.168.178.233/actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: lost-pixel-diffs-${{ github.run_number }}
           path: |

--- a/.gitea/workflows/lost-pixel.yaml
+++ b/.gitea/workflows/lost-pixel.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: 192.168.178.250:5000/gitea/runner-images:ubuntu-latest
-      options: --add-host=gitea.test:192.168.178.212
+      options: --add-host=gitea.test:192.168.178.233
     timeout-minutes: 30
     continue-on-error: true # Diffs surface as artefacts, never block.
     # Gated until lostpixel.config.ts lands at repo root and the
@@ -50,9 +50,9 @@ jobs:
       run:
         working-directory: parkhub-web
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@v4
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: http://192.168.178.212:3000/actions/setup-node@v4
+      - uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -96,7 +96,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         # SOTA-2026 (T-2280): @v4 uses a GHES-incompatible artifact API
         # not yet served by Gitea Actions. @v3 is the last GHES-compat tag.
-        uses: http://192.168.178.212:3000/actions/upload-artifact@v3
+        uses: https://192.168.178.233/actions/upload-artifact@v3
         with:
           name: lost-pixel-diffs-${{ github.run_number }}
           path: |

--- a/.gitea/workflows/nightly.yaml
+++ b/.gitea/workflows/nightly.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/nightly.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/nightly.yml as source-of-truth, then re-mirror.
 
 name: Nightly Assurance
@@ -33,8 +33,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # TODO(gitea-mirror): No mirror at http://192.168.178.212:3000/shivammathur/setup-php yet.
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/shivammathur/setup-php yet.
       # Pin upstream until we mirror; revisit when Gitea mirror lands.
 
       - name: Set up PHP
@@ -45,7 +45,7 @@ jobs:
           tools: composer:v2
 
       - name: Set up Node.js
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -91,7 +91,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -152,14 +152,14 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Set up Node.js
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -168,7 +168,7 @@ jobs:
             parkhub-web/package-lock.json
 
       - name: Cache Playwright browsers
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload Playwright report (${{ matrix.project }} shard ${{ matrix.shard }})
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nightly-playwright-report-${{ matrix.project }}-${{ matrix.shard }}
           path: playwright-report/
@@ -234,7 +234,7 @@ jobs:
 
       - name: Upload Laravel server log (${{ matrix.project }} shard ${{ matrix.shard }})
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nightly-e2e-server-log-${{ matrix.project }}-${{ matrix.shard }}
           path: /tmp/parkhub-nightly-e2e-${{ matrix.project }}-${{ matrix.shard }}.log

--- a/.gitea/workflows/openapi-drift.yaml
+++ b/.gitea/workflows/openapi-drift.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/openapi-drift.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/openapi-drift.yml as source-of-truth, then re-mirror.
 
 name: OpenAPI Drift
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # TODO(gitea-mirror): No mirror at http://192.168.178.212:3000/shivammathur/setup-php yet.
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/shivammathur/setup-php yet.
       # Pin upstream until we mirror; revisit when Gitea mirror lands.
 
       - name: Set up PHP
@@ -44,7 +44,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache composer
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: vendor
           key: composer-${{ hashFiles('composer.lock') }}

--- a/.gitea/workflows/release.yaml
+++ b/.gitea/workflows/release.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/release.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/release.yml as source-of-truth, then re-mirror.
 
 name: Release
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Require v* tag ref
         run: |
@@ -73,8 +73,8 @@ jobs:
     timeout-minutes: 30
     needs: [validate-tag]
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # TODO(gitea-mirror): No mirror at http://192.168.178.212:3000/shivammathur/setup-php yet.
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/shivammathur/setup-php yet.
       # Pin upstream until we mirror; revisit when Gitea mirror lands.
 
       - name: Set up PHP
@@ -90,7 +90,7 @@ jobs:
         # that PR runs can write to, or a malicious PR could poison a tag
         # build via the shared cache key. Cold install is acceptable on the
         # release path.
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -112,7 +112,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Create release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3

--- a/.gitea/workflows/schemathesis.yaml
+++ b/.gitea/workflows/schemathesis.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/schemathesis.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/schemathesis.yml as source-of-truth, then re-mirror.
 
 name: Schemathesis (contract fuzzing)
@@ -35,8 +35,8 @@ jobs:
     # triage follow-up tasks off the nightly run.
     continue-on-error: true
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # TODO(gitea-mirror): No mirror at http://192.168.178.212:3000/shivammathur/setup-php yet.
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/shivammathur/setup-php yet.
       # Pin upstream until we mirror; revisit when Gitea mirror lands.
 
       - name: Set up PHP
@@ -48,7 +48,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache composer
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: vendor
           key: composer-${{ hashFiles('composer.lock') }}
@@ -57,7 +57,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Set up Python
-        uses: http://192.168.178.212:3000/actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: https://192.168.178.233/actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload schemathesis report
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: schemathesis-report
           path: |

--- a/.gitea/workflows/scorecard.yaml
+++ b/.gitea/workflows/scorecard.yaml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       security-events: write  # Needed for SARIF upload (GitHub-only)
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
           publish_results: false  # GitHub-only API; we keep SARIF as artifact
 
       - name: Upload Scorecard SARIF
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always() && hashFiles('scorecard-results.sarif') != ''
         with:
           name: scorecard-results

--- a/.gitea/workflows/security.yaml
+++ b/.gitea/workflows/security.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/security.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/security.yml as source-of-truth, then re-mirror.
 
 name: Security
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # TODO(gitea-mirror): No mirror at http://192.168.178.212:3000/shivammathur/setup-php yet.
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/shivammathur/setup-php yet.
       # Pin upstream until we mirror; revisit when Gitea mirror lands.
 
       - name: Set up PHP
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -79,7 +79,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy filesystem scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -109,7 +109,7 @@ jobs:
       GITLEAKS_VERSION: 8.30.1
       GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -152,7 +152,7 @@ jobs:
     env:
       ZIZMOR_VERSION: 1.24.1
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false   # zizmor: ignore[artipacked] — read-only
 
@@ -183,7 +183,7 @@ jobs:
     env:
       OSV_SCANNER_VERSION: 2.3.5
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false   # zizmor: ignore[artipacked] — read-only
 
@@ -211,7 +211,7 @@ jobs:
     env:
       GRYPE_VERSION: 0.111.1
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false   # zizmor: ignore[artipacked] — read-only
 
@@ -246,7 +246,7 @@ jobs:
       IMAGE_REF: ghcr.io/${{ github.repository }}:latest
       GRYPE_VERSION: 0.111.1
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false   # zizmor: ignore[artipacked] — read-only
 

--- a/.gitea/workflows/storybook.yaml
+++ b/.gitea/workflows/storybook.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/storybook.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/storybook.yml as source-of-truth, then re-mirror.
 
 name: Storybook
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Storybook static build
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: storybook-static
           path: parkhub-web/storybook-static

--- a/.gitea/workflows/unlighthouse.yaml
+++ b/.gitea/workflows/unlighthouse.yaml
@@ -39,7 +39,7 @@ jobs:
     name: Unlighthouse (whole-site crawl)
     runs-on: ubuntu-latest
     container:
-      image: 192.168.178.250:5000/gitea/runner-images:ubuntu-latest
+      image: 192.168.178.250:5000/gitea/runner-images@sha256:056f41b214d06e42289a7b2918950e46e9394e855ca056c88b8131a5f0761557
       options: --add-host=gitea.test:192.168.178.233
     timeout-minutes: 45
     continue-on-error: true # Soft-fail — long-tail budgets still tuning.
@@ -138,8 +138,8 @@ jobs:
       - name: Upload Unlighthouse report
         if: always()
         # SOTA-2026 (T-2280): @v4 uses a GHES-incompatible artifact API
-        # not yet served by Gitea Actions. @v3 is the last GHES-compat tag.
-        uses: https://192.168.178.233/actions/upload-artifact@v3
+        # not yet served by Gitea Actions. Pinned to the v3 commit.
+        uses: https://192.168.178.233/actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: unlighthouse-${{ github.run_number }}
           path: parkhub-web/.unlighthouse/

--- a/.gitea/workflows/unlighthouse.yaml
+++ b/.gitea/workflows/unlighthouse.yaml
@@ -40,20 +40,20 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: 192.168.178.250:5000/gitea/runner-images:ubuntu-latest
-      options: --add-host=gitea.test:192.168.178.212
+      options: --add-host=gitea.test:192.168.178.233
     timeout-minutes: 45
     continue-on-error: true # Soft-fail — long-tail budgets still tuning.
     steps:
-      - uses: http://192.168.178.212:3000/actions/checkout@v4
+      - uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: http://192.168.178.212:3000/actions/setup-node@v4
+      - uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: parkhub-web/package-lock.json
 
       - name: Setup PHP
-        uses: http://192.168.178.212:3000/shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ env.PHP_VERSION }}
           extensions: mbstring, sqlite, pdo_sqlite, intl, gd
@@ -139,7 +139,7 @@ jobs:
         if: always()
         # SOTA-2026 (T-2280): @v4 uses a GHES-incompatible artifact API
         # not yet served by Gitea Actions. @v3 is the last GHES-compat tag.
-        uses: http://192.168.178.212:3000/actions/upload-artifact@v3
+        uses: https://192.168.178.233/actions/upload-artifact@v3
         with:
           name: unlighthouse-${{ github.run_number }}
           path: parkhub-web/.unlighthouse/

--- a/.gitea/workflows/visual-regression.yaml
+++ b/.gitea/workflows/visual-regression.yaml
@@ -1,5 +1,5 @@
 # Mirror of .github/workflows/visual-regression.yml for Gitea Actions runner.
-# Action refs rewritten to http://192.168.178.212:3000/actions/* where mirrored.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
 # Edit .github/workflows/visual-regression.yml as source-of-truth, then re-mirror.
 
 name: Visual Regression
@@ -40,8 +40,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: http://192.168.178.212:3000/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # TODO(gitea-mirror): No mirror at http://192.168.178.212:3000/shivammathur/setup-php yet.
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/shivammathur/setup-php yet.
       # Pin upstream until we mirror; revisit when Gitea mirror lands.
 
       - name: Set up PHP
@@ -53,14 +53,14 @@ jobs:
           tools: composer:v2
 
       - name: Cache Composer downloads
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.composer/cache
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Set up Node.js
-        uses: http://192.168.178.212:3000/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -69,7 +69,7 @@ jobs:
             parkhub-web/package-lock.json
 
       - name: Cache Playwright browsers
-        uses: http://192.168.178.212:3000/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: https://192.168.178.233/actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload diff artifacts
         if: failure()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: visual-regression-diffs
           path: |
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload full Playwright report
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-visual-report
           path: playwright-report/
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload Laravel server log
         if: always()
-        uses: http://192.168.178.212:3000/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: https://192.168.178.233/actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: visual-server-log
           path: /tmp/parkhub-visual.log


### PR DESCRIPTION
## Summary

- refresh PHP .gitea/workflows/** action mirror URLs from stale 192.168.178.212:3000 to the current 192.168.178.233 mirror
- update gitea.test container host aliases from .212 to .233
- pin the mirrored checkout/setup-node/setup-php action refs where the repo already had known commit SHAs
- pin the Gitea-only browser audit workflow dependencies added in c59ab0d: accessibility-insights action, upload-artifact v3 commit, and the internal runner image digest

## Verification

- rg -n "192\.168\.178\.212|http://192\.168\.178\.212:3000|gitea\.test:192\.168\.178\.212" .gitea/workflows -S returned no matches
- workflow YAML parse check over .gitea/workflows/*.yaml and .github/workflows/*.yml passed
- git diff --check
- focused yamllint over accessibility-insights.yaml, lost-pixel.yaml, and unlighthouse.yaml passed
- focused zizmor over those three Gitea workflows passed with no findings
- pre-push .github/scripts/fop-local-ci.sh --profile pr passed for c59ab0dd8339f6cbab673562d4a505fd808ab87e; report: .fop/reports/local-ci-pr-c59ab0dd8339f6cbab673562d4a505fd808ab87e.json

## Notes

- upload-artifact stays on the Gitea/GHES-compatible v3 implementation, but is now pinned to the refs/tags/v3 commit SHA
- internal Gitea runner image references in the touched workflows are pinned to digest sha256:056f41b214d06e42289a7b2918950e46e9394e855ca056c88b8131a5f0761557
