### PR TITLE
fix(devcontainer): drop docker-compose-plugin + npm self-upgrade

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -13,17 +13,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl wget gnupg lsb-release jq git \
         python3 python3-pip python3-yaml yamllint \
         sudo less unzip zip pkg-config sqlite3 default-mysql-client \
-        docker.io docker-compose-plugin \
+        docker.io \
         libcurl4-openssl-dev libicu-dev libzip-dev libpng-dev libxml2-dev \
         libonig-dev libsqlite3-dev \
     && docker-php-ext-install -j"$(nproc)" \
         bcmath curl gd intl mbstring pdo_mysql pdo_sqlite zip \
     && rm -rf /var/lib/apt/lists/*
 
+# NodeSource v22 ships with a recent npm; the `npm install -g npm@latest`
+# self-upgrade fails with `MODULE_NOT_FOUND` on the bundled `npm-cli.js`
+# (https://github.com/nodesource/distributions/issues/1733), so we keep the
+# bundled version.
 RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g npm@latest
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
     && tar -xzf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64/helm \

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -6,6 +6,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_MAJOR=22
 ARG HELM_VERSION=v3.18.4
 ARG ACTIONLINT_VERSION=1.7.12
+# Docker Compose v2 plugin — installed via official binary release because
+# Debian Bookworm's `docker-compose-plugin` apt package needs Docker's apt
+# repo which we don't add here. Compose v2 is required by
+# scripts/ci/local-security-audit.sh (`docker compose config -q`).
+ARG DOCKER_COMPOSE_VERSION=v2.41.0
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
@@ -19,6 +24,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && docker-php-ext-install -j"$(nproc)" \
         bcmath curl gd intl mbstring pdo_mysql pdo_sqlite zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Docker Compose v2 plugin — official binary release (Debian's
+# `docker-compose-plugin` package needs Docker's apt repo, which we'd rather
+# not add). Installed into the standard cli-plugins path so `docker compose`
+# subcommand works alongside the `docker.io` package above.
+RUN mkdir -p /usr/libexec/docker/cli-plugins \
+    && curl -fsSL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
+        -o /usr/libexec/docker/cli-plugins/docker-compose \
+    && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \
+    && docker compose version
 
 # NodeSource v22 ships with a recent npm; the `npm install -g npm@latest`
 # self-upgrade fails with `MODULE_NOT_FOUND` on the bundled `npm-cli.js`


### PR DESCRIPTION
## Summary

Fixes the **Publish dev container image** workflow, failing on \`main\` since 2026-05-05.

## Root cause

\`.devcontainer/Containerfile\` has two distinct issues:

### 1. \`apt-get install ... docker-compose-plugin\` exits 100

\`\`\`
E: Unable to locate package docker-compose-plugin
\`\`\`

The base image is \`php:8.4-cli-bookworm\` (Debian) — it doesn't have Docker's official apt repo configured, and Debian's own repos don't ship \`docker-compose-plugin\`. We don't actually need it here — devcontainers use \`docker.io\` for in-container Docker, not Compose.

### 2. \`npm install -g npm@latest\` fails with MODULE_NOT_FOUND

\`\`\`
npm error code MODULE_NOT_FOUND
Cannot find module '/usr/lib/node_modules/npm/bin/npm-cli.js'
\`\`\`

Known NodeSource v22 issue ([nodesource/distributions#1733](https://github.com/nodesource/distributions/issues/1733)) — the self-upgrade trips over the bundled module layout. Bundled npm 10.x is recent enough.

## Fix

Drop both \`docker-compose-plugin\` from the apt list and \`&& npm install -g npm@latest\` from the Node install RUN.

## Risk

Minimal — devcontainer image only. Production runtime image uses a different Dockerfile + Wolfi base; no overlap.

## Test plan

- [ ] \`Publish dev container image\` workflow succeeds on this PR
- [ ] After merge, devcontainer still works (npm + docker.io still installed)