### PR TITLE
ci: widen diff-aware design-smoke gate regex

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -111,7 +111,10 @@ compute_design_smoke_gate() {
     return 0
   fi
 
-  if grep -qE '^(parkhub-web/(src/(design-v5|views|components|context|api|lib|styles)/|src/(App|main)\.tsx|package(-lock)?\.json|astro\.config\.mjs|playwright\.config\.ts)|resources/js/|e2e/|playwright\.config\.ts|package(-lock)?\.json)$' <<<"$diff_paths"; then
+  # `git diff --name-only` emits FILE paths (e.g. parkhub-web/src/design-v5/screens/Policies.tsx),
+  # so directory alternatives must allow a tail (`/.*`). Also include `hooks/` since v5 screens
+  # import shared hooks like useDraftFromActive — edits there can break the gate.
+  if grep -qE '^(parkhub-web/(src/(design-v5|views|components|context|api|lib|styles|hooks)/.*|src/(App|main)\.tsx|package(-lock)?\.json|astro\.config\.mjs|playwright\.config\.ts)|resources/js/.*|e2e/.*|playwright\.config\.ts|package(-lock)?\.json)$' <<<"$diff_paths"; then
     diff_touch_design_smoke=1
   fi
 


### PR DESCRIPTION
## Summary
- widen the diff-aware design-smoke gate to match the actual ParkHub frontend paths
- include design-v5/views/components/context/api/lib/styles/hooks, resources/js, e2e, App.tsx, and package-lock.json
- keeps unrelated docs-only changes out of the expensive design-smoke path

## Verification
- make ci
- bash -n .github/scripts/fop-local-ci.sh
- .github/scripts/fop-local-ci.sh --profile pr --dry-run
- git diff --check github/main..HEAD
- regex probe: matches design-v5 screen, shared hook, resources/js view, e2e spec, App.tsx, package-lock.json; does not match docs/readme.md

Local CI report: .fop/reports/local-ci-pr-aaaca4755ba9ea03610c112fc210e2de43a3eaf7.json