### PR TITLE
fix(ci): use public base images for Install Smoke on GitHub-hosted runners

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -34,7 +34,11 @@ jobs:
         # consumed by docker-compose.yml's build args block, pointing at public
         # images that match the same Wolfi/Node major versions.
         env:
-          NODE_BASE: docker.io/library/node:22-slim
+          # Pin NODE_BASE to the same sha256 the Dockerfile defaults to so
+          # cloud + homelab smoke tests run on byte-identical bytes.
+          # WOLFI_BASE stays tag-only because Chainguard's continuous-CVE
+          # patching model recommends `:latest`.
+          NODE_BASE: docker.io/library/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
           WOLFI_BASE: cgr.dev/chainguard/wolfi-base:latest
         run: |
           # Step 2 — seed required secrets

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -29,6 +29,13 @@ jobs:
           git clone --depth 1 https://github.com/nash87/parkhub-php.git /tmp/smoke
       - name: Follow INSTALLATION.md Docker Compose steps
         working-directory: /tmp/smoke
+        # GitHub-hosted runners cannot reach the homelab internal registry
+        # (192.168.178.250:5000). Override the Dockerfile defaults via env vars
+        # consumed by docker-compose.yml's build args block, pointing at public
+        # images that match the same Wolfi/Node major versions.
+        env:
+          NODE_BASE: docker.io/library/node:22-slim
+          WOLFI_BASE: cgr.dev/chainguard/wolfi-base:latest
         run: |
           # Step 2 — seed required secrets
           {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,18 @@
 # and set real passwords there, or use a .env file. Never commit real credentials.
 # Defaults below are safe example placeholders for local dev only.
 
+# Build block shared by all services. NODE_BASE / WOLFI_BASE default to the
+# homelab internal registry (unreachable from public CI) and are overridden via
+# env vars when running on GitHub-hosted runners — see .github/workflows/install-smoke.yml.
+x-build: &build
+  context: .
+  args:
+    NODE_BASE: ${NODE_BASE:-192.168.178.250:5000/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104}
+    WOLFI_BASE: ${WOLFI_BASE:-192.168.178.250:5000/wolfi-base:latest}
+
 services:
   app:
-    build: .
+    build: *build
     restart: unless-stopped
     ports:
       - "8080:10000"
@@ -89,7 +98,7 @@ services:
           memory: 128M
 
   worker:
-    build: .
+    build: *build
     restart: unless-stopped
     command: php artisan queue:work --sleep=3 --tries=3 --max-time=3600
     env_file:
@@ -128,7 +137,7 @@ services:
           memory: 64M
 
   scheduler:
-    build: .
+    build: *build
     restart: unless-stopped
     command: >
       sh -c "while true; do php artisan schedule:run --verbose --no-interaction; sleep 60; done"


### PR DESCRIPTION
## Summary

Fixes the **Install Smoke** workflow that has been failing nightly on \`main\` since at least 2026-05-04.

## Root cause

The job runs on \`ubuntu-latest\` (GitHub-hosted) and tries \`docker compose up -d\` against a Dockerfile whose base images default to:

\`\`\`
ARG NODE_BASE=192.168.178.250:5000/node:22-slim@sha256:...
ARG WOLFI_BASE=192.168.178.250:5000/wolfi-base:latest
\`\`\`

\`192.168.178.250:5000\` is the homelab internal load-balanced registry (private LAN IP). GHA runners can't reach it:

\`\`\`
target worker: failed to solve: DeadlineExceeded:
192.168.178.250:5000/wolfi-base:latest: failed to resolve source metadata
... dial tcp 192.168.178.250:5000: i/o timeout
\`\`\`

PR #457 already parameterized these args for cloud CI override, but \`docker-compose.yml\`'s short-form \`build: .\` didn't forward env vars into build args, so the smoke workflow had no override path.

## Fix

- **\`docker-compose.yml\`**: introduce an \`x-build\` anchor with \`\${VAR:-default}\` env substitution; apply to \`app\`, \`worker\`, \`scheduler\` (3 services that all build the same image).
- **\`install-smoke.yml\`**: set step-level env vars to public images that match the Wolfi/Node major versions:
  - \`NODE_BASE=docker.io/library/node:22-slim\`
  - \`WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest\`

## Risk

Low — defaults unchanged (homelab + local + gitea-internal runners still use the homelab registry). Only the GHA Install Smoke step picks up the public override.

## Test plan

- [ ] Install Smoke workflow runs green on this PR
- [ ] After merge, Install Smoke on main is green for the first time since 2026-05-04
- [ ] Local \`docker compose up -d\` still uses homelab registry (no env vars set)