### PR TITLE
ci(nightly): install only needed Playwright browser

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -182,10 +182,25 @@ jobs:
           npm ci --prefix parkhub-web
 
       - name: Install Playwright browsers
+        env:
+          MATRIX_PROJECT: ${{ matrix.project }}
         run: |
-          CI_TIMEOUT_LABEL="Install Playwright browsers for nightly E2E" \
-            bash scripts/ci/run-with-timeout.sh 12m \
-              npx --no-install playwright install --with-deps chromium webkit
+          case "${MATRIX_PROJECT}" in
+            chromium|mobile-chrome)
+              playwright_browser=chromium
+              ;;
+            mobile-safari)
+              playwright_browser=webkit
+              ;;
+            *)
+              echo "Unsupported Playwright project: ${MATRIX_PROJECT}" >&2
+              exit 2
+              ;;
+          esac
+
+          CI_TIMEOUT_LABEL="Install Playwright ${playwright_browser} for nightly E2E" \
+            bash scripts/ci/run-with-timeout.sh 20m \
+              npx --no-install playwright install --with-deps "${playwright_browser}"
 
       - name: Build browser assets for Laravel
         run: npm run build:php --prefix parkhub-web


### PR DESCRIPTION
## Summary
- install only the Playwright browser required by each Nightly Assurance matrix project
- keep Chromium for chromium/mobile-chrome shards and WebKit for mobile-safari shards
- increase the browser-install timeout to 20m for slower hosted runners while reducing unnecessary browser work

## Verification
- fop guard preflight --json: ok/yellow, no active builds or orphans
- fop queue status: idle before local gate
- actionlint .github/workflows/nightly.yml
- git diff --check
- fop build --backend local . --resource-profile interactive-small --preset custom -- make ci

Unblocks part of T-6048. Latest failed scheduled Nightly Assurance was run 25653683212 on 12637c490ba9d44c5696cb0992d68c8507b15fad; two PHP shards timed out installing both Chromium and WebKit even though each shard runs one Playwright project.