### PR TITLE
Scope COEP to document responses

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -79,10 +79,6 @@ class SecurityHeaders
         }
 
         // --- Site isolation: COOP + COEP + CORP ---
-        // COOP same-origin prevents cross-origin windows from sharing a
-        // browsing context group (blocks window.opener attacks).
-        $response->headers->set('Cross-Origin-Opener-Policy', 'same-origin');
-
         // CORP `same-origin` is the right default for HTML/JSON responses,
         // but under COEP `credentialless` (set below) WebKit (Safari 18+,
         // mobile-safari Playwright) refuses to load module chunks like
@@ -120,15 +116,6 @@ class SecurityHeaders
             $isStaticAsset ? 'cross-origin' : 'same-origin',
         );
 
-        // COEP `credentialless` is the modern default (2026): it gives us
-        // crossOriginIsolated so we can use SharedArrayBuffer and high-res
-        // `performance.now()`, without forcing every embedded third-party
-        // resource to send CORP (`require-corp` would do that and break
-        // Stripe/Bunny/etc. in one step). Sub-resources are fetched without
-        // credentials and the server can't smuggle cookies into them.
-        // Safari shipped this in 16.4, Firefox in 110, Chromium in 96.
-        $response->headers->set('Cross-Origin-Embedder-Policy', 'credentialless');
-
         // --- Reporting-Endpoints + NEL ---
         // Reporting-Endpoints is the successor to Report-To (which is being
         // removed). The `csp` endpoint receives CSP violation reports; the
@@ -148,9 +135,25 @@ class SecurityHeaders
         );
 
         // --- Content-Security-Policy for the SPA ---
-        // Only apply CSP to HTML responses (not API JSON or static assets)
+        // Only apply document-level headers to HTML responses (not API JSON
+        // or static assets). WebKit reports same-origin JSON/module requests
+        // as access-control failures if those subresources also carry COEP,
+        // even though the document already has the isolation policy.
         $contentType = $response->headers->get('Content-Type', '');
         if (str_contains($contentType, 'text/html')) {
+            // COOP same-origin prevents cross-origin windows from sharing a
+            // browsing context group (blocks window.opener attacks).
+            $response->headers->set('Cross-Origin-Opener-Policy', 'same-origin');
+
+            // COEP `credentialless` is the modern default (2026): it gives us
+            // crossOriginIsolated so we can use SharedArrayBuffer and high-res
+            // `performance.now()`, without forcing every embedded third-party
+            // resource to send CORP (`require-corp` would do that and break
+            // Stripe/Bunny/etc. in one step). Sub-resources are fetched without
+            // credentials and the server can't smuggle cookies into them.
+            // Safari shipped this in 16.4, Firefox in 110, Chromium in 96.
+            $response->headers->set('Cross-Origin-Embedder-Policy', 'credentialless');
+
             $csp = $this->buildCsp($request, $nonce);
             $response->headers->set('Content-Security-Policy', $csp);
         }

--- a/scripts/e2e-router.php
+++ b/scripts/e2e-router.php
@@ -65,12 +65,16 @@ if (
     && str_starts_with($candidate, $publicRoot.DIRECTORY_SEPARATOR)
 ) {
     $extension = strtolower(pathinfo($candidate, PATHINFO_EXTENSION));
+    $isDocument = in_array($extension, ['html', 'htm'], true);
 
     header('X-Content-Type-Options: nosniff');
-    header('Cross-Origin-Opener-Policy: same-origin');
-    header('Cross-Origin-Embedder-Policy: credentialless');
     header('Cross-Origin-Resource-Policy: '.(parkhub_e2e_is_public_asset($extension) ? 'cross-origin' : 'same-origin'));
     header('Content-Type: '.parkhub_e2e_content_type($extension));
+
+    if ($isDocument) {
+        header('Cross-Origin-Opener-Policy: same-origin');
+        header('Cross-Origin-Embedder-Policy: credentialless');
+    }
 
     if (str_starts_with($decodedPath, '/_astro/')) {
         header('Cache-Control: public, max-age=31536000, immutable');

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -156,11 +156,14 @@ class SecurityHeadersTest extends TestCase
         // COEP credentialless lets us use crossOriginIsolated APIs
         // (SharedArrayBuffer, high-res performance.now()) without forcing
         // every embed to send CORP. It is document-level policy: HTML
-        // receives it, JSON subresources do not.
+        // receives it, JSON subresources do not. COOP is scoped the same
+        // way so API clients do not inherit document isolation policy.
         $html = $this->get('/');
+        $html->assertHeader('Cross-Origin-Opener-Policy', 'same-origin');
         $html->assertHeader('Cross-Origin-Embedder-Policy', 'credentialless');
 
         $json = $this->getJson('/api/v1/health');
+        $this->assertNull($json->headers->get('Cross-Origin-Opener-Policy'));
         $this->assertNull($json->headers->get('Cross-Origin-Embedder-Policy'));
     }
 }

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -151,15 +151,16 @@ class SecurityHeadersTest extends TestCase
         }
     }
 
-    public function test_coep_credentialless_set_globally(): void
+    public function test_coep_credentialless_set_on_html_documents_only(): void
     {
         // COEP credentialless lets us use crossOriginIsolated APIs
         // (SharedArrayBuffer, high-res performance.now()) without forcing
-        // every embed to send CORP. Asserted globally — same value on
-        // HTML, JSON, and asset paths.
-        foreach (['/api/v1/health', '/'] as $path) {
-            $response = $this->get($path);
-            $response->assertHeader('Cross-Origin-Embedder-Policy', 'credentialless');
-        }
+        // every embed to send CORP. It is document-level policy: HTML
+        // receives it, JSON subresources do not.
+        $html = $this->get('/');
+        $html->assertHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+
+        $json = $this->getJson('/api/v1/health');
+        $this->assertNull($json->headers->get('Cross-Origin-Embedder-Policy'));
     }
 }

--- a/tests/Feature/SecurityReportTest.php
+++ b/tests/Feature/SecurityReportTest.php
@@ -98,7 +98,7 @@ class SecurityReportTest extends TestCase
         $this->assertLessThanOrEqual(10, $successes, 'More than 10 requests slipped through the limiter');
     }
 
-    public function test_security_response_headers_include_reporting_endpoints_nel_coep(): void
+    public function test_security_response_headers_include_reporting_endpoints_and_nel(): void
     {
         $response = $this->getJson('/api/v1/health');
 
@@ -113,7 +113,7 @@ class SecurityReportTest extends TestCase
         $this->assertStringContainsString('"max_age":2592000', $nel);
         $this->assertStringContainsString('"include_subdomains":true', $nel);
 
-        $this->assertSame('credentialless', $response->headers->get('Cross-Origin-Embedder-Policy'));
+        $this->assertNull($response->headers->get('Cross-Origin-Embedder-Policy'));
     }
 
     public function test_audit_log_persists_full_payload(): void


### PR DESCRIPTION
## Summary
- scope Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy to HTML document responses only
- leave Cross-Origin-Resource-Policy on API and static subresources
- update security header feature tests to assert JSON responses no longer carry COEP

## Root cause
Post-PR #489 Nightly Assurance run 25697205824 fixed the legacy Chromium visual baseline shard. The remaining failure was only Full cross-browser E2E mobile-safari shard 3. Artifacts showed WebKit runtime guard errors for /api/v1/modules access-control checks and module script import failures even though the JSON response was 200. Trace headers showed API JSON and static JS were also carrying Cross-Origin-Embedder-Policy: credentialless.

## Verification
- env NO_COLOR=true make ci
- bash scripts/check-local-ci-report.sh pr
- git diff --check
- php -l app/Http/Middleware/SecurityHeaders.php
- php -l scripts/e2e-router.php
- php -l tests/Feature/SecurityHeadersTest.php
- php -l tests/Feature/SecurityReportTest.php
- local header probe: HTML keeps COOP/COEP; JS and /api/v1/modules do not

Local mobile-safari focused verification is blocked by a missing Playwright WebKit binary on this workstation: /var/tmp/florian-home-offload/xdg-cache/ms-playwright/webkit-2272/pw_run.sh. GitHub Nightly is the authoritative WebKit verifier for this fix.