### PR TITLE
fix(local-ci): refine allocate_laravel_port (ss -ltn + shuf guard + comment fix)

### DIFF
--- a/.github/scripts/fop-local-ci.sh
+++ b/.github/scripts/fop-local-ci.sh
@@ -179,7 +179,10 @@ compute_design_smoke_gate() {
 #   2. SERVER_PORT (caller may already have one in env from outer wrapper)
 #   3. 8082 if free (preserves docs + screenshots + muscle memory)
 #   4. random free port in the ephemeral range (49152-65535) from `ss`
-#   5. fallback: 8082 + small random offset (best-effort if `ss` missing)
+#   5. fallback: 8083 + small random offset 0-199 (best-effort if `ss`
+#      or `shuf` is missing). Note: tiers 3+4 inspect *listening* sockets
+#      only; a TOCTOU race window remains between observation and bind,
+#      so tier 5 acts as the deterministic-fallback for parallel runs.
 allocate_laravel_port() {
   if [[ -n "${FOP_LOCAL_CI_LARAVEL_PORT:-}" ]]; then
     printf '%s' "${FOP_LOCAL_CI_LARAVEL_PORT}"
@@ -191,16 +194,20 @@ allocate_laravel_port() {
   fi
   if command -v ss >/dev/null 2>&1; then
     local in_use
-    in_use="$(ss -tan 2>/dev/null | awk 'NR>1 {sub(/.*:/,"",$4); print $4}' | sort -un)"
+    # -ltn = listening TCP, numeric; ignores non-listening sockets so we
+    # don't spuriously avoid ports that are only client-side in use.
+    in_use="$(ss -ltn 2>/dev/null | awk 'NR>1 {sub(/.*:/,"",$4); print $4}' | sort -un)"
     if ! grep -qx '8082' <<<"$in_use"; then
       printf '%s' '8082'
       return 0
     fi
-    local picked
-    picked="$(comm -23 <(seq 49152 65535) <(printf '%s\n' "$in_use") 2>/dev/null | shuf -n 1)"
-    if [[ -n "$picked" ]]; then
-      printf '%s' "$picked"
-      return 0
+    if command -v shuf >/dev/null 2>&1; then
+      local picked
+      picked="$(comm -23 <(seq 49152 65535) <(printf '%s\n' "$in_use") 2>/dev/null | shuf -n 1)"
+      if [[ -n "$picked" ]]; then
+        printf '%s' "$picked"
+        return 0
+      fi
     fi
   fi
   printf '%s' "$((8083 + RANDOM % 200))"


### PR DESCRIPTION
Refines the 5-tier allocator merged in **PR #501**. Three Copilot-driven improvements surfaced on PR #503 (which was closed as redundant since #501 had already shipped the identical original code).

## Changes (14 LOC)

1. **`ss -tan` → `ss -ltn`** — list only *listening* TCP sockets. Old code matched all TCP connections including outbound client-side ports, which could spuriously mark `:8082` unavailable. Listening-only is the correct semantic for "what is bound on this host".

2. **`command -v shuf` guard** — guard the `shuf -n 1` invocation. If `shuf` is missing on a minimal CI runner, the allocator now falls through cleanly to tier 5 (`8083 + RANDOM % 200`) instead of returning an empty port string.

3. **Comment correctness** —
   - tier 5 header comment said `8082 + small random offset` while the code is `8083 + RANDOM % 200`. Fixed.
   - Added explicit TOCTOU race acknowledgment: tiers 3+4 inspect listening sockets only; a window remains between observation and bind, mitigated by tier 5's deterministic fallback.

## Why now

Parallel work on PR #503 (closed) hit a Copilot review with these exact comments; #501 had already merged with the same bugs intact since it shipped 2026-05-18T23:46:54Z, 24h before this review was authored.

## Verification

- `make ci` (FOP_LOCAL_CI_DIRECT=1) — clean, exit 0.
- lefthook `fop/local-ci/pr` attestation present for HEAD SHA.
- No behavioral change to the happy path; minimal-environment robustness improved.

Related: T-6238 (parkhub-php local-CI hardening thread).