### PR TITLE
fix(security): audit-log + cache-control for public iCal feed (audit M-3)

### DIFF
--- a/app/Http/Controllers/Api/ICalController.php
+++ b/app/Http/Controllers/Api/ICalController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\AuditLog;
 use App\Models\Booking;
 use App\Models\User;
 use Carbon\Carbon;
@@ -32,20 +33,47 @@ class ICalController extends Controller
     /**
      * GET /api/v1/calendar/ical/{token} — public iCal feed via token (no auth).
      */
-    public function publicFeed(string $token): Response
+    public function publicFeed(string $token, Request $request): Response
     {
         $user = User::where('ical_token', $token)->first();
 
         if (! $user) {
+            // Audit log even on miss so brute-force token guessing leaves a trail.
+            AuditLog::log([
+                'user_id' => null,
+                'username' => null,
+                'action' => 'ical.public.fetch.miss',
+                'ip_address' => $request->ip(),
+            ]);
+
             return response('Not Found', 404);
         }
+
+        // Audit-log every successful fetch (audit M-3): a leaked iCal token
+        // would otherwise be polled for months with no detection signal. The
+        // entry costs one DB row per request, throttled by the route-level
+        // `throttle:api` middleware so it can't be amplified into a write DoS.
+        AuditLog::log([
+            'user_id' => $user->id,
+            'username' => $user->username,
+            'action' => 'ical.public.fetch',
+            'ip_address' => $request->ip(),
+        ]);
 
         $bookings = Booking::where('user_id', $user->id)
             ->where('start_time', '>=', now()->subMonths(3))
             ->orderBy('start_time')
             ->get();
 
-        return $this->buildIcal($bookings, $user->name ?? $user->username);
+        $response = $this->buildIcal($bookings, $user->name ?? $user->username);
+
+        // `private, max-age=60` lets the user's own calendar app cache for a
+        // minute while preventing shared / CDN caches from holding the feed
+        // (which would otherwise stale stress on a refresh storm and leak
+        // booking data to any cache layer in front of us).
+        $response->headers->set('Cache-Control', 'private, max-age=60');
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes audit MEDIUM-3 from \`Audits/2026-04-17-parkhub-security-audit.md\`:

> The public iCal feed at \`/api/v1/calendar/ical/{token}\` has no audit log and no Cache-Control header. A leaked 48-char token can be polled for months with no detection signal, and any shared cache in front of the app holds the booking data.

## Fixes

### 1. Audit log entries

\`AuditLog::log\` on both code paths:
- \`ical.public.fetch\` — successful fetch (so leaked-token polling is visible in the audit trail)
- \`ical.public.fetch.miss\` — 404 misses (so brute-force token guessing leaves a trail)

Both entries record \`ip_address\` for correlation; \`user_id\`/\`username\` filled on success, null on miss. Cost: one DB row per request, throttled by the existing route-level \`throttle:api\` so it can't be amplified into a write DoS.

### 2. \`Cache-Control: private, max-age=60\`

Lets the user's calendar client cache for a minute (legit refresh pattern) while preventing CDN/shared caches from holding the feed.

## Deferred (separate PRs)

- Tighter rate limit (\`throttle:30,1\` per audit) — \`throttle:api\` default 60/min is defensible; can tighten if call patterns warrant.
- Token-equality via constant-time comparison — current \`User::where('ical_token', \$token)\` could leak existence via timing.
- Scheduled token rotation — bigger feature, needs UX design.

## Test plan

- [ ] PHPUnit covers ICalController (existing + new tests would assert AuditLog row + Cache-Control header — leave for follow-up)
- [ ] Manual: hit \`/api/v1/calendar/ical/<token>\` → audit_log row appears + Cache-Control header set
- [ ] Manual: hit \`/api/v1/calendar/ical/<bogus>\` → 404 + audit_log row with action=ical.public.fetch.miss