### PR TITLE
fix(openapi): sync php.json maxLength for iCal import (#474 followup)

### DIFF
--- a/docs/openapi/php.json
+++ b/docs/openapi/php.json
@@ -1304,7 +1304,7 @@
         "description": "Accepts iCal payloads either as a multipart file upload or a raw string\nbody. Rules are conditional on the transport so callers can use whichever\nshape fits their client without us routing to two separate endpoints.",
         "properties": {
           "ical": {
-            "maxLength": 1048576,
+            "maxLength": 262144,
             "type": "string"
           }
         },


### PR DESCRIPTION
## Summary

Fixes the OpenAPI drift gate failure on main after #474 merged. My iCal payload-cap change (M-2 audit) updated the validator but the committed snapshot still showed the old 1 MiB max, so the post-merge drift run was guaranteed to fail.

\`\`\`diff
-            "maxLength": 1048576,
+            "maxLength": 262144,
\`\`\`

One-line precise patch matching the diff CI surfaced.