### PR TITLE
feat: add OpenAPI alias tranche

### DIFF
--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -11,6 +11,7 @@ use App\Models\ParkingLot;
 use App\Models\Setting;
 use App\Services\ModuleRegistry;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\DB;
 
 class PublicController extends Controller
@@ -143,6 +144,28 @@ class PublicController extends Controller
         return response()->json(['status' => 'ok', 'version' => SystemController::appVersion()]);
     }
 
+    public function apiDocs(): RedirectResponse
+    {
+        return redirect('/docs/api');
+    }
+
+    public function openApiSpecification(): RedirectResponse
+    {
+        return redirect('/docs/api.json');
+    }
+
+    public function postmanCollection(): JsonResponse
+    {
+        $collection = json_decode(
+            file_get_contents(base_path('docs/postman/ParkHub.postman_collection.json')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        return response()->json($collection);
+    }
+
     public function updateCheck(): JsonResponse
     {
         return response()->json(['update_available' => false, 'current_version' => SystemController::appVersion()]);
@@ -206,7 +229,9 @@ class PublicController extends Controller
                 'endpoints' => [
                     'auth' => '/api/v1/auth/login',
                     'health' => '/api/v1/health',
-                    'docs' => '/docs/api',
+                    'docs' => '/api/v1/docs',
+                    'openapi' => '/api/v1/docs/openapi.json',
+                    'postman' => '/api/v1/docs/postman.json',
                 ],
             ],
             'error' => null,

--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -10,9 +10,12 @@ use App\Models\Booking;
 use App\Models\ParkingLot;
 use App\Models\Setting;
 use App\Services\ModuleRegistry;
+use Dedoc\Scramble\Attributes\Header;
+use Dedoc\Scramble\Attributes\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\DB;
+use JsonException;
 
 class PublicController extends Controller
 {
@@ -144,24 +147,67 @@ class PublicController extends Controller
         return response()->json(['status' => 'ok', 'version' => SystemController::appVersion()]);
     }
 
+    #[Header('Location', 'Scramble documentation UI URL.', type: 'string', status: 302, example: '/docs/api')]
+    #[Response(302, 'Redirects to the Scramble documentation UI.', mediaType: 'text/html', type: 'string')]
     public function apiDocs(): RedirectResponse
     {
+        /**
+         * @status 302
+         *
+         * @body string
+         */
         return redirect('/docs/api');
     }
 
+    #[Header('Location', 'Scramble OpenAPI JSON URL.', type: 'string', status: 302, example: '/docs/api.json')]
+    #[Response(302, 'Redirects to the Scramble OpenAPI JSON document.', mediaType: 'text/html', type: 'string')]
     public function openApiSpecification(): RedirectResponse
     {
+        /**
+         * @status 302
+         *
+         * @body string
+         */
         return redirect('/docs/api.json');
     }
 
+    #[Response(200, 'Postman collection JSON.', type: 'array{info: array, item: array}')]
+    #[Response(404, 'Postman collection asset not found.', type: 'array{error: string, message: string}')]
+    #[Response(500, 'Postman collection asset is unreadable or invalid.', type: 'array{error: string, message: string}')]
     public function postmanCollection(): JsonResponse
     {
-        $collection = json_decode(
-            file_get_contents(base_path('docs/postman/ParkHub.postman_collection.json')),
-            true,
-            512,
-            JSON_THROW_ON_ERROR,
-        );
+        $path = resource_path('docs/ParkHub.postman_collection.json');
+
+        if (! is_readable($path)) {
+            return response()->json([
+                'error' => 'DOCS_ASSET_NOT_FOUND',
+                'message' => 'Postman collection asset is not available.',
+            ], 404);
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            return response()->json([
+                'error' => 'DOCS_ASSET_UNREADABLE',
+                'message' => 'Postman collection asset could not be read.',
+            ], 500);
+        }
+
+        try {
+            $collection = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return response()->json([
+                'error' => 'DOCS_ASSET_INVALID',
+                'message' => 'Postman collection asset contains invalid JSON.',
+            ], 500);
+        }
+
+        if (! is_array($collection)) {
+            return response()->json([
+                'error' => 'DOCS_ASSET_INVALID',
+                'message' => 'Postman collection asset must be a JSON object.',
+            ], 500);
+        }
 
         return response()->json($collection);
     }

--- a/app/Http/Middleware/ApiResponseWrapper.php
+++ b/app/Http/Middleware/ApiResponseWrapper.php
@@ -14,6 +14,10 @@ class ApiResponseWrapper
     {
         $response = $next($request);
 
+        if ($request->is('api/v1/docs') || $request->is('api/v1/docs/*')) {
+            return $response;
+        }
+
         // Only wrap JSON responses from API routes
         if (! $request->is('api/*') || ! $response->headers->contains('Content-Type', 'application/json')) {
             // Try to detect JSON responses

--- a/docs/openapi-parity.md
+++ b/docs/openapi-parity.md
@@ -28,11 +28,13 @@ See also:
 
 Latest alias-tranche comparison from regenerated local OpenAPI dumps:
 
-- Rust input: `parkhub-rust` branch `t-parkhub-openapi-alias-tranche`
-  based on `github/main@24b763193130f1761d018893ed46334390cfd6ae`
+- Rust input: `parkhub-rust@65752756ea9c775abca0a317c0ff42ac4535891e`
+  on branch `t-parkhub-openapi-alias-tranche`, based on
+  `github/main@24b763193130f1761d018893ed46334390cfd6ae`
   (`docs/openapi/rust.json`)
-- PHP input: `parkhub-php` branch `t-parkhub-openapi-alias-tranche`
-  based on `github/main@83a132283550d80e4a0553495bd05daf25093f8b`
+- PHP input: `parkhub-php@63a7a5228039657938733538aa53a24b7cf0b352`
+  on branch `t-parkhub-openapi-alias-tranche`, based on
+  `github/main@83a132283550d80e4a0553495bd05daf25093f8b`
   (`docs/openapi/php.json`)
 
 | Source | Path count (normalised) |

--- a/docs/openapi-parity.md
+++ b/docs/openapi-parity.md
@@ -26,39 +26,43 @@ See also:
 
 ## Current parity (2026-05-12)
 
-Latest committed-dump comparison from `github/main`:
+Latest alias-tranche comparison from regenerated local OpenAPI dumps:
 
-- Rust input: `parkhub-rust@779eba97f8e6e8ff7e7b65cd1574bb04e4ae00e0`
+- Rust input: `parkhub-rust` branch `t-parkhub-openapi-alias-tranche`
+  based on `github/main@24b763193130f1761d018893ed46334390cfd6ae`
   (`docs/openapi/rust.json`)
-- PHP input: `parkhub-php@e0883df46d1b7c587b7798bddddbb3ae19f06cd8`
+- PHP input: `parkhub-php` branch `t-parkhub-openapi-alias-tranche`
+  based on `github/main@83a132283550d80e4a0553495bd05daf25093f8b`
   (`docs/openapi/php.json`)
 
 | Source | Path count (normalised) |
 |--------|-------------------------|
-| Rust (`utoipa`) | 233 |
-| PHP (Scramble) | 314 |
-| Shared | 201 |
-| Rust-only drift | 32 |
-| PHP-only drift | 113 |
-| Total drift | 145 |
+| Rust (`utoipa`) | 239 |
+| PHP (Scramble) | 318 |
+| Shared | 210 |
+| Rust-only drift | 29 |
+| PHP-only drift | 108 |
+| Total drift | 137 |
 
-The numbers above come from committed OpenAPI dumps, not grep/static route
-extractors. They still need a later live-server regeneration pass, but they are
-the current reviewable contract evidence on `github/main`.
+The numbers above come from regenerated OpenAPI dumps, not grep/static route
+extractors. This alias tranche reduced total drift from `145` to `137` by adding
+thin compatibility aliases for `login`, `register`, `refresh`,
+`auth/change-password`, `health/detailed`, `status`, and the public docs
+surfaces.
 
 Current drift clusters:
 
 | Cluster | Rust-only | PHP-only |
 |---|---:|---:|
-| Admin/reporting/settings | 12 | 35 |
-| Auth/profile aliases | 1 | 7 |
-| Booking/QR | 3 | 16 |
-| Demo/discovery/public | 0 | 6 |
-| Health/docs/status | 8 | 1 |
-| Import/export | 1 | 3 |
-| Payments/billing | 1 | 2 |
-| User/tenant/vehicle | 1 | 4 |
-| Other | 5 | 39 |
+| Admin/reporting/settings | 14 | 39 |
+| Auth/profile/setup aliases | 1 | 7 |
+| Booking/QR/calendar | 1 | 15 |
+| Health/docs/status | 5 | 3 |
+| Import/export | 1 | 4 |
+| Payments/billing/pricing | 4 | 1 |
+| Demo/discovery/public | 1 | 15 |
+| User/tenant/vehicle/notification | 2 | 12 |
+| Other | 0 | 12 |
 
 ## Methodology
 
@@ -107,8 +111,8 @@ for parity review.
 With the current committed snapshots and the input-specific normalisation in
 `scripts/diff-openapi.sh`, the parity diff is still materially open:
 
-- Rust-only paths: `32`
-- PHP-only paths: `113`
+- Rust-only paths: `29`
+- PHP-only paths: `108`
 
 That means parity is **not** currently “just static-extractor noise”. The
 remaining drift falls into four broad buckets:
@@ -125,9 +129,9 @@ extractor just didn't see them correctly.
 ### 2. Genuine Rust-only contract surfaces
 
 Rust still exposes paths the PHP contract does not currently publish, including
-top-level operational surfaces (`/status`, `/health/detailed`, docs endpoints),
-admin export/settings endpoints, booking QR under `/api/v1/bookings/{id}/qr`,
-and the Rust-style payments/config surface.
+top-level operational surfaces (`/status`, `/health*`, `/handshake`), admin
+export/settings endpoints, booking QR under `/api/v1/bookings/{id}/qr`, and the
+Rust-style payments/config surface.
 
 **Action**: close these in small batches instead of one mega-port:
 auth/profile/public aliases, health/docs surfaces, booking/payment aliases,
@@ -135,10 +139,9 @@ then admin/export/settings tails.
 
 ### 3. Genuine PHP-only contract surfaces
 
-PHP still publishes a substantially larger surface, including legacy public auth
-aliases (`/api/v1/login`, `/register`, `/refresh`), health/info aliases,
-demo/discovery endpoints, broader admin analytics/settings/reporting routes,
-and several booking/user convenience routes.
+PHP still publishes a substantially larger surface, including profile/setup
+aliases, demo/discovery endpoints, broader admin analytics/settings/reporting
+routes, and several booking/user convenience routes.
 
 **Action**: for each cluster decide whether it is
 (a) a missing Rust alias/annotation,
@@ -155,5 +158,7 @@ never appear in a real drift report.
 
 - **Truthful repo messaging**: README/AGENTS must say parity is tracked, not yet hard-enforced end-to-end.
 - **Real cross-repo CI gate**: current workflows check only self-snapshot drift; add a second-repo checkout and run `diff-openapi.sh` for real Rust-vs-PHP gating once the diff is smaller.
-- **Alias tranche**: eliminate the cheap path mismatches first (`login/register/refresh`, health/detail, QR/payment/config, import aliases).
+- **Alias tranche**: continue with the remaining cheap mismatches
+  (booking QR/payment/config, import aliases, profile/setup aliases) and classify
+  Rust top-level operational endpoints explicitly.
 - **Feature tranche**: close the remaining admin/reporting/demo/user feature gaps or explicitly classify intentional divergences.

--- a/docs/openapi/php.json
+++ b/docs/openapi/php.json
@@ -27307,18 +27307,28 @@
                               "type": "string"
                             },
                             "docs": {
-                              "const": "/docs/api",
+                              "const": "/api/v1/docs",
                               "type": "string"
                             },
                             "health": {
                               "const": "/api/v1/health",
+                              "type": "string"
+                            },
+                            "openapi": {
+                              "const": "/api/v1/docs/openapi.json",
+                              "type": "string"
+                            },
+                            "postman": {
+                              "const": "/api/v1/docs/postman.json",
                               "type": "string"
                             }
                           },
                           "required": [
                             "auth",
                             "health",
-                            "docs"
+                            "docs",
+                            "openapi",
+                            "postman"
                           ],
                           "type": "object"
                         },
@@ -27367,6 +27377,69 @@
           }
         },
         "summary": "GET /api/v1/discover\nHandshake/discovery endpoint — returns API version, capabilities, and available modules",
+        "tags": [
+          "Public"
+        ]
+      }
+    },
+    "/v1/docs": {
+      "get": {
+        "operationId": "v1.docs",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Public"
+        ]
+      }
+    },
+    "/v1/docs/openapi.json": {
+      "get": {
+        "operationId": "v1.docs.openapi",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Public"
+        ]
+      }
+    },
+    "/v1/docs/postman.json": {
+      "get": {
+        "operationId": "v1.docs.postman",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "description": ""
+          }
+        },
         "tags": [
           "Public"
         ]
@@ -35366,6 +35439,39 @@
         "summary": "Get current SSE connection status info",
         "tags": [
           "Sse"
+        ]
+      }
+    },
+    "/v1/status": {
+      "get": {
+        "operationId": "v1.status",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "status": {
+                      "const": "ok",
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "version"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "Public"
         ]
       }
     },

--- a/docs/openapi/php.json
+++ b/docs/openapi/php.json
@@ -27386,15 +27386,29 @@
       "get": {
         "operationId": "v1.docs",
         "responses": {
-          "200": {
+          "302": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "string"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "description": ""
+            "description": "Redirects to the Scramble documentation UI.",
+            "headers": {
+              "Location": {
+                "description": "Scramble documentation UI URL.",
+                "example": "/docs/api",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -27406,15 +27420,29 @@
       "get": {
         "operationId": "v1.docs.openapi",
         "responses": {
-          "200": {
+          "302": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "string"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "description": ""
+            "description": "Redirects to the Scramble OpenAPI JSON document.",
+            "headers": {
+              "Location": {
+                "description": "Scramble OpenAPI JSON URL.",
+                "example": "/docs/api.json",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -27430,14 +27458,69 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": [
-                    "object",
-                    "null"
-                  ]
+                  "properties": {
+                    "info": {
+                      "items": {},
+                      "type": "array"
+                    },
+                    "item": {
+                      "items": {},
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "info",
+                    "item"
+                  ],
+                  "type": "object"
                 }
               }
             },
-            "description": ""
+            "description": "Postman collection JSON."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Postman collection asset not found."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Postman collection asset is unreadable or invalid."
           }
         },
         "tags": [

--- a/resources/docs/ParkHub.postman_collection.json
+++ b/resources/docs/ParkHub.postman_collection.json
@@ -1,0 +1,1161 @@
+{
+  "info": {
+    "name": "ParkHub API",
+    "description": "Complete API collection for ParkHub — self-hosted parking management.\n\nSet the `base_url` and `token` environment variables before use.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_postman_id": "parkhub-collection-v1"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    { "key": "base_url", "value": "http://localhost:8080" },
+    { "key": "token", "value": "" }
+  ],
+  "item": [
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "Health Check",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/health",
+            "auth": { "type": "noauth" }
+          }
+        },
+        {
+          "name": "Liveness Probe",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/health/live",
+            "auth": { "type": "noauth" }
+          }
+        },
+        {
+          "name": "Readiness Probe",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/health/ready",
+            "auth": { "type": "noauth" }
+          }
+        },
+        {
+          "name": "Detailed Health",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/health/detailed",
+            "auth": { "type": "noauth" }
+          }
+        },
+        {
+          "name": "Server Status",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/status",
+            "auth": { "type": "noauth" }
+          }
+        },
+        {
+          "name": "Module Features",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/modules",
+            "auth": { "type": "noauth" }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "  var json = pm.response.json();",
+                  "  var token = json.token || json.access_token;",
+                  "  if (token) pm.environment.set('token', token);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/auth/login",
+            "auth": { "type": "noauth" },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{admin_email}}\",\n  \"password\": \"{{admin_password}}\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Register",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/auth/register",
+            "auth": { "type": "noauth" },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"newuser@example.com\",\n  \"password\": \"securePassword123\",\n  \"name\": \"New User\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Logout",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/auth/logout"
+          }
+        },
+        {
+          "name": "Refresh Token",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/auth/refresh"
+          }
+        },
+        {
+          "name": "Forgot Password",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/auth/forgot-password",
+            "auth": { "type": "noauth" },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"user@example.com\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Reset Password",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/auth/reset-password",
+            "auth": { "type": "noauth" },
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"token\": \"reset-token-here\",\n  \"new_password\": \"newSecurePassword\"\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Users",
+      "item": [
+        {
+          "name": "Get Current User",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/me"
+          }
+        },
+        {
+          "name": "Update Current User",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/me",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Updated Name\",\n  \"department\": \"Engineering\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Change Password",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/me/password",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"current_password\": \"oldPassword\",\n  \"new_password\": \"newPassword123\"\n}"
+            }
+          }
+        },
+        {
+          "name": "User Stats",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/me/stats"
+          }
+        },
+        {
+          "name": "Get Preferences",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/me/preferences"
+          }
+        },
+        {
+          "name": "Update Preferences",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/me/preferences",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"language\": \"de\",\n  \"theme\": \"dark\",\n  \"notifications_enabled\": true\n}"
+            }
+          }
+        },
+        {
+          "name": "GDPR Export Data",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/me/gdpr/export"
+          }
+        },
+        {
+          "name": "GDPR Delete Account",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/me/gdpr/delete"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Bookings",
+      "item": [
+        {
+          "name": "List Bookings",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/bookings"
+          }
+        },
+        {
+          "name": "Create Booking",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/bookings",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"lot_id\": \"{{lot_id}}\",\n  \"date\": \"2026-04-01\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Get Booking",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/bookings/{{booking_id}}"
+          }
+        },
+        {
+          "name": "Update Booking",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/bookings/{{booking_id}}",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"date\": \"2026-04-02\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Cancel Booking",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/bookings/{{booking_id}}"
+          }
+        },
+        {
+          "name": "Check In",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/bookings/{{booking_id}}/checkin"
+          }
+        },
+        {
+          "name": "Quick Book",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/bookings/quick"
+          }
+        },
+        {
+          "name": "Reschedule (Drag)",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/bookings/{{booking_id}}/reschedule",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"new_date\": \"2026-04-05\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Booking History",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/bookings/history"
+          }
+        },
+        {
+          "name": "Booking Stats",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/bookings/stats"
+          }
+        },
+        {
+          "name": "Booking Invoice",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/bookings/{{booking_id}}/invoice"
+          }
+        },
+        {
+          "name": "Booking QR Code",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/bookings/{{booking_id}}/qr"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Lots",
+      "item": [
+        {
+          "name": "List Lots",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/lots"
+          }
+        },
+        {
+          "name": "Get Lot",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}"
+          }
+        },
+        {
+          "name": "Get Lot Slots",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/slots"
+          }
+        },
+        {
+          "name": "Get Lot Pricing",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/pricing"
+          }
+        },
+        {
+          "name": "Public Occupancy",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/public/occupancy",
+            "auth": { "type": "noauth" }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Vehicles",
+      "item": [
+        {
+          "name": "List Vehicles",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/vehicles"
+          }
+        },
+        {
+          "name": "Create Vehicle",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/vehicles",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"plate\": \"M-AB 1234\",\n  \"make\": \"BMW\",\n  \"model\": \"i4\",\n  \"color\": \"blue\",\n  \"is_electric\": true\n}"
+            }
+          }
+        },
+        {
+          "name": "Update Vehicle",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/vehicles/{{vehicle_id}}",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"plate\": \"M-CD 5678\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Delete Vehicle",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/vehicles/{{vehicle_id}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Credits",
+      "item": [
+        {
+          "name": "Get Credits",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/credits"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Favorites",
+      "item": [
+        {
+          "name": "List Favorites",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/favorites"
+          }
+        },
+        {
+          "name": "Add Favorite",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/favorites",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"slot_id\": \"slot-uuid-here\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Remove Favorite",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/favorites/{{slot_id}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Notifications",
+      "item": [
+        {
+          "name": "List Notifications",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/notifications"
+          }
+        },
+        {
+          "name": "Mark Read",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/notifications/{{notification_id}}/read"
+          }
+        },
+        {
+          "name": "Mark All Read",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/notifications/read-all"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Absences",
+      "item": [
+        {
+          "name": "List Absences",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/absences"
+          }
+        },
+        {
+          "name": "Create Absence",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/absences",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"date\": \"2026-04-01\",\n  \"type\": \"homeoffice\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Update Absence",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/absences/{{absence_id}}",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"vacation\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Delete Absence",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/absences/{{absence_id}}"
+          }
+        },
+        {
+          "name": "Submit Absence Request",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/absences/requests",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"start_date\": \"2026-04-01\",\n  \"end_date\": \"2026-04-05\",\n  \"type\": \"vacation\",\n  \"reason\": \"Family holiday\"\n}"
+            }
+          }
+        },
+        {
+          "name": "My Absence Requests",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/absences/my"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Calendar",
+      "item": [
+        {
+          "name": "Calendar Events",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/calendar/events"
+          }
+        },
+        {
+          "name": "iCal Export",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/calendar/ical"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Waitlist",
+      "item": [
+        {
+          "name": "Join Waitlist",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/waitlist/subscribe",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"date\": \"2026-04-01\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Get Waitlist",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/waitlist"
+          }
+        },
+        {
+          "name": "Leave Waitlist",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/waitlist"
+          }
+        },
+        {
+          "name": "Accept Offer",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/waitlist/accept"
+          }
+        },
+        {
+          "name": "Decline Offer",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/waitlist/decline"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Parking Pass",
+      "item": [
+        {
+          "name": "Get Booking Pass",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/bookings/{{booking_id}}/pass"
+          }
+        },
+        {
+          "name": "My Passes",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/me/passes"
+          }
+        },
+        {
+          "name": "Verify Pass (Public)",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/pass/verify/{{pass_code}}",
+            "auth": { "type": "noauth" }
+          }
+        }
+      ]
+    },
+    {
+      "name": "EV Charging",
+      "item": [
+        {
+          "name": "List Lot Chargers",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/chargers"
+          }
+        },
+        {
+          "name": "Start Charging",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/chargers/{{charger_id}}/start"
+          }
+        },
+        {
+          "name": "Stop Charging",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/chargers/{{charger_id}}/stop"
+          }
+        },
+        {
+          "name": "Charging History",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/chargers/sessions"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Geofence",
+      "item": [
+        {
+          "name": "Check In (GPS)",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/geofence/check-in",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"latitude\": 48.1351,\n  \"longitude\": 11.5820\n}"
+            }
+          }
+        },
+        {
+          "name": "Get Lot Geofence",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/lots/{{lot_id}}/geofence"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Recommendations",
+      "item": [
+        {
+          "name": "Get Recommendations",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/recommendations"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Visitors",
+      "item": [
+        {
+          "name": "Register Visitor",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/visitors/register",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"john@example.com\",\n  \"vehicle_plate\": \"M-AB 1234\",\n  \"visit_date\": \"2026-04-01\"\n}"
+            }
+          }
+        },
+        {
+          "name": "My Visitors",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/visitors"
+          }
+        },
+        {
+          "name": "Check In Visitor",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/visitors/{{visitor_id}}/check-in"
+          }
+        },
+        {
+          "name": "Cancel Visitor",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/visitors/{{visitor_id}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Webhooks",
+      "item": [
+        {
+          "name": "List Webhooks",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/webhooks"
+          }
+        },
+        {
+          "name": "Create Webhook",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/webhooks",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"url\": \"https://example.com/webhook\",\n  \"events\": [\"booking.created\", \"booking.cancelled\"]\n}"
+            }
+          }
+        },
+        {
+          "name": "Update Webhook",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/webhooks/{{webhook_id}}",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"url\": \"https://example.com/webhook-v2\",\n  \"events\": [\"booking.created\"]\n}"
+            }
+          }
+        },
+        {
+          "name": "Delete Webhook",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/webhooks/{{webhook_id}}"
+          }
+        },
+        {
+          "name": "Test Webhook",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/webhooks/{{webhook_id}}/test"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin",
+      "item": [
+        {
+          "name": "List Users",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/users"
+          }
+        },
+        {
+          "name": "Update User",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/admin/users/{{user_id}}",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Updated User\",\n  \"role\": \"premium\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Delete User",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/admin/users/{{user_id}}"
+          }
+        },
+        {
+          "name": "Update User Role",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/admin/users/{{user_id}}/role",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"role\": \"admin\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Admin Stats",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/stats"
+          }
+        },
+        {
+          "name": "Admin Bookings",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/bookings"
+          }
+        },
+        {
+          "name": "Admin Reports",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/reports"
+          }
+        },
+        {
+          "name": "Admin Heatmap",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/heatmap"
+          }
+        },
+        {
+          "name": "Admin Analytics",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/analytics"
+          }
+        },
+        {
+          "name": "Audit Log",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/audit-log"
+          }
+        },
+        {
+          "name": "Audit Log Export",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/audit-log/export"
+          }
+        },
+        {
+          "name": "Pending Absences",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/absences/pending"
+          }
+        },
+        {
+          "name": "Approve Absence",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/admin/absences/{{absence_id}}/approve"
+          }
+        },
+        {
+          "name": "Reject Absence",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/admin/absences/{{absence_id}}/reject"
+          }
+        },
+        {
+          "name": "Create Lot",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/admin/lots",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Tiefgarage A\",\n  \"address\": \"Musterstr. 1\",\n  \"total_slots\": 50\n}"
+            }
+          }
+        },
+        {
+          "name": "Update Lot",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/admin/lots/{{lot_id}}",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Tiefgarage B\",\n  \"total_slots\": 60\n}"
+            }
+          }
+        },
+        {
+          "name": "Delete Lot",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/v1/admin/lots/{{lot_id}}"
+          }
+        },
+        {
+          "name": "Admin Visitors",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/visitors"
+          }
+        },
+        {
+          "name": "Admin Chargers",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/chargers"
+          }
+        },
+        {
+          "name": "Add Charger",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/admin/chargers",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"lot_id\": \"{{lot_id}}\",\n  \"connector_type\": \"Type2\",\n  \"max_power_kw\": 22.0\n}"
+            }
+          }
+        },
+        {
+          "name": "Grant Credits",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/v1/admin/credits/grant",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"user_id\": \"{{user_id}}\",\n  \"amount\": 10,\n  \"reason\": \"Monthly allocation\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Export Users CSV",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/export/users"
+          }
+        },
+        {
+          "name": "Export Bookings CSV",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/export/bookings"
+          }
+        },
+        {
+          "name": "Export Revenue CSV",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/export/revenue"
+          }
+        },
+        {
+          "name": "Widget Layout",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/widgets"
+          }
+        },
+        {
+          "name": "Save Widget Layout",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/admin/widgets",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"widgets\": [\"occupancy_chart\", \"revenue_summary\", \"recent_bookings\"]\n}"
+            }
+          }
+        },
+        {
+          "name": "Widget Data",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/widgets/data/occupancy_chart"
+          }
+        },
+        {
+          "name": "Settings",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/settings"
+          }
+        },
+        {
+          "name": "Update Settings",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/admin/settings",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"auto_release_enabled\": true,\n  \"auto_release_minutes\": 30\n}"
+            }
+          }
+        },
+        {
+          "name": "Features",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/admin/features"
+          }
+        },
+        {
+          "name": "Update Features",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/v1/admin/features",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"mod-ev-charging\": true,\n  \"mod-visitors\": false\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Documentation",
+      "item": [
+        {
+          "name": "Swagger UI",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/docs",
+            "auth": { "type": "noauth" }
+          }
+        },
+        {
+          "name": "OpenAPI Spec",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/docs/openapi.json",
+            "auth": { "type": "noauth" }
+          }
+        },
+        {
+          "name": "Postman Collection",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/v1/docs/postman.json",
+            "auth": { "type": "noauth" }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -63,11 +63,17 @@ Route::prefix('demo')->group(function () {
 });
 
 // Health (no auth)
+Route::get('/status', [PublicController::class, 'healthCheck'])->name('api.v1.status');
 Route::get('/health', [PublicController::class, 'healthCheck']);
 Route::get('/health/live', [HealthController::class, 'live']);
 Route::get('/health/ready', [HealthController::class, 'ready']);
 Route::get('/health/info', [HealthController::class, 'info']);
 Route::get('/health/detailed', [HealthController::class, 'info']);
+
+// API docs/spec aliases (no auth)
+Route::get('/docs', [PublicController::class, 'apiDocs'])->name('api.v1.docs');
+Route::get('/docs/openapi.json', [PublicController::class, 'openApiSpecification'])->name('api.v1.docs.openapi');
+Route::get('/docs/postman.json', [PublicController::class, 'postmanCollection'])->name('api.v1.docs.postman');
 
 // System (public)
 Route::get('/system/version', [SystemController::class, 'version']);

--- a/tests/Feature/ApiDocsTest.php
+++ b/tests/Feature/ApiDocsTest.php
@@ -30,6 +30,26 @@ class ApiDocsTest extends TestCase
             "Expected 200/301/302 but got {$status}");
     }
 
+    public function test_api_v1_docs_alias_redirects_to_scramble_docs(): void
+    {
+        $this->get('/api/v1/docs')
+            ->assertRedirect('/docs/api');
+    }
+
+    public function test_api_v1_openapi_alias_redirects_to_scramble_json(): void
+    {
+        $this->get('/api/v1/docs/openapi.json')
+            ->assertRedirect('/docs/api.json');
+    }
+
+    public function test_api_v1_postman_alias_serves_collection(): void
+    {
+        $response = $this->get('/api/v1/docs/postman.json');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('info._postman_id', 'parkhub-collection-v1');
+    }
+
     public function test_api_docs_module_is_enabled(): void
     {
         $this->assertTrue(

--- a/tests/Feature/ApiDocsTest.php
+++ b/tests/Feature/ApiDocsTest.php
@@ -50,6 +50,11 @@ class ApiDocsTest extends TestCase
             ->assertJsonPath('info._postman_id', 'parkhub-collection-v1');
     }
 
+    public function test_api_v1_postman_alias_uses_runtime_included_asset(): void
+    {
+        $this->assertFileExists(resource_path('docs/ParkHub.postman_collection.json'));
+    }
+
     public function test_api_docs_module_is_enabled(): void
     {
         $this->assertTrue(

--- a/tests/Feature/HealthTest.php
+++ b/tests/Feature/HealthTest.php
@@ -35,6 +35,14 @@ class HealthTest extends TestCase
             ->assertJsonPath('data.status', 'ok');
     }
 
+    public function test_status_alias_matches_health_contract(): void
+    {
+        $response = $this->getJson('/api/v1/status');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.status', 'ok');
+    }
+
     public function test_health_endpoints_require_no_auth(): void
     {
         // All health endpoints must work without authentication


### PR DESCRIPTION
## Summary
- add PHP compatibility aliases for /api/v1/docs, docs/openapi.json, docs/postman.json, and status
- skip response wrapping for API docs artifacts so redirects/raw docs stay contract-compatible
- regenerate docs/openapi/php.json and update parity docs with the alias-tranche totals for T-6061

## Verification
- php -l on touched PHP files
- git diff --check
- focused ApiDocsTest and HealthTest
- make ci-post passed and wrote .fop/reports/local-ci-pr-63a7a5228039657938733538aa53a24b7cf0b352.json
- normal pre-push hook passed on retry after the local CI report existed