### PR TITLE
chore(ci): tighten cosign identity regex + dedupe SPDX deny-list via composite action

### DIFF
--- a/.github/actions/dependency-review/action.yml
+++ b/.github/actions/dependency-review/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Review dependencies
-      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+      uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4 (repo allow-listed SHA)
       # Advisory until GitHub Dependency Graph is enabled for this repo.
       continue-on-error: true
       with:

--- a/.github/actions/dependency-review/action.yml
+++ b/.github/actions/dependency-review/action.yml
@@ -1,0 +1,34 @@
+name: Dependency Review (shared)
+description: >
+  Single-source SPDX license deny-list for dependency review.
+  Canonical list lives here; both ci.yml and dependency-review.yml call this
+  action so the deny-licenses value is never duplicated or allowed to drift.
+
+# No inputs — the deny-list and severity threshold are project policy, not
+# per-call configuration. Add inputs here only if a call site genuinely
+# needs a different policy.
+
+runs:
+  using: composite
+  steps:
+    - name: Review dependencies
+      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+      # Advisory until GitHub Dependency Graph is enabled for this repo.
+      continue-on-error: true
+      with:
+        fail-on-severity: high
+        # Canonical SPDX deny-list — single source of truth.
+        # Reject (SPDX identifiers — verified against https://spdx.org/licenses/):
+        # - GPL-2.0/-3.0, AGPL-1.0/-3.0/-or-later: copyleft stronger than
+        #   what we ship under (MIT/Apache).
+        # - BUSL-1.1: Business Source License — source-available "anti-cloud"
+        #   model used by Sentry, MariaDB, etc. NOT the same as `BSL-1.0`
+        #   (Boost Software License, which is permissive — DON'T add it).
+        # - SSPL-1.0: Server Side Public License (Elastic, MongoDB current).
+        # - FSL-1.0-ALv2/-MIT, FSL-1.1-MIT: Functional Source License family
+        #   (Sentry, BoxyHQ, Discord) — Apache/MIT future-grant model that
+        #   today behaves as anti-cloud.
+        # Project policy is "MIT / Apache-2.0 / BSD / ISC only"; this list is
+        # drift protection for new deps (gate is advisory via continue-on-error
+        # until GitHub Dependency Graph is enabled).
+        deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0, AGPL-3.0-or-later, BUSL-1.1, SSPL-1.0, FSL-1.0-ALv2, FSL-1.0-MIT, FSL-1.1-MIT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,15 +80,9 @@ jobs:
           persist-credentials: false
 
       - name: Review dependencies
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
-        # Advisory until GitHub Dependency Graph is enabled for this repo.
-        continue-on-error: true
-        with:
-          fail-on-severity: high
-          # Mirror of `.github/workflows/dependency-review.yml` deny-list —
-          # keep both in sync. SPDX identifiers verified against
-          # https://spdx.org/licenses/ (BUSL-1.1, NOT BSL-1.1 which is Boost).
-          deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0, AGPL-3.0-or-later, BUSL-1.1, SSPL-1.0, FSL-1.0-ALv2, FSL-1.0-MIT, FSL-1.1-MIT
+        # Canonical SPDX deny-list lives in the composite action.
+        # Edit .github/actions/dependency-review/action.yml to change policy.
+        uses: ./.github/actions/dependency-review
 
   local-ci-attestation:
     # Attestation gate: same-repo PRs must publish a successful

--- a/.github/workflows/cosign-verify.yml
+++ b/.github/workflows/cosign-verify.yml
@@ -38,7 +38,7 @@ jobs:
       # Identity expected for keyless cosign signatures: the docker-publish
       # workflow on the main branch of this repository, signed via the
       # GitHub-hosted Sigstore Fulcio issuer.
-      EXPECTED_IDENTITY_REGEX: ^https://github.com/${{ github.repository }}/.github/workflows/docker-publish.yml@refs/(heads|tags)/.+$
+      EXPECTED_IDENTITY_REGEX: ^https://github.com/${{ github.repository }}/.github/workflows/docker-publish.yml@refs/(heads/main|tags/v.+)$
       EXPECTED_OIDC_ISSUER: https://token.actions.githubusercontent.com
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,22 +24,6 @@ jobs:
           persist-credentials: false
 
       - name: Review dependencies
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
-        # Advisory until GitHub Dependency Graph is enabled for this repo.
-        continue-on-error: true
-        with:
-          fail-on-severity: high
-          # Reject (SPDX identifiers — verified against https://spdx.org/licenses/):
-          # - GPL-2.0/-3.0, AGPL-1.0/-3.0/-or-later: copyleft stronger than
-          #   what we ship under (MIT/Apache).
-          # - BUSL-1.1: Business Source License — source-available "anti-cloud"
-          #   model used by Sentry, MariaDB, etc. NOT the same as `BSL-1.0`
-          #   (Boost Software License, which is permissive — DON'T add it).
-          # - SSPL-1.0: Server Side Public License (Elastic, MongoDB current).
-          # - FSL-1.0-ALv2/-MIT, FSL-1.1-MIT: Functional Source License family
-          #   (Sentry, BoxyHQ, Discord) — Apache/MIT future-grant model that
-          #   today behaves as anti-cloud.
-          # Project policy is "MIT / Apache-2.0 / BSD / ISC only"; this list is
-          # drift protection for new deps (gate is advisory via continue-on-error
-          # until GitHub Dependency Graph is enabled — same as before).
-          deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0, AGPL-3.0-or-later, BUSL-1.1, SSPL-1.0, FSL-1.0-ALv2, FSL-1.0-MIT, FSL-1.1-MIT
+        # Canonical SPDX deny-list lives in the composite action.
+        # Edit .github/actions/dependency-review/action.yml to change policy.
+        uses: ./.github/actions/dependency-review


### PR DESCRIPTION
## Summary

Two supply-chain hardening fixes shipped as one YAML-only PR.

### Task 1 — cosign keyless OIDC identity regex (cosign-verify.yml)

Narrows `EXPECTED_IDENTITY_REGEX` from the loose pattern:

```
refs/(heads|tags)/.+
```

to the tight pattern:

```
refs/(heads/main|tags/v.+)
```

This rejects cosign signatures produced by arbitrary feature-branch
`workflow_dispatch` runs. Only main-push and semver-tag (`v*`) releases
can produce accepted signatures — which exactly matches the
`docker-publish.yml` trigger set.

### Task 2 — Single-source SPDX deny-list (composite action)

Moves the duplicated `deny-licenses` block out of:
- `.github/workflows/ci.yml` (`dependency-review` job)
- `.github/workflows/dependency-review.yml`

into a new composite action at:

```
.github/actions/dependency-review/action.yml
```

Both call sites now use `uses: ./.github/actions/dependency-review` with
no inline policy. To update the denied-license list in future, edit the
composite action once — no more "keep both in sync" comments.

The canonical SPDX deny-list now lives at:
`.github/actions/dependency-review/action.yml`

## Files changed

- `.github/actions/dependency-review/action.yml` — new composite action (single source of truth)
- `.github/workflows/cosign-verify.yml` — tightened `EXPECTED_IDENTITY_REGEX`
- `.github/workflows/ci.yml` — replaced inline `deny-licenses` with composite action call
- `.github/workflows/dependency-review.yml` — replaced inline `deny-licenses` with composite action call

## Test plan

- [x] All 4 modified YAML files pass `python3 -c "import yaml; yaml.safe_load_all(open(...))"` validation
- [x] Local CI (`fop-local-ci.sh --profile pr`) passed (diff-aware: workflows path triggered workflow checks + security audit)
- [ ] CI workflow runs green on this PR
- [ ] cosign-verify.yml continues to accept `refs/heads/main` and `refs/tags/v1.2.3` shaped refs
- [ ] cosign-verify.yml rejects `refs/heads/my-feature-branch` shaped refs

Refs T-6238