### PR TITLE
ci: port image-scan lefthook gate (fleet parity with fop-web-ui#171, fop-web-backend#62)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -66,3 +66,22 @@ pre-push:
       skip:
         - run: 'test ! -x "$(command -v gh 2>/dev/null)"'
       run: 'bash scripts/post-attestation-deferred.sh success "Local-first attestation - lefthook pre-push gates clean (php)"'
+
+    image-scan:
+      # Local container image vulnerability scan — fleet parity port from
+      # parkhub-rust + fop-web-ui#171 + fop-web-backend#62. Gating only on
+      # changes to files that drive image content (Dockerfile,
+      # composer.lock, parkhub-web/package-lock.json) so most pushes hit
+      # the cached stamp and skip in milliseconds.
+      #
+      # Skips entirely when podman/trivy/grype are missing on PATH (the
+      # script handles tool detection internally and exits 0). Bazzite
+      # devs and CI runners with the tools installed get the gate; others
+      # see a one-line skip notice.
+      glob: "{Dockerfile,composer.lock,parkhub-web/package-lock.json}"
+      skip:
+        - run: 'test ! -x scripts/local-image-scan.sh'
+      run: ./scripts/local-image-scan.sh
+      fail_text: |
+        Container image scan surfaced CRITICAL/HIGH vulnerabilities.
+        Triage with: trivy image parkhub-php-local:ci-* (see scripts/local-image-scan.sh)

--- a/scripts/local-image-scan.sh
+++ b/scripts/local-image-scan.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Local container image vulnerability scan — fleet parity port from
+# parkhub-rust / fop-web-ui#171 / fop-web-backend#62.
+#
+# parkhub-php had trust-inversion attestation but no local image-scan gate.
+# This closes the gap so a vulnerable runtime image never reaches the
+# registry without local discovery.
+#
+# Mechanism:
+#   1. Compute a stable input hash from Dockerfile + composer.lock +
+#      parkhub-web/package-lock.json.
+#   2. If `.fop/image-scan-validated-<hash>.stamp` exists, skip (cached).
+#   3. Otherwise: podman build → trivy image → grype image, fail on critical.
+#   4. On success, write the stamp.
+#
+# Usage:
+#   scripts/local-image-scan.sh [--force] [--no-cache]
+#
+# Env:
+#   FOP_IMAGE_SCAN_TAG     image tag (default: parkhub-php-local:ci-<hash[0:10]>)
+#   FOP_IMAGE_SCAN_DIR     stamp dir (default: .fop)
+#
+# Skips gracefully if podman, trivy, or grype is missing on PATH.
+
+set -euo pipefail
+
+force=0
+no_cache=""
+for arg in "$@"; do
+  case "$arg" in
+    --force) force=1 ;;
+    --no-cache) no_cache="--no-cache" ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Compute input hash deterministically across the 3 files that drive image
+# content. If any is missing, the missing component is hashed as empty so
+# the stamp varies when a file appears later.
+hash_input() {
+  for f in Dockerfile composer.lock parkhub-web/package-lock.json; do
+    if [[ -f "$f" ]]; then
+      sha256sum "$f"
+    else
+      echo "0000000000000000000000000000000000000000000000000000000000000000  $f (missing)"
+    fi
+  done | sha256sum | awk '{print $1}'
+}
+
+input_hash=$(hash_input)
+short_hash=${input_hash:0:10}
+stamp_dir="${FOP_IMAGE_SCAN_DIR:-.fop}"
+stamp_file="$stamp_dir/image-scan-validated-$short_hash.stamp"
+image_tag="${FOP_IMAGE_SCAN_TAG:-parkhub-php-local:ci-$short_hash}"
+
+if [[ -f "$stamp_file" ]] && (( ! force )); then
+  echo "✓ image scan skipped (stamp present: $stamp_file)"
+  echo "  image-input hash: $input_hash"
+  exit 0
+fi
+
+# Tool availability — skip the stage entirely if any required tool is missing.
+need_podman=0
+need_trivy=0
+need_grype=0
+command -v podman >/dev/null 2>&1 || need_podman=1
+command -v trivy >/dev/null 2>&1 || need_trivy=1
+command -v grype >/dev/null 2>&1 || need_grype=1
+
+if (( need_podman + need_trivy + need_grype > 0 )); then
+  echo "⊘ image scan skipped — missing tools:"
+  (( need_podman )) && echo "    podman not on PATH (install: dnf install podman)"
+  (( need_trivy )) && echo "    trivy not on PATH (install: https://aquasecurity.github.io/trivy/)"
+  (( need_grype )) && echo "    grype not on PATH (install: https://github.com/anchore/grype#installation)"
+  exit 0
+fi
+
+mkdir -p "$stamp_dir"
+
+# Build the image. --network=host is required under Bazzite Flatpak sandbox
+# (podman default rootless networking conflicts with the sandbox) and lets
+# the Wolfi runtime stage's `apk update && apk upgrade --available` reach
+# packages.wolfi.dev for current glibc/openssl revisions.
+echo "▶ podman build $image_tag (input hash $short_hash)"
+podman build $no_cache --network=host -t "$image_tag" . >&2
+
+# Trivy image scan — CRITICAL/HIGH on wolfi system + node-pkg + composer-vendor.
+echo "▶ trivy image $image_tag (CRITICAL,HIGH; .trivyignore filters applied)"
+trivy_args=(
+  image --quiet
+  --scanners=vuln,secret
+  --severity=CRITICAL,HIGH
+  --exit-code=1
+)
+[[ -f .trivyignore ]] && trivy_args+=(--ignorefile .trivyignore)
+trivy "${trivy_args[@]}" "$image_tag"
+
+# Grype image scan — defense-in-depth, fail-on critical.
+echo "▶ grype $image_tag (defense-in-depth, fail-on critical)"
+grype "$image_tag" --fail-on critical --quiet
+
+# All checks passed — write stamp.
+{
+  echo "image-input hash: $input_hash"
+  echo "image tag:        $image_tag"
+  echo "validated at:     $(date -u +%FT%TZ)"
+  echo "trivy version:    $(trivy --version 2>&1 | head -1)"
+  echo "grype version:    $(grype version 2>&1 | grep -i ^version | head -1)"
+} > "$stamp_file"
+
+echo "✓ image scan passed; stamp written to $stamp_file"


### PR DESCRIPTION
T-2783. Fleet parity: parkhub-php was the last repo without a local image-scan gate. This closes the gap.

## What this adds

- `scripts/local-image-scan.sh` — hashes Dockerfile + composer.lock + parkhub-web/package-lock.json, builds image, runs trivy + grype on CRITICAL/HIGH, caches with stamp file at `.fop/image-scan-validated-<hash>.stamp`. Skips gracefully when podman/trivy/grype missing on PATH.
- lefthook `image-scan` pre-push hook with `glob: "{Dockerfile,composer.lock,parkhub-web/package-lock.json}"` — fires only when image inputs change.

## Pattern parity across parkhub fleet

| Repo | Hash inputs |
|---|---|
| parkhub-rust | Dockerfile + Cargo.lock + parkhub-web/package-lock.json |
| parkhub-php | Dockerfile + composer.lock + parkhub-web/package-lock.json |
| fop-web-ui (gitea#171) | Dockerfile + package-lock.json |
| fop-web-backend (gitea#62, MERGED) | Containerfile + Cargo.lock |

Image tag prefix mirrors repo: `parkhub-php-local:ci-<hash>`.

## Test plan

- [x] Script syntax check + executable bit
- [x] make ci diff-aware skipped heavy gates (only `scripts/` + `lefthook.yml` touched); local-ci report posted at .fop/reports/
- [x] Push: lefthook image-scan correctly SKIPPED (no Dockerfile/lockfile changes); local-ci + post-attestation green
- [ ] First real trigger: future PR touching one of the 3 hash inputs
- [ ] Wolfi runtime (#454 already merged) means trivy + grype expected to come back clean