### PR TITLE
ci: preserve fop local failure status

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 usage() {
   cat <<'EOF'

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL := bash
 .SHELLFLAGS := -euo pipefail -c
 MAKEFLAGS += --no-print-directory
 
-.PHONY: help ci ci-post full cd release-preflight ci-security lint test static-analysis drift frontend act pre-push clean
+.PHONY: help ci ci-post full cd release-preflight ci-security script-tests lint test static-analysis drift frontend act pre-push clean
 
 help:
 	@echo "parkhub-php local-first CI/CD"
@@ -37,6 +37,7 @@ help:
 	@echo "  make cd         — fop CD profile"
 	@echo "  make release-preflight — required release gate (CD profile)"
 	@echo "  make ci-security — strict local OSS security/workflow mirror"
+	@echo "  make script-tests — shell script contract tests"
 	@echo "  make lint       — pint --test (backend-quality)"
 	@echo "  make static-analysis — phpstan (static-analysis job)"
 	@echo "  make test       — full backend PHPUnit suite (backend-tests)"
@@ -121,8 +122,13 @@ mutants:
 		echo "infection returned non-zero (advisory)."
 
 ci-security:
+	$(MAKE) script-tests
 	.github/scripts/fop-local-ci.sh --profile pr --dry-run >/dev/null
 	scripts/ci/local-security-audit.sh --profile cd --strict-tools --fail-advisory
+
+script-tests:
+	bash scripts/tests/test-drift-scripts.sh
+	bash scripts/tests/test-fop-local-ci-failure-trap.sh
 
 pre-push: ci
 

--- a/scripts/tests/test-fop-local-ci-failure-trap.sh
+++ b/scripts/tests/test-fop-local-ci-failure-trap.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Smoke test for .github/scripts/fop-local-ci.sh failure handling.
+#
+# The local CI script runs most checks through shell functions. Bash does not
+# inherit ERR traps into functions unless errtrace is enabled, so a failed
+# inner command can otherwise leave the GitHub fop/local-ci/pr status pending.
+#
+# Run: bash scripts/tests/test-fop-local-ci-failure-trap.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+sha="$(git rev-parse HEAD)"
+report=".fop/reports/local-ci-pr-${sha}.json"
+tmp_dir="$(mktemp -d)"
+gh_log="$tmp_dir/gh-statuses.log"
+report_backup=""
+
+cleanup() {
+    rm -rf "$tmp_dir"
+    if [[ -n "$report_backup" && -f "$report_backup" ]]; then
+        mkdir -p "$(dirname "$report")"
+        cp -p "$report_backup" "$report"
+        rm -f "$report_backup"
+    else
+        rm -f "$report"
+    fi
+}
+trap cleanup EXIT
+
+if [[ -f "$report" ]]; then
+    report_backup="$(mktemp)"
+    cp -p "$report" "$report_backup"
+fi
+
+cat > "$tmp_dir/composer" <<'STUB'
+#!/usr/bin/env bash
+echo "intentional composer failure for fop-local-ci ERR trap test" >&2
+exit 42
+STUB
+chmod +x "$tmp_dir/composer"
+
+cat > "$tmp_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_STATUS_LOG"
+printf '{}\n'
+STUB
+chmod +x "$tmp_dir/gh"
+
+red() { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+echo "==> fop-local-ci posts failure when a run_step command fails"
+set +e
+PATH="$tmp_dir:$PATH" \
+GH_STATUS_LOG="$gh_log" \
+FOP_LOCAL_CI_DIRECT=1 \
+FOP_LOCAL_CI_STATUS_REPO=nash87/parkhub-php \
+    .github/scripts/fop-local-ci.sh --profile pr --post-status >/tmp/parkhub-fop-local-ci-failure-trap.out 2>&1
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+    red "    FAILED: fop-local-ci returned 0 despite failing composer"
+    cat /tmp/parkhub-fop-local-ci-failure-trap.out
+    exit 1
+fi
+
+if [[ ! -f "$report" ]]; then
+    red "    FAILED: failure report was not written"
+    cat /tmp/parkhub-fop-local-ci-failure-trap.out
+    exit 1
+fi
+
+if ! grep -q '"state": "failure"' "$report"; then
+    red "    FAILED: failure report does not record failure state"
+    cat "$report"
+    exit 1
+fi
+
+if ! grep -q -- '-f state=failure' "$gh_log"; then
+    red "    FAILED: failure commit status was not posted"
+    cat "$gh_log"
+    exit 1
+fi
+
+green "    OK"


### PR DESCRIPTION
## Summary
- enable Bash errtrace so fop-local-ci failure handling runs for failures inside shell functions
- add a regression smoke test that stubs composer/gh and verifies a failure report plus fop/local-ci/pr=failure status
- wire shell script contract tests into make script-tests and ci-security

## Verification
- make script-tests
- git diff --check
- normal git push pre-push gate: local CI passed and posted deferred attestation

## Context
This was found while validating PR #444: the frontend build failed, but the fop/local-ci/pr status initially remained pending because the ERR trap was not inherited into run_step.