### PR TITLE
ci(nightly): use isolated asset router

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -236,7 +236,7 @@ jobs:
           # empty database and everything that walks a list 404s.
           php artisan migrate:fresh --seed --seeder=ProductionSimulationSeeder --force
 
-          php artisan serve --host=127.0.0.1 --port=8082 > "/tmp/parkhub-nightly-e2e-${MATRIX_PROJECT}-${MATRIX_SHARD}.log" 2>&1 &
+          php -S 127.0.0.1:8082 -t public scripts/e2e-router.php > "/tmp/parkhub-nightly-e2e-${MATRIX_PROJECT}-${MATRIX_SHARD}.log" 2>&1 &
           server_pid=$!
           trap 'kill "${server_pid}" 2>/dev/null || true' EXIT
 


### PR DESCRIPTION
Root cause: PR #486 added scripts/e2e-router.php so static assets get COOP/COEP/CORP headers, but Nightly Assurance still started php artisan serve directly. GitHub traces after #486 still showed _astro/*.js responses without the isolation headers, leaving mobile-safari shard 3 red with module import/access-control failures.\n\nFix: start the Nightly E2E server with php -S 127.0.0.1:8082 -t public scripts/e2e-router.php, matching the local e2e harness and preserving the same host/port/log/wait flow.\n\nVerification:\n- actionlint .github/workflows/nightly.yml\n- git diff --check HEAD~1 HEAD\n- php -l scripts/e2e-router.php\n- bash -n scripts/e2e-local.sh\n- fop build --backend local . --resource-profile interactive-small --preset custom -- make ci\n\nLocal CI report: .fop/reports/local-ci-pr-af0c5c6f6c8ec595b0c38cd21a65d83e9baff891.json\n\nUnblocks: T-6048 PHP Nightly Assurance. Note: chromium shard 4 visual snapshot diffs may remain as a separate parity/baseline closure item after mobile-safari asset loading is fixed.