### PR TITLE
fix(ci): use public base images for Docker build step on GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,8 +432,15 @@ jobs:
           # NODE_BASE / WOLFI_BASE default to the homelab internal registry,
           # which GitHub-hosted runners can't reach. Override with public images
           # so the CI Docker build step succeeds. Mirrors the install-smoke fix.
+          # NODE_BASE pinned to the same sha256 the Dockerfile defaults to so
+          # cloud + homelab builds run on identical bytes. WOLFI_BASE stays
+          # tag-only because Chainguard recommends `:latest` for continuous
+          # CVE patching — pinning a wolfi digest defeats the security model.
+          # The .gitea/workflows/ci.yaml mirror is intentionally NOT updated:
+          # Gitea runners run on the homelab LAN and can reach the internal
+          # registry, so the Dockerfile defaults are correct there.
           build-args: |
-            NODE_BASE=docker.io/library/node:22-slim
+            NODE_BASE=docker.io/library/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
             WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest
 
   integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,12 @@ jobs:
           tags: parkhub-php:ci
           cache-from: type=gha,scope=ci-docker
           cache-to: type=gha,scope=ci-docker,mode=max
+          # NODE_BASE / WOLFI_BASE default to the homelab internal registry,
+          # which GitHub-hosted runners can't reach. Override with public images
+          # so the CI Docker build step succeeds. Mirrors the install-smoke fix.
+          build-args: |
+            NODE_BASE=docker.io/library/node:22-slim
+            WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest
 
   integration:
     name: Integration tests


### PR DESCRIPTION
## Summary

Fixes the **CI** workflow's \`Docker build\` step on \`main\`, failing since at least 2026-05-06.

## Root cause

\`.github/workflows/ci.yml\` step \`Build Docker image\` uses \`docker/build-push-action\` without \`build-args\`, so it inherits the Dockerfile's default base images:

\`\`\`
ARG NODE_BASE=192.168.178.250:5000/node:22-slim@sha256:...
ARG WOLFI_BASE=192.168.178.250:5000/wolfi-base:latest
\`\`\`

The \`192.168.178.250:5000\` registry is on the homelab LAN — GitHub-hosted runners can't reach it:

\`\`\`
DeadlineExceeded: 192.168.178.250:5000/wolfi-base:latest:
failed to do request: dial tcp 192.168.178.250:5000: i/o timeout
\`\`\`

This is the same root cause as #464 (which patched \`install-smoke.yml\`). The CI workflow needs the same fix in its own Docker build step.

## Fix

Add \`build-args\` to the \`docker/build-push-action\` invocation pointing at public images (\`docker.io/library/node:22-slim\` + \`cgr.dev/chainguard/wolfi-base:latest\`).

## Risk

Minimal — only the CI Docker build step. Local builds + gitea-internal runner builds still pick up the homelab defaults (env vars unset). Doesn't conflict with #464 (different files: ci.yml vs docker-compose.yml + install-smoke.yml).

## Test plan

- [ ] CI workflow's \`Docker build\` job succeeds on this PR
- [ ] After merge + #464 merge, CI green on next push to main