### PR TITLE
fix(ci): use real Docker Hub digest for node:22-slim

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,7 +76,7 @@ jobs:
           # base images from public registries. Dockerfile defaults to LAN
           # for local + gitea-runner builds.
           build-args: |
-            NODE_BASE=docker.io/library/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
+            NODE_BASE=docker.io/library/node:22-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
             WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest
 
       - name: Scan image with Trivy
@@ -103,7 +103,7 @@ jobs:
           sbom: true
           # Same public-registry override as the scan build above.
           build-args: |
-            NODE_BASE=docker.io/library/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
+            NODE_BASE=docker.io/library/node:22-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
             WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest
 
       - name: Attest image provenance


### PR DESCRIPTION
## Summary

Follow-up to #457. The build-args added there used the LAN-mirror's local digest `sha256:aa8ccf90...` for `node:22-slim`, but Docker Hub publishes a different digest for the same tag. GitHub-hosted runners pulled and got `failed to resolve source metadata: not found`, so Release Container failed on the merge commit (run 25463627499).

Replace with Docker Hub's actual current digest `sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c` (last_updated 2026-04-22 per hub.docker.com manifest API).

## Test plan
- [x] make ci passes locally (lefthook gates clean)
- [ ] Release Container CI passes on this PR (proves the digest is valid on Docker Hub)