### PR TITLE
ci(visual): add update-snapshots dispatch input + baselines artifact

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -155,6 +155,10 @@ jobs:
           path: |
             test-results/**/*-diff.png
             test-results/**/*-actual.png
+            test-results/**/*-expected.png
+            playwright-report/
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Upload regenerated baselines
         if: always() && inputs.update-snapshots == true
@@ -166,10 +170,6 @@ jobs:
             e2e/v5-visual.spec.ts-snapshots/**
             e2e/v5-happy-paths.spec.ts-snapshots/**
           retention-days: 14
-            test-results/**/*-expected.png
-            playwright-report/
-          retention-days: 14
-          if-no-files-found: ignore
 
       - name: Upload full Playwright report
         if: always()

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -8,12 +8,20 @@ name: Visual Regression
 # `continue-on-error: true`).
 #
 # Run manually via `workflow_dispatch` when intentionally rebasing
-# baselines.
+# baselines: trigger with `update-snapshots: true` and the regenerated
+# PNGs are uploaded as the `visual-baselines` artifact (retained 14 days).
+# Download, extract over `e2e/*-snapshots/` locally, commit on a branch.
 
 on:
   schedule:
     - cron: '0 3 * * *'  # 03:00 UTC daily
   workflow_dispatch:
+    inputs:
+      update-snapshots:
+        description: 'Regenerate visual baselines (uploads new PNGs as artifact for manual commit)'
+        required: false
+        default: 'false'
+        type: boolean
 
 concurrency:
   group: visual-${{ github.workflow }}-${{ github.ref }}
@@ -97,6 +105,7 @@ jobs:
           PARKHUB_ADMIN_PASSWORD: demo
           PARKHUB_DISABLE_RATE_LIMITS: 'true'
           RUN_STORAGE_LINK: '1'
+          UPDATE_SNAPSHOTS: ${{ inputs.update-snapshots || 'false' }}
         run: |
           ./scripts/ci/bootstrap-laravel.sh
           php artisan migrate:fresh --seed --seeder=ProductionSimulationSeeder --force
@@ -111,18 +120,30 @@ jobs:
           # render/runtime coverage lives in npm run test:e2e:design-smoke.
           # Keep workers=1 — php artisan serve is single-process and
           # concurrent logins race.
+          # When the dispatch input asks for a baseline rebase, pass
+          # `--update-snapshots` so Playwright writes new PNGs into the
+          # `*-snapshots/` directories. The artifact upload step picks
+          # them up — operators download + commit them on their own branch.
+          UPDATE_FLAG=""
+          if [ "${UPDATE_SNAPSHOTS}" = "true" ]; then
+            UPDATE_FLAG="--update-snapshots"
+            echo "::notice title=Regenerating visual baselines::Pass --update-snapshots to Playwright. Download the visual-baselines artifact after the run completes."
+          fi
+
           set +e
+          # shellcheck disable=SC2086
           npx playwright test \
             --project=chromium \
             --workers=1 \
             --reporter=github,html \
+            ${UPDATE_FLAG} \
             e2e/visual.spec.ts \
             e2e/v5-visual.spec.ts \
             e2e/v5-happy-paths.spec.ts
           visual_status=$?
           set -e
 
-          if [ "${visual_status}" -ne 0 ]; then
+          if [ "${visual_status}" -ne 0 ] && [ "${UPDATE_SNAPSHOTS}" != "true" ]; then
             echo "::warning title=Visual regression detected::Playwright exited ${visual_status}. See uploaded diff and report artifacts."
           fi
 
@@ -134,6 +155,17 @@ jobs:
           path: |
             test-results/**/*-diff.png
             test-results/**/*-actual.png
+
+      - name: Upload regenerated baselines
+        if: always() && inputs.update-snapshots == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: visual-baselines
+          path: |
+            e2e/visual.spec.ts-snapshots/**
+            e2e/v5-visual.spec.ts-snapshots/**
+            e2e/v5-happy-paths.spec.ts-snapshots/**
+          retention-days: 14
             test-results/**/*-expected.png
             playwright-report/
           retention-days: 14

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -20,7 +20,7 @@ on:
       update-snapshots:
         description: 'Regenerate visual baselines (uploads new PNGs as artifact for manual commit)'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 concurrency:
@@ -105,7 +105,9 @@ jobs:
           PARKHUB_ADMIN_PASSWORD: demo
           PARKHUB_DISABLE_RATE_LIMITS: 'true'
           RUN_STORAGE_LINK: '1'
-          UPDATE_SNAPSHOTS: ${{ inputs.update-snapshots || 'false' }}
+          # `inputs` is null on `schedule` triggers — coerce to false so we
+          # never accidentally regenerate baselines on the nightly run.
+          UPDATE_SNAPSHOTS: ${{ github.event_name == 'workflow_dispatch' && inputs.update-snapshots || false }}
         run: |
           ./scripts/ci/bootstrap-laravel.sh
           php artisan migrate:fresh --seed --seeder=ProductionSimulationSeeder --force
@@ -143,8 +145,16 @@ jobs:
           visual_status=$?
           set -e
 
-          if [ "${visual_status}" -ne 0 ] && [ "${UPDATE_SNAPSHOTS}" != "true" ]; then
-            echo "::warning title=Visual regression detected::Playwright exited ${visual_status}. See uploaded diff and report artifacts."
+          # Always emit a warning on non-zero exit. With UPDATE_SNAPSHOTS=true,
+          # Playwright should ALSO succeed (it just writes new baselines) — a
+          # crash there means the suite couldn't even start, so the warning
+          # is still the right signal.
+          if [ "${visual_status}" -ne 0 ]; then
+            if [ "${UPDATE_SNAPSHOTS}" = "true" ]; then
+              echo "::warning title=Baseline regen failed::Playwright exited ${visual_status} during --update-snapshots. The visual-baselines artifact may be partial; check uploaded report."
+            else
+              echo "::warning title=Visual regression detected::Playwright exited ${visual_status}. See uploaded diff and report artifacts."
+            fi
           fi
 
       - name: Upload diff artifacts
@@ -161,7 +171,9 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload regenerated baselines
-        if: always() && inputs.update-snapshots == true
+        # `inputs` is only populated for workflow_dispatch — guard so the
+        # nightly schedule never accidentally uploads a baselines artifact.
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.update-snapshots == true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: visual-baselines


### PR DESCRIPTION
## Summary

Makes visual baseline regeneration a one-click operator action. Adds a \`update-snapshots\` boolean input to the \`Visual Regression\` workflow's existing \`workflow_dispatch\` trigger, plus a \`visual-baselines\` artifact upload when the flag is set.

## Why now

The php Nightly Assurance investigation (sub-agent on run 25593467466) surfaced two failure classes that aren't real bugs but stale baselines:

- \`v5-visual.spec.ts\` — 94-99% pixel diff on 5+ admin/v5 pages
- \`visual.spec.ts\` — same drift on a subset of admin pages

Today, regenerating baselines requires running locally in a CI-equivalent environment (font rendering + PHP/Astro server timing differ host-vs-runner), which produces brittle results. The proper fix is to regenerate on the actual CI runner.

## Changes

### \`.github/workflows/visual-regression.yml\`

- \`workflow_dispatch\` gets a \`update-snapshots\` boolean input (default \`false\`)
- The Run step exports \`UPDATE_SNAPSHOTS\` env var
- When \`true\`, \`--update-snapshots\` is appended to the playwright invocation
- When \`true\`, baselines are uploaded as \`visual-baselines\` artifact (14-day retention)

## Operator workflow

1. Trigger \`Visual Regression\` from Actions UI with \`update-snapshots: true\`
2. Wait for the run, download the \`visual-baselines\` artifact
3. Extract over \`e2e/*-snapshots/\` on a branch, commit, open PR

## Risk

Minimal — workflow-only change. Default behavior unchanged (when input is \`false\` or unset, the run is identical to before).

## Test plan

- [ ] CI green on this PR (existing scheduled runs unaffected)
- [ ] Trigger workflow with \`update-snapshots: true\` after merge — verify the \`visual-baselines\` artifact contains regenerated PNGs