### PR TITLE
fix(ci): install composer deps before design smoke

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -491,6 +491,10 @@ if (( diff_touch_frontend || diff_touch_e2e )); then
   run_step "frontend build" "cd parkhub-web && CI=true npm run build && cd .. && CI=true npm run build"
 
   if (( diff_touch_design_smoke )); then
+    # The design-smoke harness boots Laravel even for frontend-only diffs.
+    # Clean Dependabot worktrees may not have vendor/ when PHP gates are
+    # diff-skipped, so ensure Composer deps exist before scripts/e2e-local.sh.
+    run_step "composer install for Laravel design smoke" "if [[ -f vendor/autoload.php ]]; then echo 'vendor/autoload.php already present'; else composer install --prefer-dist --no-interaction --no-progress; fi"
     run_step_heavy "frontend route + v5 design smoke" "npm run test:e2e:design-smoke"
   else
     skip_step "frontend route + v5 design smoke" "diff-aware: no route/design/e2e files touched"

--- a/scripts/tests/test-fop-local-ci-ergonomics.sh
+++ b/scripts/tests/test-fop-local-ci-ergonomics.sh
@@ -70,6 +70,22 @@ fi
 
 green "    OK"
 
+echo "==> fop-local-ci pr dry-run prepares Composer deps before design smoke"
+FOP_LOCAL_CI_DIFF_PATHS=$'package-lock.json\nparkhub-web/package-lock.json' \
+    .github/scripts/fop-local-ci.sh --profile pr --dry-run >"$tmp_dir/design-smoke-dry-run" 2>&1
+
+for pattern in \
+    'composer install for Laravel design smoke' \
+    'frontend route \+ v5 design smoke'; do
+    if ! grep -Eq "$pattern" "$tmp_dir/design-smoke-dry-run"; then
+        red "    FAILED: design-smoke dry-run output missing pattern: $pattern"
+        cat "$tmp_dir/design-smoke-dry-run"
+        exit 1
+    fi
+done
+
+green "    OK"
+
 echo "==> fop-local-ci background mode returns a PID and writes a log"
 FOP_LOCAL_CI_BG_LOG_DIR="$tmp_dir/bg" \
 FOP_LOCAL_CI_DIFF_PATHS=$'docs/parkhub-notes.md' \


### PR DESCRIPTION
Root cause: diff-aware local CI skipped composer install for FE-only PRs, so scripts/e2e-local.sh could boot Laravel without vendor/autoload.php.\n\nFix: ensure Composer dependencies are installed before design smoke in .github/scripts/fop-local-ci.sh, with a focused ergonomics contract in scripts/tests/test-fop-local-ci-ergonomics.sh.\n\nPrior verification recorded in the T-6043 handoff: fop build --backend local interactive-small, bash scripts/tests/test-fop-local-ci-ergonomics.sh, and make ci via the normal pre-push gate. This turn re-verified the branch diff, remote branch, and whitespace with git diff --check; host guard is yellow, so I did not duplicate the heavy local CI run.\n\nUnblocks: T-6043 / Dependabot batch PRs #478, #479, #480, #481, and #482.