### PR TITLE
fix(e2e): serve static assets with isolation headers

### DIFF
--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -32,7 +32,7 @@ echo "== bootstrap Laravel =="
 php artisan migrate:fresh --seed --seeder=ProductionSimulationSeeder --force
 
 echo "== start Laravel app on ${E2E_BASE_URL} =="
-php artisan serve --host="${SERVER_HOST}" --port="${SERVER_PORT}" > "${SERVER_LOG}" 2>&1 &
+php -S "${SERVER_HOST}:${SERVER_PORT}" -t public scripts/e2e-router.php > "${SERVER_LOG}" 2>&1 &
 SERVER_PID=$!
 cleanup() {
   kill "${SERVER_PID}" 2>/dev/null || true

--- a/scripts/e2e-router.php
+++ b/scripts/e2e-router.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+$publicRoot = realpath(__DIR__.'/../public');
+
+if ($publicRoot === false) {
+    http_response_code(500);
+    echo 'public root missing';
+
+    return true;
+}
+
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+$decodedPath = rawurldecode($path);
+$candidate = realpath($publicRoot.$decodedPath);
+
+function parkhub_e2e_content_type(string $extension): string
+{
+    return match ($extension) {
+        'css' => 'text/css; charset=UTF-8',
+        'js', 'mjs' => 'application/javascript; charset=UTF-8',
+        'json', 'map' => 'application/json; charset=UTF-8',
+        'html', 'htm' => 'text/html; charset=UTF-8',
+        'svg' => 'image/svg+xml',
+        'png' => 'image/png',
+        'jpg', 'jpeg' => 'image/jpeg',
+        'gif' => 'image/gif',
+        'webp' => 'image/webp',
+        'avif' => 'image/avif',
+        'ico' => 'image/x-icon',
+        'woff' => 'font/woff',
+        'woff2' => 'font/woff2',
+        'ttf' => 'font/ttf',
+        'eot' => 'application/vnd.ms-fontobject',
+        default => 'application/octet-stream',
+    };
+}
+
+function parkhub_e2e_is_public_asset(string $extension): bool
+{
+    return in_array($extension, [
+        'avif',
+        'css',
+        'eot',
+        'gif',
+        'ico',
+        'jpeg',
+        'jpg',
+        'js',
+        'map',
+        'mjs',
+        'png',
+        'svg',
+        'ttf',
+        'webp',
+        'woff',
+        'woff2',
+    ], true);
+}
+
+if (
+    $candidate !== false
+    && is_file($candidate)
+    && str_starts_with($candidate, $publicRoot.DIRECTORY_SEPARATOR)
+) {
+    $extension = strtolower(pathinfo($candidate, PATHINFO_EXTENSION));
+
+    header('X-Content-Type-Options: nosniff');
+    header('Cross-Origin-Opener-Policy: same-origin');
+    header('Cross-Origin-Embedder-Policy: credentialless');
+    header('Cross-Origin-Resource-Policy: '.(parkhub_e2e_is_public_asset($extension) ? 'cross-origin' : 'same-origin'));
+    header('Content-Type: '.parkhub_e2e_content_type($extension));
+
+    if (str_starts_with($decodedPath, '/_astro/')) {
+        header('Cache-Control: public, max-age=31536000, immutable');
+    }
+
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'HEAD') {
+        readfile($candidate);
+    }
+
+    return true;
+}
+
+require $publicRoot.'/index.php';
+
+return true;


### PR DESCRIPTION
Root cause: PHP Nightly uses the local PHP server, while v5 static HTML and Astro chunks live under public/ and bypass both Laravel SecurityHeaders and Apache .htaccess. WebKit/mobile-safari then reports access-control/module import errors during v5 smoke even though production Apache has static asset header handling. Fix: run E2E through a small PHP router that serves public files with COOP/COEP and CORP cross-origin for static assets, then falls back to Laravel for API/dynamic routes. Verified: php -l scripts/e2e-router.php; bash -n scripts/e2e-local.sh; git diff --check; local header probe showed /v5/index.html gets COOP/COEP/CORP same-origin and /_astro/*.js gets CORP cross-origin; focused Chromium v5 design smoke passed through scripts/e2e-local.sh; make ci passed and wrote local CI attestation. Local mobile-safari repro is blocked by missing local WebKit binary; GitHub Nightly has WebKit installed and is the required proof. Unblocks: T-6048 / PHP Nightly Assurance.