### PR TITLE
chore(ci): port workflow-drift detector + wire into lefthook pre-push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -56,6 +56,18 @@ pre-push:
       run: bash scripts/check-local-ci-report.sh pr
       fail_text: "Local fop CI report missing or stale. Run `make ci`, then push again."
 
+    workflow-drift:
+      # Advisory check: warns if .github/workflows/* and .gitea/workflows/*
+      # have drifted (missing files OR different `on:` triggers OR different
+      # `jobs:` keys). Mirror of parkhub-rust's pre-push drift gate. Only
+      # fails on missing files (gating); trigger/job drift exits 0 since
+      # gitea-runner and github-actions intentionally diverge in places.
+      run: bash scripts/local-workflow-drift.sh
+      fail_text: |
+        Workflow file missing in one side. Either add the corresponding file
+        in .gitea/workflows/ or .github/workflows/, or document the split in
+        scripts/local-workflow-drift.sh's EXEMPT list.
+
     post-attestation:
       # Forks a deferred poll-and-post that waits until the SHA shows up
       # on GitHub (after `git push` transmits the commit) and then

--- a/scripts/local-workflow-drift.sh
+++ b/scripts/local-workflow-drift.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Workflow drift detector — flags when .gitea/workflows/* diverges from
+# .github/workflows/* in ways that aren't documented as intentional splits.
+#
+# Why: parkhub-php ships BOTH .gitea/workflows (gitea actions runner on the
+# homelab LAN) AND .github/workflows (GitHub Actions). Some files are
+# intentionally split (e.g. lost-pixel runs only on gitea-internal because
+# it needs a private S3 store). Most should be kept in sync to avoid the
+# "fixed it on github but forgot gitea" drift trap.
+#
+# What this checks:
+#   1. Every file in .github/workflows/<NAME>.yml has a matching .gitea/
+#      workflows/<NAME>.yml or .yaml (or is in the EXEMPT list).
+#   2. For each matched pair: same `on:` triggers, same `jobs:` keys.
+#      Step bodies are NOT compared (they intentionally differ —
+#      gitea uses local action mirrors + the homelab registry, github
+#      uses public actions + ghcr.io).
+#
+# Usage:
+#   scripts/local-workflow-drift.sh [--strict]
+#
+# --strict treats EXEMPT-listed files as still-required (no exemption).
+#
+# Ported from parkhub-rust/scripts/local-workflow-drift.sh — keep the two
+# in lockstep since the design is shared. EXEMPT lists differ per repo.
+
+set -euo pipefail
+
+strict=0
+[[ "${1:-}" == "--strict" ]] && strict=1
+
+# Files that are documented as github-only (no gitea mirror needed) — these
+# typically depend on github-specific infrastructure (Codespaces, Copilot bot,
+# Dependabot, GitHub Dependency Graph API, ghcr.io, OIDC, etc).
+EXEMPT_GITEA_MISSING=(
+  copilot-setup-steps.yml         # Codespaces/Copilot setup
+  dependabot-auto-merge.yml       # Dependabot bot
+  dependency-review.yml           # GitHub Dependency Graph API
+  scorecard.yml                   # OSSF Scorecard publishes to github API
+  labeler.yml                     # GitHub PR labels
+  changelog.yml                   # PR-merge driven, github webhook
+  release.yml                     # Cosign keyless OIDC needs github OIDC
+  cosign-verify.yml               # post-publish verification on ghcr.io
+  devcontainer-publish.yml        # publishes to ghcr.io
+  auto-merge.yml                  # github-only auto-merge of dependabot PRs
+  deploy.yml                      # github-only Render/Fly/Koyeb dispatch
+)
+
+# Files that are documented as gitea-only (no github mirror needed) — these
+# typically depend on homelab-internal infrastructure (private buckets,
+# accessibility scanners that need internal data, lighthouse on internal URLs).
+EXEMPT_GITHUB_MISSING=(
+  accessibility-insights.yaml     # gitea-internal accessibility-insights run
+  lost-pixel.yaml                 # gitea-internal lost-pixel against private artifact store
+  unlighthouse.yaml               # gitea-internal full-site lighthouse sweep
+  storybook.yaml                  # gitea-runner internal Storybook publish (parity with parkhub-rust)
+)
+
+contains() {
+  local needle="$1"; shift
+  for hay in "$@"; do
+    [[ "$hay" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# Collect file lists.
+mapfile -t gh_files < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) -exec basename {} \; 2>/dev/null | sort -u)
+mapfile -t gt_files < <(find .gitea/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) -exec basename {} \; 2>/dev/null | sort -u)
+
+# Normalize names to compare (drop extension).
+norm() { printf '%s' "$1" | sed -E 's/\.(yml|yaml)$//'; }
+
+declare -a missing_in_gitea=()
+declare -a missing_in_github=()
+declare -a trigger_drift=()
+declare -a job_drift=()
+
+for f in "${gh_files[@]}"; do
+  base=$(norm "$f")
+  found=0
+  for g in "${gt_files[@]}"; do
+    [[ "$(norm "$g")" == "$base" ]] && { found=1; break; }
+  done
+  if (( ! found )); then
+    if (( strict )) || ! contains "$f" "${EXEMPT_GITEA_MISSING[@]}"; then
+      missing_in_gitea+=("$f")
+    fi
+  fi
+done
+
+for f in "${gt_files[@]}"; do
+  base=$(norm "$f")
+  found=0
+  for g in "${gh_files[@]}"; do
+    [[ "$(norm "$g")" == "$base" ]] && { found=1; break; }
+  done
+  if (( ! found )); then
+    if (( strict )) || ! contains "$f" "${EXEMPT_GITHUB_MISSING[@]}"; then
+      missing_in_github+=("$f")
+    fi
+  fi
+done
+
+# Compare matched pairs.
+for f in "${gh_files[@]}"; do
+  base=$(norm "$f")
+  gh_path=".github/workflows/$f"
+  gt_path=""
+  for g in "${gt_files[@]}"; do
+    if [[ "$(norm "$g")" == "$base" ]]; then
+      gt_path=".gitea/workflows/$g"
+      break
+    fi
+  done
+  [[ -z "$gt_path" ]] && continue
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    continue
+  fi
+
+  drift=$(python3 - "$gh_path" "$gt_path" <<'PY' 2>/dev/null || true
+import sys, yaml
+gh, gt = sys.argv[1], sys.argv[2]
+with open(gh) as f: gh_y = yaml.safe_load(f)
+with open(gt) as f: gt_y = yaml.safe_load(f)
+gh_on = sorted((gh_y.get('on') or gh_y.get(True) or {}).keys()) if isinstance(gh_y.get('on') or gh_y.get(True), dict) else []
+gt_on = sorted((gt_y.get('on') or gt_y.get(True) or {}).keys()) if isinstance(gt_y.get('on') or gt_y.get(True), dict) else []
+if gh_on != gt_on:
+    print(f"on:gh={gh_on} on:gt={gt_on}")
+gh_jobs = sorted((gh_y.get('jobs') or {}).keys())
+gt_jobs = sorted((gt_y.get('jobs') or {}).keys())
+gh_only = [j for j in gh_jobs if j not in gt_jobs]
+gt_only = [j for j in gt_jobs if j not in gh_jobs]
+if gh_only or gt_only:
+    print(f"jobs:gh-only={gh_only} jobs:gt-only={gt_only}")
+PY
+)
+  if [[ -n "$drift" ]]; then
+    if [[ "$drift" == on:* ]]; then
+      trigger_drift+=("$base: $drift")
+    else
+      job_drift+=("$base: $drift")
+    fi
+  fi
+done
+
+# Report.
+exit_code=0
+total_drift=$((${#missing_in_gitea[@]} + ${#missing_in_github[@]} + ${#trigger_drift[@]} + ${#job_drift[@]}))
+
+if (( total_drift == 0 )); then
+  echo "✓ no workflow drift detected (gh:${#gh_files[@]} files, gt:${#gt_files[@]} files)"
+  exit 0
+fi
+
+if (( ${#missing_in_gitea[@]} > 0 )); then
+  echo "✗ in .github/workflows but missing from .gitea/workflows:"
+  for f in "${missing_in_gitea[@]}"; do echo "    $f"; done
+  exit_code=1
+fi
+
+if (( ${#missing_in_github[@]} > 0 )); then
+  echo "✗ in .gitea/workflows but missing from .github/workflows:"
+  for f in "${missing_in_github[@]}"; do echo "    $f"; done
+  exit_code=1
+fi
+
+if (( ${#trigger_drift[@]} > 0 )); then
+  echo "⚠ trigger drift (different on: keys):"
+  for d in "${trigger_drift[@]}"; do echo "    $d"; done
+  # Trigger drift is advisory — gitea + github often diverge here intentionally.
+fi
+
+if (( ${#job_drift[@]} > 0 )); then
+  echo "⚠ job drift (different jobs.* keys):"
+  for d in "${job_drift[@]}"; do echo "    $d"; done
+fi
+
+echo
+echo "Total drift: ${total_drift}"
+echo "(missing files are gating; trigger/job drift is advisory)"
+exit $exit_code


### PR DESCRIPTION
## Summary

Ports \`scripts/local-workflow-drift.sh\` from parkhub-rust to parkhub-php and wires it into lefthook pre-push so gitea + github workflows can't silently drift.

## Why

parkhub-rust has shipped this gate for a while; parkhub-php hadn't ported it. Without the gate, fixes in \`.github/workflows/ci.yml\` (e.g. PR #466 build-args fix) don't propagate to \`.gitea/workflows/ci.yaml\` and gitea-side runs miss the fix. The drift compounds over weeks until someone notices CI on gitea is different from CI on github.

## Changes

### \`scripts/local-workflow-drift.sh\` (new)

177-line port from parkhub-rust. Compares:
- File-level: every \`.github/workflows/<NAME>.yml\` should have a matching \`.gitea/workflows/<NAME>.yaml\` (or be in EXEMPT_GITEA_MISSING).
- Trigger-level: \`on:\` keys should match.
- Job-level: \`jobs:*\` keys should match.

EXEMPT lists adjusted for parkhub-php specifically:
- \`EXEMPT_GITEA_MISSING\`: github-only workflows (changelog, cosign-verify, dependabot-auto-merge, dependency-review, devcontainer-publish, labeler, deploy, copilot-setup-steps, auto-merge).
- \`EXEMPT_GITHUB_MISSING\`: gitea-internal-only workflows (accessibility-insights, lost-pixel, unlighthouse, storybook — all need homelab-internal infrastructure).

### \`lefthook.yml\` — wire into pre-push

Added \`workflow-drift\` advisory gate after \`local-ci\`. Exits 0 unless a workflow file is missing on one side; trigger/job drift only prints a warning.

## Test

\`\`\`
$ bash scripts/local-workflow-drift.sh
⚠ trigger drift (different on: keys):
    lighthouse: on:gh=['push', 'workflow_dispatch'] on:gt=['pull_request', 'push', 'workflow_dispatch']
    openapi-drift: on:gh=['push', 'workflow_dispatch'] on:gt=['pull_request', 'push', 'workflow_dispatch']
    storybook: on:gh=['push', 'workflow_dispatch'] on:gt=['pull_request', 'push', 'workflow_dispatch']
⚠ job drift (different jobs.* keys):
    ci: jobs:gh-only=['local-ci-attestation'] jobs:gt-only=[]
    security: jobs:gh-only=['typos'] jobs:gt-only=['grype']

Total drift: 5
(missing files are gating; trigger/job drift is advisory)
\`\`\`

5 known intentional splits (gitea CI runs on PRs for faster feedback, gitea-side has no fop attestation gate, security uses different scanners). Exit 0 — clean baseline.

## Risk

Minimal — script is read-only YAML comparison, exits 0 on the current state. Lefthook gate only fails on file-missing (gating) which is genuinely a problem.