### PR TITLE
fix(ci): correct Docker Hub digest + bump compose version (regressions in #464/#466/#465)

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -8,9 +8,11 @@ ARG HELM_VERSION=v3.18.4
 ARG ACTIONLINT_VERSION=1.7.12
 # Docker Compose v2 plugin — installed via official binary release because
 # Debian Bookworm's `docker-compose-plugin` apt package needs Docker's apt
-# repo which we don't add here. Compose v2 is required by
+# repo which we don't add here. Compose v2/v5 is required by
 # scripts/ci/local-security-audit.sh (`docker compose config -q`).
-ARG DOCKER_COMPOSE_VERSION=v2.41.0
+# Note: docker/compose project versioned past 2.x → 5.x line; v5.1.3 is
+# the current stable plugin binary as of 2026-05-10. Bump regularly.
+ARG DOCKER_COMPOSE_VERSION=v5.1.3
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
           # Gitea runners run on the homelab LAN and can reach the internal
           # registry, so the Dockerfile defaults are correct there.
           build-args: |
-            NODE_BASE=docker.io/library/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
+            NODE_BASE=docker.io/library/node:22-slim@sha256:868499d55378719bffa87b0ed1f099591823c029b543043c09c2483468e93201
             WOLFI_BASE=cgr.dev/chainguard/wolfi-base:latest
 
   integration:

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -34,11 +34,16 @@ jobs:
         # consumed by docker-compose.yml's build args block, pointing at public
         # images that match the same Wolfi/Node major versions.
         env:
-          # Pin NODE_BASE to the same sha256 the Dockerfile defaults to so
-          # cloud + homelab smoke tests run on byte-identical bytes.
+          # Pin NODE_BASE to a real Docker Hub digest. The Dockerfile's
+          # default digest (aa8ccf90...) is the homelab MIRROR's stored
+          # manifest, NOT the Docker Hub original — pushing to a private
+          # registry re-encodes the manifest, so the digest differs.
+          # We pin Docker Hub's actual digest for `node:22-slim` here so
+          # cloud CI is reproducible without trying to pull the homelab
+          # mirror digest from Docker Hub (which 404s).
           # WOLFI_BASE stays tag-only because Chainguard's continuous-CVE
           # patching model recommends `:latest`.
-          NODE_BASE: docker.io/library/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104
+          NODE_BASE: docker.io/library/node:22-slim@sha256:868499d55378719bffa87b0ed1f099591823c029b543043c09c2483468e93201
           WOLFI_BASE: cgr.dev/chainguard/wolfi-base:latest
         run: |
           # Step 2 — seed required secrets


### PR DESCRIPTION
## Summary

Three regressions from the recent CI-fix wave became visible in the post-merge runs:

| Workflow | Failure | Root cause |
|----------|---------|------------|
| **CI** (Docker build job, run 25612860596) | \`docker.io/library/node:22-slim@sha256:aa8ccf90...: not found\` | I pinned the homelab mirror's digest, not Docker Hub's |
| **Install Smoke** (will fail next nightly) | Same as above (same env var) | Same |
| **Publish dev container image** (run 25612612168) | \`docker-compose-linux-x86_64: 404\` for v2.41.0 | docker/compose has versioned to v5.x line — v2.41.0 doesn't exist |

## Fixes

### 1. NODE_BASE digest

\`aa8ccf90...\` is the digest of the homelab mirror's stored manifest at \`192.168.178.250:5000\`. Pushing to a private registry re-encodes the manifest → digest differs from Docker Hub. Looked up Docker Hub's actual current digest for \`node:22-slim\` linux/amd64:

\`\`\`
sha256:868499d55378719bffa87b0ed1f099591823c029b543043c09c2483468e93201
\`\`\`

(Verified via \`https://registry-1.docker.io/v2/library/node/manifests/22-slim\` HEAD).

### 2. Docker Compose version

\`docker/compose\` released the v5.x line. v2.41.0 doesn't exist on GitHub releases. Latest stable plugin binary as of 2026-05-10 is **v5.1.3**.

## Risk

Low — pure version/digest corrections. Local dev + Gitea-internal builds remain on the homelab mirror (Dockerfile defaults unchanged).

## Test plan

- [ ] CI Docker build step succeeds on this PR
- [ ] After merge, scheduled Install Smoke + Publish dev container image both green on next run