### PR TITLE
ci: default PHP VEX metadata to GitHub

### DIFF
--- a/scripts/generate-vex.sh
+++ b/scripts/generate-vex.sh
@@ -19,7 +19,9 @@ if [[ $# -ne 0 ]]; then
 fi
 
 DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-REPO_URL="${GITHUB_SERVER_URL:-https://gitea.test}/${GITHUB_REPOSITORY:-parkhub-php}"
+REPO_HOST="${GITHUB_SERVER_URL:-https://github.com}"
+REPO_PATH="${GITHUB_REPOSITORY:-nash87/parkhub-php}"
+REPO_URL="${REPO_HOST}/${REPO_PATH}"
 COMMIT="${GITHUB_SHA:-unknown}"
 
 # ── Known accepted vulnerabilities (edit as baseline changes) ──


### PR DESCRIPTION
## Summary

- default locally generated PHP VEX metadata to GitHub when GitHub Actions env
  vars are absent
- keep existing `GITHUB_SERVER_URL` / `GITHUB_REPOSITORY` behavior intact inside
  CI

## Verification

- `bash -n scripts/generate-vex.sh`
- `bash scripts/generate-vex.sh | jq -r '.document.publisher.namespace'`
  returned `https://github.com/nash87/parkhub-php`
- `git diff --check`

## Notes

This is intentionally separate from `fix/release-preflight-e2e-base-url` so the
green PHP PR branch stays at its verified `a49f728` head.
