### PR TITLE
fix(e2e): align nightly origin for v5 tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -210,6 +210,9 @@ jobs:
           CI: true
           DB_CONNECTION: sqlite
           DB_DATABASE: database/database.sqlite
+          APP_URL: http://127.0.0.1:8082
+          APP_EXTRA_ALLOWED_ORIGINS: http://127.0.0.1:8082,http://localhost:8082
+          SANCTUM_STATEFUL_DOMAINS: 127.0.0.1,127.0.0.1:8082,localhost,localhost:8082
           # File-based cache / session. The default SQLite-backed cache
           # store locks under concurrent requests (Playwright fires
           # dozens of parallel requests per test) and every

--- a/e2e/v5-helpers.ts
+++ b/e2e/v5-helpers.ts
@@ -92,6 +92,29 @@ export function v5ScreenTitle(page: Page) {
   return page.getByTestId('v5-screen-title');
 }
 
+async function pinRemoteV5Mode(page: Page, mode: V5Mode): Promise<void> {
+  await page.unroute('**/api/v1/me/settings').catch(() => {
+    /* no prior route */
+  });
+  await page.route('**/api/v1/me/settings', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: {
+          appearance: { mode },
+        },
+      }),
+    });
+  });
+}
+
 /**
  * Pre-seed localStorage so the v5 shell boots already on the target
  * screen + mode, then navigate to `/v5/index.html` and wait for the
@@ -102,6 +125,7 @@ export async function openV5(
   screen: V5Screen,
   mode: V5Mode = 'marble_light',
 ): Promise<void> {
+  await pinRemoteV5Mode(page, mode);
   await page.addInitScript(
     ([s, m]) => {
       try {


### PR DESCRIPTION
Root cause: PHP Nightly serves Laravel on http://127.0.0.1:8082 while the app config still defaulted APP_URL to localhost:8080, leaving WebKit/mobile-safari with inconsistent CSP/origin state. v5 visual tests also preseeded localStorage mode, but remote /api/v1/me/settings hydration could overwrite the requested mode and make void screenshots compare against the wrong UI. Fix: pin Nightly APP_URL/CORS/Sanctum domains to the E2E origin and have openV5() fulfill GET /api/v1/me/settings with the requested appearance mode during v5 tests. Verified: actionlint .github/workflows/nightly.yml; git diff --check; make ci. Unblocks: T-6048 / PHP Nightly Assurance.