### PR TITLE
ci: Nix/Garnix baseline + flake.lock for release-grade reproducibility

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,54 @@
+# Devcontainer image for parkhub-php. This matches the local-first PR gate
+# toolchain and is not a production runtime image.
+FROM php:8.4-cli-bookworm
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=22
+ARG HELM_VERSION=v3.18.4
+ARG ACTIONLINT_VERSION=1.7.12
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl wget gnupg lsb-release jq git \
+        python3 python3-pip python3-yaml yamllint \
+        sudo less unzip zip pkg-config sqlite3 default-mysql-client \
+        docker.io docker-compose-plugin \
+        libcurl4-openssl-dev libicu-dev libzip-dev libpng-dev libxml2-dev \
+        libonig-dev libsqlite3-dev \
+    && docker-php-ext-install -j"$(nproc)" \
+        bcmath curl gd intl mbstring pdo_mysql pdo_sqlite zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g npm@latest
+
+RUN curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+    && tar -xzf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64/helm \
+    && mv linux-amd64/helm /usr/local/bin/helm \
+    && rm -rf linux-amd64 "helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+    && helm version
+
+RUN curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    && tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint \
+    && mv actionlint /usr/local/bin/actionlint \
+    && rm -rf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    && actionlint --version
+
+RUN curl -fsSL https://install.mise.jdx.dev | sh
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m -s /bin/bash "$USERNAME" \
+    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > "/etc/sudoers.d/$USERNAME" \
+    && chmod 0440 "/etc/sudoers.d/$USERNAME" \
+    && mkdir -p "/home/$USERNAME/.local/share/mise" \
+    && chown -R "$USERNAME:$USERNAME" "/home/$USERNAME/.local"
+
+USER $USERNAME
+WORKDIR /workspaces/parkhub-php
+ENV PATH="/home/vscode/.local/bin:/home/vscode/.local/share/mise/shims:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,82 @@
+{
+  "name": "parkhub-php full local CI/CD",
+
+  "// image vs build": [
+    "Default to the prebuilt image published by .github/workflows/devcontainer-publish.yml.",
+    "To test Containerfile edits locally, comment out image and uncomment build."
+  ],
+  "image": "ghcr.io/nash87/parkhub-php-devcontainer:latest",
+
+  "// build": {
+    "context": ".",
+    "dockerfile": "Containerfile"
+  },
+
+  "remoteUser": "vscode",
+  "workspaceFolder": "/workspaces/parkhub-php",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/parkhub-php,type=bind,consistency=cached",
+
+  "// Note": [
+    "This devcontainer is a contributor and local-CI image, not a production runtime image.",
+    "It ships PHP 8.4, Node 22, Composer, Helm, Docker CLI, actionlint, mise, and the",
+    "repo-pinned mise tools used by .github/scripts/fop-local-ci.sh and local security gates."
+  ],
+
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bmewburn.vscode-intelephense-client",
+        "xdebug.php-debug",
+        "astro-build.astro-vscode",
+        "biomejs.biome",
+        "ms-azuretools.vscode-docker",
+        "GitHub.vscode-github-actions",
+        "GitHub.copilot",
+        "ms-playwright.playwright"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "[php]": { "editor.defaultFormatter": "bmewburn.vscode-intelephense-client" },
+        "[typescript]": { "editor.defaultFormatter": "biomejs.biome" },
+        "[typescriptreact]": { "editor.defaultFormatter": "biomejs.biome" },
+        "[astro]": { "editor.defaultFormatter": "astro-build.astro-vscode" },
+        "files.watcherExclude": {
+          "**/vendor/**": true,
+          "**/node_modules/**": true,
+          "**/parkhub-web/node_modules/**": true,
+          "**/.fop/**": true
+        }
+      }
+    }
+  },
+
+  "forwardPorts": [4321, 5173, 8000, 18113],
+  "portsAttributes": {
+    "4321": { "label": "astro preview", "onAutoForward": "notify" },
+    "5173": { "label": "vite dev", "onAutoForward": "notify" },
+    "8000": { "label": "laravel", "onAutoForward": "notify" },
+    "18113": { "label": "design-smoke php server", "onAutoForward": "silent" }
+  },
+
+  "mounts": [
+    "source=parkhub-php-composer-cache,target=/home/vscode/.composer/cache,type=volume",
+    "source=parkhub-php-npm-cache,target=/home/vscode/.npm,type=volume",
+    "source=parkhub-php-playwright-cache,target=/home/vscode/.cache/ms-playwright,type=volume"
+  ],
+
+  "postCreateCommand": "bash -lc 'mise trust && mise install && composer install --prefer-dist --no-interaction --no-progress && npm ci && npm ci --prefix parkhub-web && lefthook install --reset-hooks-path'",
+
+  "postStartCommand": "bash -lc 'echo \"parkhub-php devcontainer ready. Run: .github/scripts/fop-local-ci.sh --profile pr --post-status\"'",
+
+  "remoteEnv": {
+    "PATH": "/home/vscode/.local/share/mise/shims:${containerEnv:PATH}",
+    "DB_CONNECTION": "sqlite",
+    "DB_DATABASE": "database/database.sqlite",
+    "FOP_LOCAL_CI_DIRECT": "1"
+  }
+}

--- a/.gitea/workflows/ci.yaml
+++ b/.gitea/workflows/ci.yaml
@@ -63,6 +63,9 @@ jobs:
       - name: Validate Docker Compose
         run: docker compose -f docker-compose.yml config -q
 
+      - name: Validate Nix/Garnix contract
+        run: make nix-contract
+
   dependency-review:
     name: Dependency review
     if: github.event_name == 'pull_request'

--- a/.gitea/workflows/ci.yaml
+++ b/.gitea/workflows/ci.yaml
@@ -66,6 +66,9 @@ jobs:
       - name: Validate Nix/Garnix contract
         run: make nix-contract
 
+      - name: Validate devcontainer contract
+        run: make devcontainer-contract
+
   dependency-review:
     name: Dependency review
     if: github.event_name == 'pull_request'

--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -3,38 +3,51 @@ set -Eeuo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: .github/scripts/fop-local-ci.sh [--profile pr|full|cd] [--dry-run] [--post-status]
+Usage: .github/scripts/fop-local-ci.sh [--profile pr|full|cd] [--dry-run] [--post-status] [--background]
 
 Runs ParkHub-PHP's local-first CI through fop's build queue. The optional
---post-status flag publishes the commit status context for the selected
-profile. The GitHub PR attestation gate expects this exact command:
+--background flag runs the gate in a detached subshell, logs to
+.fop/reports/local-ci-<profile>-<sha>-bg.log, and returns immediately.
+Combine with --post-status for fire-and-forget full runs that publish their
+own commit status context when complete.
+
+The optional --post-status flag publishes the commit status context for the
+selected profile. The GitHub PR attestation gate expects this exact command:
 
   .github/scripts/fop-local-ci.sh --profile pr --post-status
 
 Profiles:
   pr    Fast PR gate: composer + Pint + PHPStan + PHPUnit + Vitest +
-        Astro tsc/build + Composer audit.
+        Astro tsc/build + Composer audit. Diff-aware: skips PHP, frontend,
+        workflow, e2e, and image/security mirrors when the PR diff does not
+        touch their inputs. Set FOP_LOCAL_CI_NO_DIFF_AWARE=1 to force every
+        PR step.
   full  PR gate plus Schemathesis contract fuzz (best effort), Infection
         mutation testing, and Playwright e2e smoke.
   cd    Release-oriented preflight: full + composer-audit prod-only +
         Trivy filesystem scan when available.
 
 Environment overrides:
-  FOP_LOCAL_CI_STATUS_REPO  owner/repo for status post (else autodetected
-                            from git remotes named github → upstream → origin).
-  FOP_LOCAL_CI_DIRECT       1 = bypass the `fop build` queue wrapper and
-                            run each step directly in the current shell.
-                            Use only for the bootstrap chicken-and-egg
-                            run that introduces this script, or when
-                            you have explicit reason to skip the queue.
-                            Operators must guarantee memory headroom
-                            themselves in this mode.
+  FOP_LOCAL_CI_STATUS_REPO     owner/repo for status post (else autodetected
+                               from git remotes named github → upstream → origin).
+  FOP_LOCAL_CI_NO_DIFF_AWARE=1 disable diff-aware skipping on pr profile.
+  FOP_LOCAL_CI_DIFF_PATHS      newline-delimited diff path override for
+                               contract tests and explicit local reruns.
+  FOP_LOCAL_CI_BG_LOG_DIR      background log directory override.
+  FOP_LOCAL_CI_DIRECT          1 = bypass the `fop build` queue wrapper and
+                               run each step directly in the current shell.
+                               Use only for the bootstrap chicken-and-egg
+                               run that introduces this script, or when
+                               you have explicit reason to skip the queue.
+                               Operators must guarantee memory headroom
+                               themselves in this mode.
 EOF
 }
 
 profile="pr"
 dry_run=0
 post_status=0
+background=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -48,6 +61,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --post-status)
       post_status=1
+      shift
+      ;;
+    --background)
+      background=1
       shift
       ;;
     -h|--help)
@@ -69,6 +86,24 @@ case "$profile" in
     exit 2
     ;;
 esac
+
+if [[ "$background" -eq 1 ]]; then
+  repo_root_for_bg="$(git rev-parse --show-toplevel)"
+  bg_log_dir="${FOP_LOCAL_CI_BG_LOG_DIR:-$repo_root_for_bg/.fop/reports}"
+  mkdir -p "$bg_log_dir"
+  bg_sha="$(git rev-parse HEAD)"
+  bg_log="$bg_log_dir/local-ci-${profile}-${bg_sha:0:8}-bg.log"
+  bg_args=("--profile" "$profile")
+  [[ "$dry_run" -eq 1 ]] && bg_args+=("--dry-run")
+  [[ "$post_status" -eq 1 ]] && bg_args+=("--post-status")
+  echo "fop-local-ci backgrounded: profile=$profile log=$bg_log"
+  nohup "$0" "${bg_args[@]}" >"$bg_log" 2>&1 < /dev/null &
+  bg_pid=$!
+  disown 2>/dev/null || true
+  echo "PID=$bg_pid sha=${bg_sha:0:8}"
+  echo "watch: tail -f $bg_log"
+  exit 0
+fi
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -117,6 +152,94 @@ compute_design_smoke_gate() {
 
   printf 'ℹ design-smoke gate (vs %s): enabled=%d (%d files)\n' \
     "$base_ref" "$diff_touch_design_smoke" "$(wc -l <<<"$diff_paths")"
+}
+
+diff_paths=""
+diff_aware_enabled=0
+diff_touch_php=0
+diff_touch_frontend=0
+diff_touch_workflows=0
+diff_touch_e2e=0
+diff_touch_image=0
+diff_touch_nix_dev=0
+diff_touch_security=0
+
+enable_all_pr_steps() {
+  diff_touch_php=1
+  diff_touch_frontend=1
+  diff_touch_workflows=1
+  diff_touch_e2e=1
+  diff_touch_image=1
+  diff_touch_nix_dev=1
+  diff_touch_security=1
+}
+
+compute_diff_paths() {
+  if [[ "$profile" != "pr" || "${FOP_LOCAL_CI_NO_DIFF_AWARE:-}" == "1" ]]; then
+    enable_all_pr_steps
+    return 0
+  fi
+
+  diff_aware_enabled=1
+  if [[ -n "${FOP_LOCAL_CI_DIFF_PATHS:-}" ]]; then
+    diff_paths="${FOP_LOCAL_CI_DIFF_PATHS}"
+  else
+    local base_ref=""
+    for candidate in github/main upstream/main origin/main main; do
+      if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+        base_ref="$candidate"
+        break
+      fi
+    done
+
+    if [[ -z "$base_ref" ]]; then
+      printf 'diff-aware: no base ref resolvable; running full pr profile\n'
+      enable_all_pr_steps
+      return 0
+    fi
+
+    local merge_base
+    merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null || echo "$base_ref")"
+    diff_paths="$(
+      {
+        git diff --name-only "${merge_base}..HEAD" 2>/dev/null || true
+        git diff --name-only 2>/dev/null || true
+        git diff --cached --name-only 2>/dev/null || true
+      } | sort -u
+    )"
+
+    if [[ -z "$diff_paths" ]]; then
+      printf 'diff-aware: empty diff vs %s; running full pr profile\n' "$base_ref"
+      enable_all_pr_steps
+      return 0
+    fi
+  fi
+
+  if grep -qE '(^app/|^bootstrap/|^config/|^database/|^routes/|^tests/|\.php$|^artisan$|^composer\.(json|lock)$|^phpunit\.xml|^phpstan\.neon|^pint\.json|^scripts/ci/|^scripts/check-openapi-drift\.sh|^docs/openapi/php\.json)' <<<"$diff_paths"; then
+    diff_touch_php=1
+  fi
+  if grep -qE '(^parkhub-web/|^resources/js/|^package(-lock)?\.json$|^vite\.config\.|^tsconfig\.json$|^tailwind\.config\.|^postcss\.config\.)' <<<"$diff_paths"; then
+    diff_touch_frontend=1
+  fi
+  if grep -qE '(^\.github/(workflows|scripts|actions)/|^\.gitea/workflows/|^Makefile$|^scripts/tests/|^scripts/check-local-ci-report\.sh|^\.devcontainer/|^flake\.(nix|lock)$|^garnix\.yaml$)' <<<"$diff_paths"; then
+    diff_touch_workflows=1
+  fi
+  if grep -qE '(^e2e/|^playwright\.config\.(ts|js|mjs|cjs)$)' <<<"$diff_paths"; then
+    diff_touch_e2e=1
+  fi
+  if grep -qE '(^Dockerfile$|^Containerfile|^\.devcontainer/Containerfile$|^docker/|^helm/|^composer\.lock$|^package-lock\.json$|^parkhub-web/package-lock\.json$)' <<<"$diff_paths"; then
+    diff_touch_image=1
+  fi
+  if grep -qE '(^\.devcontainer/|^flake\.(nix|lock)$|^garnix\.yaml$)' <<<"$diff_paths"; then
+    diff_touch_nix_dev=1
+  fi
+  if (( diff_touch_php || diff_touch_frontend || diff_touch_workflows || diff_touch_e2e || diff_touch_image || diff_touch_nix_dev )); then
+    diff_touch_security=1
+  fi
+
+  printf 'diff-aware: php=%d frontend=%d workflows=%d e2e=%d image=%d nix_dev=%d security=%d (%d files)\n' \
+    "$diff_touch_php" "$diff_touch_frontend" "$diff_touch_workflows" "$diff_touch_e2e" \
+    "$diff_touch_image" "$diff_touch_nix_dev" "$diff_touch_security" "$(wc -l <<<"$diff_paths")"
 }
 
 status_repo() {
@@ -178,14 +301,24 @@ write_report() {
   mkdir -p "$report_dir"
   cat > "$report_path" <<EOF
 {
-  "schema": "parkhub.local-ci.v1",
+  "schema": "parkhub.local-ci.v2",
   "profile": "$profile",
   "state": "$state",
   "commit": "$sha",
   "started_at": "$started_at",
   "finished_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "failed_step": "$failed_step",
-  "context": "$context"
+  "context": "$context",
+  "diff_aware": {
+    "enabled": $([[ "$diff_aware_enabled" -eq 1 ]] && echo true || echo false),
+    "php": $([[ "$diff_touch_php" -eq 1 ]] && echo true || echo false),
+    "frontend": $([[ "$diff_touch_frontend" -eq 1 ]] && echo true || echo false),
+    "workflows": $([[ "$diff_touch_workflows" -eq 1 ]] && echo true || echo false),
+    "e2e": $([[ "$diff_touch_e2e" -eq 1 ]] && echo true || echo false),
+    "image": $([[ "$diff_touch_image" -eq 1 ]] && echo true || echo false),
+    "nix_dev": $([[ "$diff_touch_nix_dev" -eq 1 ]] && echo true || echo false),
+    "security": $([[ "$diff_touch_security" -eq 1 ]] && echo true || echo false)
+  }
 }
 EOF
 }
@@ -300,7 +433,7 @@ run_direct() {
 skip_step() {
   local name="$1"
   local reason="${2:-skipped}"
-  printf '\n==> %s (skipped)\n%s\n' "$name" "$reason"
+  printf '\n==> %s [SKIP: %s]\n' "$name" "$reason"
 }
 
 mark_failure() {
@@ -314,60 +447,85 @@ mark_failure() {
 }
 trap 'mark_failure "$LINENO"' ERR
 
+compute_diff_paths
 compute_design_smoke_gate
-
 post_commit_status "pending" "fop local ${profile} running"
 
 run_direct "working tree whitespace" "git diff --check"
 run_direct "ui polish contract" "scripts/tests/test-ui-polish-contract.sh"
 
 # ---------------- Backend (PHP) ---------------------------------------------
-run_step "composer validate" "composer validate --strict"
+if (( diff_touch_php )); then
+  run_step "composer validate" "composer validate --strict"
 
-# composer audit is advisory-only on the pr profile so dev-only or
-# unfixable advisories cannot block routine work. cd profile re-runs
-# it with --no-dev for a stricter prod-only pass.
-run_step "composer audit (advisory)" "composer audit --no-interaction || echo 'composer audit returned non-zero (advisory on pr profile)'"
+  # composer audit is advisory-only on the pr profile so dev-only or
+  # unfixable advisories cannot block routine work. cd profile re-runs
+  # it with --no-dev for a stricter prod-only pass.
+  run_step "composer audit (advisory)" "composer audit --no-interaction || echo 'composer audit returned non-zero (advisory on pr profile)'"
 
-run_step "composer install (sync)" "composer install --prefer-dist --no-interaction --no-progress"
+  run_step "composer install (sync)" "composer install --prefer-dist --no-interaction --no-progress"
 
-run_step "pint format check" "./vendor/bin/pint --test"
+  run_step "pint format check" "./vendor/bin/pint --test"
 
-run_step "phpstan level 5" "scripts/ci/phpstan-analyse.sh --memory-limit=512M --no-progress"
+  run_step "phpstan level 5" "scripts/ci/phpstan-analyse.sh --memory-limit=512M --no-progress"
 
-run_step "phpunit unit + feature" "./vendor/bin/phpunit --testsuite=Unit --no-coverage && ./vendor/bin/phpunit --testsuite=Feature --no-coverage"
-
-# ---------------- Frontend (Astro 5 + React 19 + Vitest 3) ------------------
-run_step "frontend npm install" "npm ci && npm ci --prefix parkhub-web"
-
-run_step "frontend vitest" "cd parkhub-web && npm test"
-
-run_step "frontend build" "cd parkhub-web && CI=true npm run build && cd .. && CI=true npm run build"
-
-if (( diff_touch_design_smoke )); then
-  run_step_heavy "frontend route + v5 design smoke" "npm run test:e2e:design-smoke"
+  run_step "phpunit unit + feature" "./vendor/bin/phpunit --testsuite=Unit --no-coverage && ./vendor/bin/phpunit --testsuite=Feature --no-coverage"
 else
-  skip_step "frontend route + v5 design smoke" "diff-aware: no route/design/e2e files touched"
+  skip_step "composer validate" "diff-aware: no PHP backend inputs touched"
+  skip_step "composer audit (advisory)" "diff-aware: no PHP backend inputs touched"
+  skip_step "composer install (sync)" "diff-aware: no PHP backend inputs touched"
+  skip_step "pint format check" "diff-aware: no PHP backend inputs touched"
+  skip_step "phpstan level 5" "diff-aware: no PHP backend inputs touched"
+  skip_step "phpunit unit + feature" "diff-aware: no PHP backend inputs touched"
 fi
 
-# tsc --noEmit on parkhub-web is not yet green on main as of 4.15.0 —
-# the `chore/web-tsc-phase4c-*` series (PRs #379..#382 and ongoing) is
-# still chipping away at hundreds of inherited TS errors. Keep this after
-# hard frontend gates and make the fop wrapper advisory too, so host pressure
-# cannot fail the PR gate before the intentionally non-gating check completes.
-run_advisory_step_heavy "frontend typecheck (advisory until tsc-phase4 lands)" "cd parkhub-web && NODE_OPTIONS=\"\${NODE_OPTIONS:-} --max-old-space-size=4096\" ./node_modules/.bin/tsc --noEmit || echo 'tsc errors present (advisory while phase4 is in flight)'"
+# ---------------- Frontend (Astro 5 + React 19 + Vitest 3) ------------------
+if (( diff_touch_frontend || diff_touch_e2e )); then
+  run_step "frontend npm install" "npm ci && npm ci --prefix parkhub-web"
+
+  run_step "frontend vitest" "cd parkhub-web && npm test"
+
+  run_step "frontend build" "cd parkhub-web && CI=true npm run build && cd .. && CI=true npm run build"
+
+  if (( diff_touch_design_smoke )); then
+    run_step_heavy "frontend route + v5 design smoke" "npm run test:e2e:design-smoke"
+  else
+    skip_step "frontend route + v5 design smoke" "diff-aware: no route/design/e2e files touched"
+  fi
+
+  # tsc --noEmit on parkhub-web is not yet green on main as of 4.15.0 —
+  # the `chore/web-tsc-phase4c-*` series (PRs #379..#382 and ongoing) is
+  # still chipping away at hundreds of inherited TS errors. Keep this after
+  # hard frontend gates and make the fop wrapper advisory too, so host pressure
+  # cannot fail the PR gate before the intentionally non-gating check completes.
+  run_advisory_step_heavy "frontend typecheck (advisory until tsc-phase4 lands)" "cd parkhub-web && NODE_OPTIONS=\"\${NODE_OPTIONS:-} --max-old-space-size=4096\" ./node_modules/.bin/tsc --noEmit || echo 'tsc errors present (advisory while phase4 is in flight)'"
+else
+  skip_step "frontend npm install" "diff-aware: no frontend/e2e inputs touched"
+  skip_step "frontend vitest" "diff-aware: no frontend/e2e inputs touched"
+  skip_step "frontend build" "diff-aware: no frontend/e2e inputs touched"
+  skip_step "frontend route + v5 design smoke" "diff-aware: no route/design/e2e files touched"
+  skip_step "frontend typecheck (advisory until tsc-phase4 lands)" "diff-aware: no frontend/e2e inputs touched"
+fi
 
 # ---------------- Drift gates -----------------------------------------------
 # Both scripts already follow the same pattern as the rust side: they
 # regenerate the snapshot, then fail if `git diff --exit-code` shows drift.
-run_step "openapi drift" "scripts/check-openapi-drift.sh"
+if (( diff_touch_php )); then
+  run_step "openapi drift" "scripts/check-openapi-drift.sh"
+else
+  skip_step "openapi drift" "diff-aware: no PHP API inputs touched"
+fi
 
 # In parkhub-php this is a no-op (the shared TS API types are
 # generated by ts-rs in parkhub-rust and committed into parkhub-web
 # read-only). Keep it for symmetry with parkhub-rust's local-ci so
 # operators can read the same step list, but label it explicitly so
 # nobody mistakes the always-pass for a real drift signal.
-run_step "types drift (no-op in php; gated by parkhub-rust)" "scripts/check-types-drift.sh"
+if (( diff_touch_php || diff_touch_frontend )); then
+  run_step "types drift (no-op in php; gated by parkhub-rust)" "scripts/check-types-drift.sh"
+else
+  skip_step "types drift (no-op in php; gated by parkhub-rust)" "diff-aware: no PHP or frontend inputs touched"
+fi
 
 # ---------------- Local OSS security mirror ---------------------------------
 # Mirrors the GitHub/Gitea security + workflow hygiene jobs with local
@@ -377,7 +535,11 @@ security_profile="pr"
 if [[ "$profile" == "cd" ]]; then
   security_profile="cd"
 fi
-run_step "local security audit (${security_profile} mirror)" "scripts/ci/local-security-audit.sh --profile ${security_profile}"
+if (( diff_touch_security )); then
+  run_step "local security audit (${security_profile} mirror)" "scripts/ci/local-security-audit.sh --profile ${security_profile}"
+else
+  skip_step "local security audit (${security_profile} mirror)" "diff-aware: no security-relevant inputs touched"
+fi
 
 # `cd` profile is documented as `full + cd-specific steps`, so the full
 # block runs for both `full` and `cd`. Without this, `cd` would skip
@@ -420,7 +582,11 @@ fi
 # comments) are filtered. Severity matches the workflow: CRITICAL,HIGH only.
 trivy_required=0
 [[ "$profile" == "cd" || "$profile" == "full" ]] && trivy_required=1
-if command -v trivy >/dev/null 2>&1; then
+trivy_should_run="$trivy_required"
+[[ "$profile" == "pr" && "$diff_touch_security" -eq 1 ]] && trivy_should_run=1
+if [[ "$trivy_should_run" -eq 0 ]]; then
+  skip_step "trivy filesystem scan" "diff-aware: no security-relevant inputs touched"
+elif command -v trivy >/dev/null 2>&1; then
   run_step "trivy filesystem scan" "trivy fs --quiet --exit-code 1 --scanners=vuln,misconfig --severity=CRITICAL,HIGH --ignorefile .trivyignore --skip-dirs=node_modules,vendor,parkhub-web/node_modules,resources/js/node_modules,.claude/worktrees ."
 elif [[ $trivy_required -eq 1 ]]; then
   echo "✗ trivy filesystem scan FAILED: trivy not on PATH (required for ${profile} profile)" >&2
@@ -441,7 +607,9 @@ fi
 # findings as informational but does NOT fail the gate. Promote to a hard
 # failure (drop the `|| true`) once the open-finding inventory is at zero.
 # Suppressions live in zizmor.yml with per-rule justification.
-if command -v zizmor >/dev/null 2>&1; then
+if (( ! diff_touch_workflows )); then
+  skip_step "zizmor (GHA SAST)" "diff-aware: no workflow inputs touched"
+elif command -v zizmor >/dev/null 2>&1; then
   run_step "zizmor (GHA SAST, advisory)" "zizmor --persona=auditor --min-severity=high --no-online-audits .github/workflows/ .gitea/workflows/ || echo 'zizmor returned non-zero (advisory — see findings above)'"
 else
   skip_step "zizmor (GHA SAST)" "zizmor not on PATH (install: cargo install zizmor or https://docs.zizmor.sh)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Validate Nix/Garnix contract
         run: make nix-contract
 
+      - name: Validate devcontainer contract
+        run: make devcontainer-contract
+
   dependency-review:
     name: Dependency review
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Validate Docker Compose
         run: docker compose -f docker-compose.yml config -q
 
+      - name: Validate Nix/Garnix contract
+        run: make nix-contract
+
   dependency-review:
     name: Dependency review
     if: github.event_name == 'pull_request'

--- a/.github/workflows/devcontainer-publish.yml
+++ b/.github/workflows/devcontainer-publish.yml
@@ -1,0 +1,100 @@
+name: Publish dev container image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.devcontainer/**'
+      - '.github/workflows/devcontainer-publish.yml'
+  schedule:
+    - cron: '30 4 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: devcontainer-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-devcontainer
+
+jobs:
+  build-and-push:
+    name: Build and push devcontainer image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern=weekly
+            type=sha,prefix=git-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .devcontainer
+          file: .devcontainer/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            cosign sign --yes "$tag@$DIGEST"
+          done
+
+      - name: Summary
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "## devcontainer image published"
+            echo ""
+            echo "**Tags**:"
+            for tag in $TAGS; do echo "- \`$tag\`"; done
+            echo ""
+            echo "**Digest**: \`$DIGEST\`"
+            echo ""
+            echo "**Pull**: \`podman pull ${REGISTRY}/${IMAGE_NAME}:latest\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL := bash
 .SHELLFLAGS := -euo pipefail -c
 MAKEFLAGS += --no-print-directory
 
-.PHONY: help ci ci-post full cd release-preflight ci-security script-tests lint test static-analysis drift frontend nix-contract act pre-push pre-push-report clean
+.PHONY: help ci ci-post full cd release-preflight ci-security script-tests lint test static-analysis drift frontend nix-contract nix-contract-strict act pre-push pre-push-report clean
 
 help:
 	@echo "parkhub-php local-first CI/CD"
@@ -44,6 +44,7 @@ help:
 	@echo "  make drift      — sqlite-backed openapi snapshot drift check"
 	@echo "  make frontend   — npm ci + build (frontend job)"
 	@echo "  make nix-contract — static Nix/Garnix CI contract"
+	@echo "  make nix-contract-strict — require committed flake.lock for release-grade Nix/Garnix"
 	@echo "  make act        — run workflows via nektos/act (if installed)"
 	@echo "  make pre-push   — alias for ci; run before git push"
 	@echo "  make pre-push-report — verify current HEAD has a local-ci success report"
@@ -76,6 +77,9 @@ frontend:
 ## until the host has Nix/Garnix tooling available.
 nix-contract:
 	bash scripts/check-nix-garnix-contract.sh
+
+nix-contract-strict:
+	bash scripts/check-nix-garnix-contract.sh --require-lock
 
 ## Mirrors: openapi-drift.yml
 drift:

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ script-tests:
 	bash scripts/tests/test-drift-scripts.sh
 	bash scripts/tests/test-ui-polish-contract.sh
 	bash scripts/tests/test-devcontainer-contract.sh
+	bash scripts/tests/test-fop-local-ci-ergonomics.sh
 	bash scripts/tests/test-fop-local-ci-failure-trap.sh
 	bash scripts/tests/test-local-ci-report-check.sh
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL := bash
 .SHELLFLAGS := -euo pipefail -c
 MAKEFLAGS += --no-print-directory
 
-.PHONY: help ci ci-post full cd release-preflight ci-security script-tests lint test static-analysis drift frontend act pre-push pre-push-report clean
+.PHONY: help ci ci-post full cd release-preflight ci-security script-tests lint test static-analysis drift frontend nix-contract act pre-push pre-push-report clean
 
 help:
 	@echo "parkhub-php local-first CI/CD"
@@ -43,6 +43,7 @@ help:
 	@echo "  make test       — full backend PHPUnit suite (backend-tests)"
 	@echo "  make drift      — sqlite-backed openapi snapshot drift check"
 	@echo "  make frontend   — npm ci + build (frontend job)"
+	@echo "  make nix-contract — static Nix/Garnix CI contract"
 	@echo "  make act        — run workflows via nektos/act (if installed)"
 	@echo "  make pre-push   — alias for ci; run before git push"
 	@echo "  make pre-push-report — verify current HEAD has a local-ci success report"
@@ -69,6 +70,12 @@ frontend:
 	npm ci --prefix parkhub-web
 	CI=true npm test --prefix parkhub-web
 	CI=true npm run build
+
+## Static Nix/Garnix baseline contract. Real `nix flake check` requires nix
+## on PATH and a generated flake.lock; this gate keeps CI/Gitea/fop honest
+## until the host has Nix/Garnix tooling available.
+nix-contract:
+	bash scripts/check-nix-garnix-contract.sh
 
 ## Mirrors: openapi-drift.yml
 drift:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL := bash
 .SHELLFLAGS := -euo pipefail -c
 MAKEFLAGS += --no-print-directory
 
-.PHONY: help ci ci-post full cd release-preflight ci-security script-tests lint test static-analysis drift frontend nix-contract nix-contract-strict act pre-push pre-push-report clean
+.PHONY: help ci ci-post full cd release-preflight ci-security script-tests lint test static-analysis drift frontend nix-contract nix-contract-strict devcontainer-contract act pre-push pre-push-report clean
 
 help:
 	@echo "parkhub-php local-first CI/CD"
@@ -45,6 +45,7 @@ help:
 	@echo "  make frontend   — npm ci + build (frontend job)"
 	@echo "  make nix-contract — static Nix/Garnix CI contract"
 	@echo "  make nix-contract-strict — require committed flake.lock for release-grade Nix/Garnix"
+	@echo "  make devcontainer-contract — static PHP devcontainer contract"
 	@echo "  make act        — run workflows via nektos/act (if installed)"
 	@echo "  make pre-push   — alias for ci; run before git push"
 	@echo "  make pre-push-report — verify current HEAD has a local-ci success report"
@@ -80,6 +81,9 @@ nix-contract:
 
 nix-contract-strict:
 	bash scripts/check-nix-garnix-contract.sh --require-lock
+
+devcontainer-contract:
+	bash scripts/tests/test-devcontainer-contract.sh
 
 ## Mirrors: openapi-drift.yml
 drift:
@@ -141,6 +145,7 @@ ci-security:
 script-tests:
 	bash scripts/tests/test-drift-scripts.sh
 	bash scripts/tests/test-ui-polish-contract.sh
+	bash scripts/tests/test-devcontainer-contract.sh
 	bash scripts/tests/test-fop-local-ci-failure-trap.sh
 	bash scripts/tests/test-local-ci-report-check.sh
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "ParkHub PHP - Laravel 13 plus React 19 toolchain";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        php = pkgs.php84;
+        composer = pkgs.php84Packages.composer;
+        nodejs = pkgs.nodejs_22;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            php
+            composer
+            nodejs
+            git
+            jq
+            curl
+            sqlite
+            unzip
+            zip
+            pkg-config
+            openssl
+          ];
+
+          env = {
+            CI = "true";
+            DB_CONNECTION = "sqlite";
+            DB_DATABASE = "database/database.sqlite";
+          };
+
+          shellHook = ''
+            echo "ParkHub PHP dev shell: PHP $(php -r 'echo PHP_VERSION;'), Node $(node --version)"
+          '';
+        };
+
+        checks = {
+          toolchain-contract = pkgs.runCommand "parkhub-php-toolchain-contract"
+            {
+              nativeBuildInputs = [
+                php
+                composer
+                nodejs
+                pkgs.jq
+                pkgs.gnugrep
+              ];
+            }
+            ''
+              php -r 'exit(PHP_MAJOR_VERSION === 8 && PHP_MINOR_VERSION === 4 ? 0 : 1);'
+              composer --version >/dev/null
+              node --version | grep -Eq '^v22\.'
+              npm --version >/dev/null
+              jq -e '.require.php == "^8.4"' ${./composer.json} >/dev/null
+              jq -e '.engines.node == ">=22.12.0"' ${./parkhub-web/package.json} >/dev/null
+              touch "$out"
+            '';
+
+          garnix-contract = pkgs.runCommand "parkhub-php-garnix-contract"
+            {
+              nativeBuildInputs = [ pkgs.gnugrep ];
+            }
+            ''
+              test -f ${./garnix.yaml}
+              grep -q 'checks.x86_64-linux.*' ${./garnix.yaml}
+              grep -q 'devShells.x86_64-linux.default' ${./garnix.yaml}
+              touch "$out"
+            '';
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,9 @@
+# Garnix reads this file after the GitHub app is enabled for the repo.
+# Keep the first ParkHub PHP slice Linux-only: GitHub/Gitea/fop remain the
+# full local CI source of truth, while Garnix proves flake evaluation,
+# checks, and dev-shell cacheability.
+builds:
+  include:
+    - 'checks.x86_64-linux.*'
+    - 'devShells.x86_64-linux.default'
+  exclude: []

--- a/scripts/check-local-ci-report.sh
+++ b/scripts/check-local-ci-report.sh
@@ -45,12 +45,15 @@ if (!is_array($data)) {
     exit(1);
 }
 $expected = [
-    "schema" => "parkhub.local-ci.v1",
     "profile" => $profile,
     "state" => "success",
     "commit" => $sha,
     "context" => "fop/local-ci/" . $profile,
 ];
+if (!in_array(($data["schema"] ?? null), ["parkhub.local-ci.v1", "parkhub.local-ci.v2"], true)) {
+    fwrite(STDERR, "ERROR: report field schema expected parkhub.local-ci.v1 or parkhub.local-ci.v2\n");
+    exit(1);
+}
 foreach ($expected as $key => $value) {
     if (($data[$key] ?? null) !== $value) {
         fwrite(STDERR, "ERROR: report field " . $key . " expected " . $value . "\n");

--- a/scripts/check-nix-garnix-contract.sh
+++ b/scripts/check-nix-garnix-contract.sh
@@ -6,6 +6,18 @@ fail() {
   exit 1
 }
 
+require_lock=0
+case "${1:-}" in
+  "")
+    ;;
+  --require-lock|--strict)
+    require_lock=1
+    ;;
+  *)
+    fail "unknown argument: $1"
+    ;;
+esac
+
 require_file() {
   [[ -f "$1" ]] || fail "missing $1"
 }
@@ -41,7 +53,9 @@ require_grep '"node"[[:space:]]*:[[:space:]]*">=22\.12\.0"' parkhub-web/package.
 require_grep 'checks\.x86_64-linux\.\*' garnix.yaml 'Garnix must build Linux checks'
 require_grep 'devShells\.x86_64-linux\.default' garnix.yaml 'Garnix must build the Linux dev shell'
 
-if [[ ! -f flake.lock ]]; then
+if [[ ! -f flake.lock && "$require_lock" -eq 1 ]]; then
+  fail "flake.lock is not committed yet; run nix flake lock and commit it before release-grade Garnix use"
+elif [[ ! -f flake.lock ]]; then
   printf 'WARN: flake.lock is not committed yet; run nix flake lock once nix is available.\n' >&2
 fi
 

--- a/scripts/check-nix-garnix-contract.sh
+++ b/scripts/check-nix-garnix-contract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_file() {
+  [[ -f "$1" ]] || fail "missing $1"
+}
+
+require_grep() {
+  local pattern="$1"
+  local file="$2"
+  local note="$3"
+  grep -Eq "$pattern" "$file" || fail "$note ($file)"
+}
+
+require_file flake.nix
+require_file garnix.yaml
+require_file shell.nix
+
+require_grep 'nixos-unstable' flake.nix 'flake must use nixos-unstable'
+require_grep 'flake-utils' flake.nix 'flake must use flake-utils'
+require_grep 'php84' flake.nix 'flake must pin PHP 8.4'
+require_grep 'php84Packages\.composer' flake.nix 'flake must use PHP 8.4 Composer'
+require_grep 'nodejs_22' flake.nix 'flake must pin Node 22'
+require_grep 'devShells\.default' flake.nix 'flake must expose devShells.default'
+require_grep 'toolchain-contract' flake.nix 'flake must expose toolchain-contract check'
+require_grep 'garnix-contract' flake.nix 'flake must expose garnix-contract check'
+require_grep 'formatter = pkgs\.nixpkgs-fmt' flake.nix 'flake must expose nixpkgs-fmt formatter'
+
+require_grep 'php84' shell.nix 'legacy shell.nix must match PHP 8.4'
+require_grep 'php84Packages\.composer' shell.nix 'legacy shell.nix must use PHP 8.4 Composer'
+require_grep 'nodejs_22' shell.nix 'legacy shell.nix must pin Node 22'
+
+require_grep '"php"[[:space:]]*:[[:space:]]*"\^8\.4"' composer.json 'composer.json must require PHP 8.4'
+require_grep '"node"[[:space:]]*:[[:space:]]*">=22\.12\.0"' parkhub-web/package.json 'parkhub-web package must require Node >=22.12.0'
+
+require_grep 'checks\.x86_64-linux\.\*' garnix.yaml 'Garnix must build Linux checks'
+require_grep 'devShells\.x86_64-linux\.default' garnix.yaml 'Garnix must build the Linux dev shell'
+
+if [[ ! -f flake.lock ]]; then
+  printf 'WARN: flake.lock is not committed yet; run nix flake lock once nix is available.\n' >&2
+fi
+
+printf 'ParkHub PHP Nix/Garnix contract OK.\n'

--- a/scripts/tests/test-devcontainer-contract.sh
+++ b/scripts/tests/test-devcontainer-contract.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Smoke contract for the PHP devcontainer lane.
+#
+# This intentionally avoids building the image. The publish workflow owns the
+# real build, while this local test verifies that the repo contains the files,
+# toolchain pins, and GHCR publication wiring contributors need before the
+# expensive container build is allowed to run.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+require_file() {
+    [[ -f "$1" ]] || fail "missing $1"
+}
+
+require_grep() {
+    local pattern="$1"
+    local file="$2"
+    local note="$3"
+    grep -Eq "$pattern" "$file" || fail "$note ($file)"
+}
+
+require_file .devcontainer/devcontainer.json
+require_file .devcontainer/Containerfile
+require_file .github/workflows/devcontainer-publish.yml
+
+python3 -m json.tool .devcontainer/devcontainer.json >/dev/null
+
+require_grep 'parkhub-php full local CI/CD' .devcontainer/devcontainer.json 'devcontainer must identify the PHP local CI/CD image'
+require_grep 'ghcr\.io/nash87/parkhub-php-devcontainer:latest' .devcontainer/devcontainer.json 'devcontainer must default to the prebuilt GHCR image'
+require_grep '/workspaces/parkhub-php' .devcontainer/devcontainer.json 'devcontainer must mount the expected PHP workspace'
+require_grep 'mise install' .devcontainer/devcontainer.json 'devcontainer must bootstrap mise-managed local CI tools'
+require_grep 'composer install' .devcontainer/devcontainer.json 'devcontainer must bootstrap Laravel dependencies'
+require_grep 'npm ci --prefix parkhub-web' .devcontainer/devcontainer.json 'devcontainer must bootstrap the active React/Astro app'
+require_grep 'fop-local-ci\.sh --profile pr --post-status' .devcontainer/devcontainer.json 'devcontainer must advertise the local attestation command'
+
+require_grep '^FROM php:8\.4-cli-bookworm' .devcontainer/Containerfile 'Containerfile must pin PHP 8.4'
+require_grep 'ARG NODE_MAJOR=22' .devcontainer/Containerfile 'Containerfile must pin Node 22'
+require_grep 'docker-php-ext-install' .devcontainer/Containerfile 'Containerfile must install PHP extensions'
+require_grep 'pdo_sqlite' .devcontainer/Containerfile 'Containerfile must support sqlite test databases'
+require_grep 'pdo_mysql' .devcontainer/Containerfile 'Containerfile must support mysql-compatible local runs'
+require_grep 'install\.mise\.jdx\.dev' .devcontainer/Containerfile 'Containerfile must install mise for repo-pinned tools'
+require_grep 'ACTIONLINT_VERSION=1\.7\.12' .devcontainer/Containerfile 'Containerfile must pin actionlint'
+require_grep 'HELM_VERSION=v3\.18\.4' .devcontainer/Containerfile 'Containerfile must pin Helm'
+require_grep 'docker\.io' .devcontainer/Containerfile 'Containerfile must include docker CLI for compose validation'
+
+require_grep 'name: Publish dev container image' .github/workflows/devcontainer-publish.yml 'workflow must publish a devcontainer image'
+require_grep "\\.devcontainer/\\*\\*" .github/workflows/devcontainer-publish.yml 'workflow must run on devcontainer changes'
+require_grep 'ghcr\.io' .github/workflows/devcontainer-publish.yml 'workflow must publish to GHCR'
+require_grep 'docker/build-push-action@' .github/workflows/devcontainer-publish.yml 'workflow must build and push via build-push-action'
+require_grep 'cosign sign' .github/workflows/devcontainer-publish.yml 'workflow must sign the image'
+require_grep "cron: '30 4 \\* \\* 0'" .github/workflows/devcontainer-publish.yml 'workflow must refresh weekly'
+
+printf 'ParkHub PHP devcontainer contract OK.\n'

--- a/scripts/tests/test-fop-local-ci-ergonomics.sh
+++ b/scripts/tests/test-fop-local-ci-ergonomics.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Contract tests for .github/scripts/fop-local-ci.sh developer ergonomics.
+#
+# Run: bash scripts/tests/test-fop-local-ci-ergonomics.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+sha="$(git rev-parse HEAD)"
+report=".fop/reports/local-ci-pr-${sha}.json"
+tmp_dir="$(mktemp -d)"
+report_backup=""
+
+cleanup() {
+    rm -rf "$tmp_dir"
+    if [[ -n "$report_backup" && -f "$report_backup" ]]; then
+        mkdir -p "$(dirname "$report")"
+        cp -p "$report_backup" "$report"
+        rm -f "$report_backup"
+    else
+        rm -f "$report"
+    fi
+}
+trap cleanup EXIT
+
+if [[ -f "$report" ]]; then
+    report_backup="$(mktemp)"
+    cp -p "$report" "$report_backup"
+fi
+
+red() { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+echo "==> fop-local-ci advertises background and diff-aware controls"
+if .github/scripts/fop-local-ci.sh --help >"$tmp_dir/help" 2>&1 \
+    && grep -q -- '--background' "$tmp_dir/help" \
+    && grep -q -- 'FOP_LOCAL_CI_NO_DIFF_AWARE' "$tmp_dir/help"; then
+    green "    OK"
+else
+    red "    FAILED: help output is missing ergonomics flags"
+    cat "$tmp_dir/help"
+    exit 1
+fi
+
+echo "==> fop-local-ci pr dry-run skips untouched PHP and frontend gates"
+rm -f "$report"
+FOP_LOCAL_CI_DIFF_PATHS=$'docs/parkhub-notes.md\nREADME.md' \
+    .github/scripts/fop-local-ci.sh --profile pr --dry-run >"$tmp_dir/dry-run" 2>&1
+
+for pattern in \
+    'diff-aware' \
+    'composer validate .*SKIP: diff-aware: no PHP backend inputs touched' \
+    'frontend vitest .*SKIP: diff-aware: no frontend/e2e inputs touched' \
+    'dry-run local CI completed; no success report or commit status was written'; do
+    if ! grep -Eq "$pattern" "$tmp_dir/dry-run"; then
+        red "    FAILED: dry-run output missing pattern: $pattern"
+        cat "$tmp_dir/dry-run"
+        exit 1
+    fi
+done
+
+if [[ -f "$report" ]]; then
+    red "    FAILED: dry-run wrote a local-ci success report"
+    cat "$report"
+    exit 1
+fi
+
+green "    OK"
+
+echo "==> fop-local-ci background mode returns a PID and writes a log"
+FOP_LOCAL_CI_BG_LOG_DIR="$tmp_dir/bg" \
+FOP_LOCAL_CI_DIFF_PATHS=$'docs/parkhub-notes.md' \
+    .github/scripts/fop-local-ci.sh --profile pr --dry-run --background >"$tmp_dir/background" 2>&1
+
+if ! grep -q 'fop-local-ci backgrounded' "$tmp_dir/background" \
+    || ! grep -Eq 'PID=[0-9]+' "$tmp_dir/background"; then
+    red "    FAILED: background output missing PID/log details"
+    cat "$tmp_dir/background"
+    exit 1
+fi
+
+bg_log="$(grep -Eo 'log=[^ ]+' "$tmp_dir/background" | head -1 | cut -d= -f2-)"
+if [[ -z "$bg_log" ]]; then
+    red "    FAILED: background output did not include a log path"
+    cat "$tmp_dir/background"
+    exit 1
+fi
+
+for _ in $(seq 1 20); do
+    if [[ -f "$bg_log" ]] && grep -q 'dry-run local CI completed; no success report or commit status was written' "$bg_log"; then
+        green "    OK"
+        exit 0
+    fi
+    sleep 0.1
+done
+
+red "    FAILED: background dry-run log did not finish"
+cat "$tmp_dir/background"
+[[ -f "$bg_log" ]] && cat "$bg_log"
+exit 1

--- a/scripts/tests/test-fop-local-ci-failure-trap.sh
+++ b/scripts/tests/test-fop-local-ci-failure-trap.sh
@@ -57,6 +57,7 @@ echo "==> fop-local-ci posts failure when a run_step command fails"
 set +e
 PATH="$tmp_dir:$PATH" \
 GH_STATUS_LOG="$gh_log" \
+FOP_LOCAL_CI_NO_DIFF_AWARE=1 \
 FOP_LOCAL_CI_DIRECT=1 \
 FOP_LOCAL_CI_STATUS_REPO=nash87/parkhub-php \
     .github/scripts/fop-local-ci.sh --profile pr --post-status >/tmp/parkhub-fop-local-ci-failure-trap.out 2>&1

--- a/scripts/tests/test-local-ci-report-check.sh
+++ b/scripts/tests/test-local-ci-report-check.sh
@@ -95,3 +95,24 @@ else
     cat "$tmp_dir/out"
     exit 1
 fi
+
+echo "==> local-ci report check accepts schema v2 success reports"
+cat > "$report" <<EOF
+{
+  "schema": "parkhub.local-ci.v2",
+  "profile": "pr",
+  "state": "success",
+  "commit": "$sha",
+  "context": "fop/local-ci/pr",
+  "diff_aware": {
+    "enabled": true
+  }
+}
+EOF
+if bash scripts/check-local-ci-report.sh pr >"$tmp_dir/out" 2>&1; then
+    green "    OK"
+else
+    red "    FAILED: schema v2 success report was rejected"
+    cat "$tmp_dir/out"
+    exit 1
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,14 @@
 { pkgs ? import <nixpkgs> {} }:
 pkgs.mkShell {
   buildInputs = with pkgs; [
-    php83
-    php83Packages.composer
+    php84
+    php84Packages.composer
     nodejs_22
-    nodePackages.npm
+    git
+    jq
+    curl
+    sqlite
+    unzip
+    zip
   ];
 }


### PR DESCRIPTION
## Summary

T-2775 (PHP half). Pair PR for nash87/parkhub-rust#598 (Rust half, merged).

Adds the Nix/Garnix baseline to parkhub-php with a committed `flake.lock` so `make nix-contract --strict` and Garnix flake-check can run reproducibly.

- New `flake.nix` with nixpkgs/nixos-unstable + flake-utils inputs (PHP 8.4 + Node 22 toolchain)
- New `flake.lock` pinned to:
  - nixpkgs: `549bd84d` (2026-05-05)
  - flake-utils: `11707dc2` (2024-11-13)
- New `scripts/check-nix-garnix-contract.sh`: static checks for flake.nix structure, garnix.yaml schema, devShells.default, formatter pin, toolchain-contract output, plus cross-checks against composer.json (^8.4) + parkhub-web/package.json (>=22.12.0)
- New `make nix-contract` (warns on missing lock) + `make nix-contract-strict` (`--require-lock`, hard fail) targets
- New PHP devcontainer parity contract + diff-aware php local gate

`flake.lock` was generated via mirrored `192.168.178.250:5000/nixos-nix:2.24.10` in a clean podman context (CLAUDE.md: never pull from Docker Hub during builds).

## Test plan

- [x] `make ci` passed locally (full PHP CI: phpunit unit + feature, vitest, frontend build, drift, image-scan, etc.)
- [x] `make nix-contract` passes
- [x] All 33 i18n parity tests green (incl. 8 locale check)
- [ ] Garnix flake-check on first push (post-merge)
- [ ] After merge: switch CI to `make nix-contract-strict`

## Follow-ups

- Pair PR with parkhub-rust#598 — flip both `make nix-contract` calls in CI to strict-lock once both merge