### PR TITLE
feat(ci): add CodeQL workflow (PHP + JS-TS first-party SAST, advisory until SHAs pinned)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,9 +76,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4 (repo allow-listed SHA)
 
       - name: Initialize CodeQL
-        # TODO operator: replace tag with verified 40-char SHA for v3
-        # latest release before adding to required checks. See header.
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -96,7 +94,7 @@ jobs:
       # composer install --no-dev --no-progress here.
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         with:
           category: /language:${{ matrix.language }}
           # Upload SARIF to Security tab. Off-by-default for forks

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,104 @@
+name: CodeQL
+
+# First-party SAST for the application sources (PHP backend + JS/TS
+# frontend). Complements security.yml zizmor (which scans GHA
+# workflows only) and dependency-review.yml (which checks
+# dependencies, not first-party code).
+#
+# Identified as the highest-impact gap in 2026-05-19 audit (gap #3
+# of /tmp/parkhub-php-cicd-audit.md): zizmor is Actions-only; CodeQL
+# is the obvious cross-language complement.
+#
+# IMPORTANT - operator action items before this workflow becomes a
+# required check:
+#   1. Pin every github/codeql-action/*@<SHA> reference below to a
+#      verified 40-char commit SHA (currently version tags). The repo's
+#      allowed-actions list (see PR #499's experience with
+#      dependency-review-action) rejects anything not explicitly
+#      listed.
+#   2. Add the chosen SHAs to the allow-list in repo Settings ->
+#      Actions -> 'Allow specified actions and reusable workflows'.
+#   3. Enable GitHub Advanced Security on the repo if private (parkhub
+#      visibility unclear from this lane; CodeQL is free on public
+#      repos and requires GHAS on private).
+#   4. Only after a first green run on main, add CodeQL / Analyze
+#      (javascript-typescript) and ... (php) to required status
+#      checks in branch protection.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Sunday 06:14 UTC - off-peak; mirrors scorecard.yml weekly cadence
+    # so security weekly artifacts converge on the same Monday review.
+    - cron: '14 6 * * 0'
+
+# Single-run cancellation per ref. PRs replace older runs; main pushes
+# replace older main runs. Saves runner minutes during rebase storms.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  # security-events: write is required for CodeQL to upload SARIF to
+  # the repo Security tab. Without it the job runs but findings are
+  # invisible to the operator review surface.
+  security-events: write
+  # actions: read needed for CodeQL to enumerate workflow files when
+  # language: javascript-typescript picks up GHA YAML as JS via its
+  # template engine. Without this the JS-TS analysis silently degrades.
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # javascript-typescript is the 2026 unified language ID
+          # (replaces separate javascript and typescript). Covers
+          # both Astro 5 + React 19 frontend + Vitest specs.
+          - language: javascript-typescript
+            build-mode: none
+          # PHP analysis covers the Laravel backend.
+          - language: php
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4 (repo allow-listed SHA)
+
+      - name: Initialize CodeQL
+        # TODO operator: replace tag with verified 40-char SHA for v3
+        # latest release before adding to required checks. See header.
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended adds query packs beyond security -
+          # widens injection / serialization / SSRF / XXE coverage at
+          # a small runtime cost. security-and-quality would add
+          # maintainability noise (complexity-high, etc.) - keep
+          # those for nightly only if ever enabled.
+          queries: security-extended
+
+      # build-mode: none implies CodeQL extracts directly without a
+      # build step. PHP and JS-TS both support this in 2026. If the
+      # PHP autoloader-reflection ever degrades extraction quality,
+      # switch this job's build-mode to manual and run
+      # composer install --no-dev --no-progress here.
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}
+          # Upload SARIF to Security tab. Off-by-default for forks
+          # (CodeQL refuses upload from forks for security reasons).
+          upload: always

--- a/scripts/local-workflow-drift.sh
+++ b/scripts/local-workflow-drift.sh
@@ -46,6 +46,7 @@ EXEMPT_GITEA_MISSING=(
   devcontainer-publish.yml        # publishes to ghcr.io
   auto-merge.yml                  # github-only auto-merge of dependabot PRs
   deploy.yml                      # github-only Render/Fly/Koyeb dispatch
+  codeql.yml                      # GitHub Advanced Security exclusive (no gitea equivalent)
 )
 
 # Files that are documented as gitea-only (no github mirror needed) — these


### PR DESCRIPTION
## Summary

Closes the highest-impact gap from the 2026-05-18 CI/CD audit (`/tmp/parkhub-php-cicd-audit.md` gap #3): zizmor scans GHA workflows only; CodeQL is the obvious cross-language complement covering the Laravel backend and the Astro 5 + React 19 frontend.

Initial wiring is advisory-only by design.

## Commits

1. `961568e` — **CodeQL workflow** with matrix on `javascript-typescript` (2026 unified language ID, replaces separate js/ts) and `php` against the `security-extended` query pack. `build-mode: none` (both languages support direct extraction in 2026). Triggers: push to main, PR, weekly Sunday 06:14 UTC (mirrors `scorecard.yml` cadence). Concurrency cancellation on PR ref. Minimum permissions (`contents: read`, `security-events: write`, `actions: read`).
2. `73f1098` — **drift-detector exemption** for `codeql.yml` in `scripts/local-workflow-drift.sh` `EXEMPT_GITEA_MISSING` list (CodeQL is a GitHub Advanced Security feature with no gitea-runner equivalent, so a `.gitea/workflows/codeql.yml` mirror would never make sense).

## Operator action items before promoting to a required check (also inline in workflow header)

1. Pin every `github/codeql-action/*@<SHA>` reference to a verified 40-char commit SHA. The repo's allowed-actions list rejected the wrong SHA on `dependency-review-action` in PR #499; the same gate applies here.
2. Add the chosen SHAs to repo Settings → Actions → "Allow specified actions and reusable workflows".
3. Enable GitHub Advanced Security if the repo is private (CodeQL is free on public repos; requires GHAS on private).
4. After a first green main run, add `CodeQL / Analyze (javascript-typescript)` and `CodeQL / Analyze (php)` to required status checks in branch protection.

## Verification

- `bash -n` + `python3 -c "import yaml; yaml.safe_load_all(...)"` pass.
- `fop-local-ci.sh --profile pr --post-status` PASSED via DIRECT mode on commit `73f1098`.

## Refs

T-6238
