### PR TITLE
ci: switch nix-contract gate to --strict (--require-lock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Validate Docker Compose
         run: docker compose -f docker-compose.yml config -q
 
-      - name: Validate Nix/Garnix contract
-        run: make nix-contract
+      - name: Validate Nix/Garnix contract (strict, --require-lock)
+        run: make nix-contract-strict
 
       - name: Validate devcontainer contract
         run: make devcontainer-contract


### PR DESCRIPTION
T-2778 — audit follow-up from PR #453.

Now that flake.lock is committed in main, flip CI from non-strict make nix-contract (warns on missing lock) to make nix-contract-strict (--require-lock, hard fails if lock drifts). Locks in the strict reproducibility gate.

## Test plan
- [x] make ci passed locally on the new ci.yml