### PR TITLE
fix(security): tighter absolute-session cap for admins (audit L-3)

### DIFF
--- a/app/Http/Middleware/EnforceAbsoluteSessionLifetime.php
+++ b/app/Http/Middleware/EnforceAbsoluteSessionLifetime.php
@@ -39,7 +39,17 @@ class EnforceAbsoluteSessionLifetime
             return $next($request);
         }
 
-        $absoluteLifetimeMinutes = (int) config('session.absolute_lifetime', 1440);
+        // Default cap is 24h (1440 min). Admin sessions get a tighter
+        // 12h cap (720 min) per OWASP ASVS 3.3.2 + audit L-3 — admin
+        // privileges merit a more aggressive re-auth interval.
+        // Override via env: SESSION_ABSOLUTE_LIFETIME (default cap),
+        // SESSION_ABSOLUTE_LIFETIME_ADMIN (admin-specific cap).
+        $defaultMinutes = (int) config('session.absolute_lifetime', 1440);
+        $adminMinutes = (int) config('session.absolute_lifetime_admin', 720);
+        $isAdmin = method_exists($user, 'hasRole')
+            ? ((bool) $user->hasRole('admin') || (bool) $user->hasRole('superadmin'))
+            : (in_array($user->role ?? null, ['admin', 'superadmin'], true));
+        $absoluteLifetimeMinutes = $isAdmin ? $adminMinutes : $defaultMinutes;
         $absoluteLifetimeSeconds = $absoluteLifetimeMinutes * 60;
 
         $session = $request->session();

--- a/config/session.php
+++ b/config/session.php
@@ -53,6 +53,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Admin-Session Absolute Lifetime
+    |--------------------------------------------------------------------------
+    |
+    | OWASP ASVS 3.3.2 recommends a tighter cap for sensitive admin sessions
+    | than for end-user sessions. Default: 720 minutes (12h) per audit L-3.
+    | Override via SESSION_ABSOLUTE_LIFETIME_ADMIN env var.
+    |
+    | Applied by EnforceAbsoluteSessionLifetime middleware when the
+    | authenticated user has admin/superadmin role.
+    |
+    */
+
+    'absolute_lifetime_admin' => (int) env('SESSION_ABSOLUTE_LIFETIME_ADMIN', 720),
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Encryption
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Closes audit L-3. Admins get 12h cap (default 720 min); regular users keep 24h. Role-aware split per OWASP ASVS 3.3.2 recommendation. Override via SESSION_ABSOLUTE_LIFETIME_ADMIN env var.