### PR TITLE
fix(ci): parameterize NODE_BASE+WOLFI_BASE build-args for cloud CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,6 +72,12 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
           cache-from: type=gha,scope=release-docker
           cache-to: type=gha,scope=release-docker,mode=max
+          # Cloud runners can't reach the homelab LAN mirror; pull the same
+          # base images from public registries. Dockerfile defaults to LAN
+          # for local + gitea-runner builds.
+          build-args: |
+            NODE_BASE=docker.io/library/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
+            WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -95,6 +101,10 @@ jobs:
           cache-to: type=gha,scope=release-docker,mode=max
           provenance: mode=max
           sbom: true
+          # Same public-registry override as the scan build above.
+          build-args: |
+            NODE_BASE=docker.io/library/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
+            WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest
 
       - name: Attest image provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,17 @@
 # ---------------------------------------------------------------------------
 # Stage 1: Frontend build (Astro + Vite)
 # Mirrored node:22-slim — pinned to the registry digest, NOT Docker Hub.
+#
+# NODE_BASE / WOLFI_BASE are parameterized so cloud CI (GitHub Actions) can
+# pass --build-arg NODE_BASE=docker.io/library/node:22-slim@sha256:aa8ccf90...
+# and --build-arg WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest while
+# local + gitea-runner builds default to the LAN mirror. Same images either
+# way, just different ingress to them.
 # ---------------------------------------------------------------------------
-FROM 192.168.178.250:5000/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104 AS frontend
+ARG NODE_BASE=192.168.178.250:5000/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
+ARG WOLFI_BASE=192.168.178.250:5000/wolfi-base:latest
+
+FROM ${NODE_BASE} AS frontend
 WORKDIR /app
 COPY parkhub-web/package*.json ./
 RUN npm ci
@@ -30,7 +39,7 @@ RUN DOCKER=1 npm run build
 # Wolfi base + apk-installed php-8.4 + composer + git — replaces composer:2
 # Docker Hub image. Smaller surface, no Hub pull.
 # ---------------------------------------------------------------------------
-FROM 192.168.178.250:5000/wolfi-base:latest AS vendor
+FROM ${WOLFI_BASE} AS vendor
 # Vendor stage runs `composer install` + `composer dump-autoload`. The latter
 # triggers Laravel's `package:discover` post-autoload-dump script, which
 # touches the DB layer (PDO) — so pdo + pdo_sqlite are needed even though
@@ -72,7 +81,7 @@ RUN composer dump-autoload --optimize --no-dev --no-scripts
 # libc6 CVE-2026-5450 because Wolfi tracks current upstream and is
 # scanned daily by Chainguard.
 # ---------------------------------------------------------------------------
-FROM 192.168.178.250:5000/wolfi-base:latest AS runtime
+FROM ${WOLFI_BASE} AS runtime
 
 # Single apk layer. `apk upgrade --no-cache` first to pull current glibc/etc.
 # (mirrored wolfi-base:latest can lag the apk repo by a release; without


### PR DESCRIPTION
## Summary

- **CI fix**: Add `ARG NODE_BASE` and `ARG WOLFI_BASE` (declared globally before the first FROM so all stages see them) to make the runtime image build configurable. Defaults = LAN mirror (`192.168.178.250:5000/...`); cloud CI passes `--build-arg NODE_BASE=docker.io/library/node:22-slim@sha256:aa8ccf90...` and `--build-arg WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest` to source the same images from public registries. Both build-push-action steps in `docker-publish.yml` (scan + push) get the same `build-args:` block.
- Closes the **Release Container** failures since the Wolfi rebase (#454) — three `FROM` lines pinned to the LAN mirror that GitHub-hosted runners can't reach (`dial tcp 192.168.178.250:5000: i/o timeout`).
- Same root cause / same approach as parkhub-rust#603.

## Why
Wolfi runtime rebase (#454) preserved the "never pull from Docker Hub in builds" convention by mirroring through the homelab LAN registry. Cloud runners can't reach the LAN, so any GitHub-hosted CI that triggers a docker build broke immediately. Local + gitea-runner builds keep the LAN convention; only cloud CI overrides via build-args.

## Test plan
- [x] Local lefthook full pre-push pass (pint / image-scan / local-ci / post-attestation)
- [x] Trivy: 0 vulns, Grype: 0 vulns on the rebuilt image (wolfi 20230201 + node-pkg + composer-vendor surfaces all clean)
- [x] `make ci` success report on disk
- [ ] CI: Release Container should now succeed (verifies cgr.dev + Docker Hub digest-pinned ingress works on GitHub-hosted runners)