### PR TITLE
feat(ci): bridge fop/local-ci/pr status for Dependabot PRs (unblock 8 stuck PRs)

### DIFF
--- a/.gitea/workflows/dependabot-local-ci-bridge.yaml
+++ b/.gitea/workflows/dependabot-local-ci-bridge.yaml
@@ -1,0 +1,159 @@
+# Mirror of .github/workflows/dependabot-local-ci-bridge.yml for Gitea Actions runner.
+# Action refs rewritten to https://192.168.178.233/actions/* where mirrored.
+# Edit .github/workflows/dependabot-local-ci-bridge.yml as source-of-truth, then re-mirror.
+
+name: Dependabot local-CI bridge
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-local-ci-bridge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PHP_VERSION: '8.4'
+  NODE_VERSION: '22.12.0'
+  GITLEAKS_VERSION: 8.30.1
+  GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+  OSV_SCANNER_VERSION: 2.3.5
+  OSV_SCANNER_SHA256: bb30c580afe5e757d3e959f4afd08a4795ea505ef84c46962b9a738aa573b41b
+
+# Default shell to bash so 'set -euo pipefail' works in step scripts —
+# act_runner's default 'sh' is dash/BusyBox which doesn't support pipefail.
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  headless-gate:
+    name: Headless local-CI gate (Dependabot)
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+
+    steps:
+      - name: Checkout
+        uses: https://192.168.178.233/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # --- Composer audit ---
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/shivammathur/setup-php yet.
+      # Pin upstream until we mirror; revisit when Gitea mirror lands.
+      - name: Set up PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Audit production Composer dependencies
+        run: composer audit --locked --no-dev
+
+      # --- npm audit ---
+      - name: Set up Node.js
+        uses: https://192.168.178.233/actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Audit root npm dependencies
+        run: npm audit --package-lock-only --omit=dev --audit-level=high
+        continue-on-error: true
+
+      - name: Audit Astro npm dependencies
+        run: npm audit --prefix parkhub-web --package-lock-only --omit=dev --audit-level=high
+        continue-on-error: true
+
+      # --- Secret scan ---
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Secret scan (PR range)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          gitleaks detect --source=. --redact --verbose --no-banner \
+            --log-opts="--no-merges ${BASE_SHA}..${HEAD_SHA}"
+
+      # --- OSV-Scanner ---
+      - name: Install osv-scanner
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/osv-scanner \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
+          chmod +x /tmp/osv-scanner
+          sudo mv /tmp/osv-scanner /usr/local/bin/osv-scanner
+          osv-scanner --version
+
+      - name: OSV-Scanner (composer + npm lockfiles)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          osv-scanner scan source \
+            --config=osv-scanner.toml \
+            -L composer.lock \
+            -L package-lock.json \
+            -L parkhub-web/package-lock.json \
+            --format=table || true
+
+      # --- Typos (advisory) ---
+      # TODO(gitea-mirror): No mirror at https://192.168.178.233/crate-ci/typos yet.
+      - name: Run typos
+        continue-on-error: true
+        uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83 # v1.45.1
+
+      # --- Post fop/local-ci/pr commit status ---
+      - name: Post fop/local-ci/pr status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          case "${JOB_STATUS}" in
+            success)   STATE="success"; DESC="Local-CI bridge: headless gate suite passed (dependabot)" ;;
+            failure)   STATE="failure"; DESC="Local-CI bridge: headless gate suite failed (dependabot)" ;;
+            cancelled) STATE="error";   DESC="Local-CI bridge: headless gate cancelled (dependabot)" ;;
+            *)         STATE="error";   DESC="Local-CI bridge: unknown status ${JOB_STATUS} (dependabot)" ;;
+          esac
+
+          live_sha="$(
+            gh pr view "${PR_NUMBER}" \
+              --repo "${REPO}" --json headRefOid --jq .headRefOid 2>/dev/null || true
+          )"
+          if [[ "${live_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            SHA="${live_sha}"
+          fi
+
+          gh api \
+            --method POST \
+            "repos/${REPO}/statuses/${SHA}" \
+            -f state="${STATE}" \
+            -f context="fop/local-ci/pr" \
+            -f description="${DESC}" \
+            -f target_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"

--- a/.github/workflows/dependabot-local-ci-bridge.yml
+++ b/.github/workflows/dependabot-local-ci-bridge.yml
@@ -1,0 +1,173 @@
+name: Dependabot local-CI bridge
+
+# Bridge workflow: posts `fop/local-ci/pr: success/failure` commit status for
+# Dependabot-authored PRs. The status is normally posted by a developer
+# running `.github/scripts/fop-local-ci.sh --profile pr --post-status` locally.
+# Dependabot pushes from GitHub-side; no local developer means no invocation,
+# so the `local-ci-attestation` gate in ci.yml blocks indefinitely.
+#
+# This workflow runs the essential headless gate suite
+# (composer-audit + npm-audit + secret-scan + osv-scanner + typos) and
+# posts the status result so Dependabot PRs can merge cleanly.
+#
+# Advisory: this workflow is NOT yet a required check. Monitor the first few
+# Dependabot cycles before promoting to required in branch protection.
+#
+# Unblocks: parkhub-php #493/#496/#498 + parkhub-rust #638/#639/#640/#641/#642
+# (parkhub-rust port tracked as follow-up task #19).
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+# Minimal top-level permissions; statuses:write is declared on the job only.
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-local-ci-bridge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PHP_VERSION: '8.4'
+  NODE_VERSION: '22.12.0'
+  GITLEAKS_VERSION: 8.30.1
+  GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+  OSV_SCANNER_VERSION: 2.3.5
+  OSV_SCANNER_SHA256: bb30c580afe5e757d3e959f4afd08a4795ea505ef84c46962b9a738aa573b41b
+
+jobs:
+  headless-gate:
+    name: Headless local-CI gate (Dependabot)
+    # Only run for Dependabot PRs — human PRs go through the normal local-CI
+    # attestation path (fop-local-ci.sh + local-ci-attestation in ci.yml).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read       # checkout source + lockfiles
+      pull-requests: read  # resolve live head SHA on reruns
+      statuses: write      # post fop/local-ci/pr status (write scope required per
+                           # https://github.com/orgs/community/discussions/40769)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # --- Composer audit (mirrors security.yml: composer-audit) ---
+      - name: Set up PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Audit production Composer dependencies
+        run: composer audit --locked --no-dev
+
+      # --- npm audit (mirrors security.yml: npm-audit) ---
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Audit root npm dependencies
+        run: npm audit --package-lock-only --omit=dev --audit-level=high
+        continue-on-error: true
+
+      - name: Audit Astro npm dependencies
+        run: npm audit --prefix parkhub-web --package-lock-only --omit=dev --audit-level=high
+        continue-on-error: true
+
+      # --- Secret scan (mirrors security.yml: secret-scan) ---
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Secret scan (PR range)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          gitleaks detect --source=. --redact --verbose --no-banner \
+            --log-opts="--no-merges ${BASE_SHA}..${HEAD_SHA}"
+
+      # --- OSV-Scanner (mirrors security.yml: osv-scanner) ---
+      - name: Install osv-scanner
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/osv-scanner \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
+          chmod +x /tmp/osv-scanner
+          sudo mv /tmp/osv-scanner /usr/local/bin/osv-scanner
+          osv-scanner --version
+
+      - name: OSV-Scanner (composer + npm lockfiles)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          osv-scanner scan source \
+            --config=osv-scanner.toml \
+            -L composer.lock \
+            -L package-lock.json \
+            -L parkhub-web/package-lock.json \
+            --format=table || true
+
+      # --- Typos (mirrors security.yml: typos, advisory) ---
+      - name: Run typos
+        continue-on-error: true
+        uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83 # v1.45.1
+
+      # --- Post fop/local-ci/pr commit status ---
+      # Uses gh api (same tooling as local-ci-attestation in ci.yml) to avoid
+      # introducing actions/github-script which has no existing pinned SHA.
+      # All github.event.* values are passed through env vars to prevent
+      # expression injection in the run shell.
+      - name: Post fop/local-ci/pr status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          # Map GitHub job status to commit-status state.
+          # job.status values: success, failure, cancelled.
+          case "${JOB_STATUS}" in
+            success)   STATE="success"; DESC="Local-CI bridge: headless gate suite passed (dependabot)" ;;
+            failure)   STATE="failure"; DESC="Local-CI bridge: headless gate suite failed (dependabot)" ;;
+            cancelled) STATE="error";   DESC="Local-CI bridge: headless gate cancelled (dependabot)" ;;
+            *)         STATE="error";   DESC="Local-CI bridge: unknown status ${JOB_STATUS} (dependabot)" ;;
+          esac
+
+          # Resolve the live head SHA in case of rerun on a force-push.
+          live_sha="$(
+            gh pr view "${PR_NUMBER}" \
+              --repo "${REPO}" --json headRefOid --jq .headRefOid 2>/dev/null || true
+          )"
+          if [[ "${live_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            SHA="${live_sha}"
+          fi
+
+          gh api \
+            --method POST \
+            "repos/${REPO}/statuses/${SHA}" \
+            -f state="${STATE}" \
+            -f context="fop/local-ci/pr" \
+            -f description="${DESC}" \
+            -f target_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"


### PR DESCRIPTION
**Closes task #11** (Dependabot fop/local-ci/pr gate architectural fix). Authored 2026-05-19 ~07:00 as part of the parkhub E2E fan-out. Initially staged behind the devalue 5.6.4 image-scan blocker (RESUME.md); now unblocked since PR #510 landed the devalue 5.8.1 fix on main.

## Architectural rationale

`fop/local-ci/pr` is a required PAT-posted commit status set by a developer running `./scripts/fop-local-ci.sh` locally — which runs lefthook pre-push gates + posts the result.

Dependabot bots commit from GitHub-side; no local developer means no `fop-local-ci.sh` invocation means no `fop/local-ci/pr: success` status. Result: PR sits MERGEABLE+BLOCKED indefinitely. **8 Dependabot PRs are stuck right now** by this exact gap: parkhub-php #493/#496/#498 + parkhub-rust #638/#639/#640/#641/#642.

## What this bridge does

New GHA + Gitea-Actions workflow `dependabot-local-ci-bridge.yml` that:

1. Triggers only on PRs where `github.event.pull_request.user.login == 'dependabot[bot]'`
2. Runs the headless equivalent of `make ci`: composer-audit hard + npm-audit advisory + gitleaks (scoped to PR range) hard + osv-scanner advisory + typos advisory
3. Posts `fop/local-ci/pr: success|failure` commit status via `gh api POST /repos/.../statuses/{sha}` matching the local-ci-attestation convention (no `actions/github-script`, no new third-party action SHAs)
4. Job permission `statuses: write` (scoped to job, not top-level — minimum privilege)
5. All `github.event.*` values flow through `env:` vars (no injection surface)

## SOTA-2026 discipline notes

- Advisory adoption initially — not yet promoted to required gate; verify it runs cleanly over a few Dependabot cycles first.
- Both `.github/workflows/dependabot-local-ci-bridge.yml` (GHA) + `.gitea/workflows/dependabot-local-ci-bridge.yaml` (Gitea mirror) committed per workflow-drift requirement.
- All actions SHA-pinned, reusing the same SHAs as `security.yml` + `ci.yml` (zero new pin surface).
- The bridge does NOT replace the human-developer path — both can post the status; whichever fires first wins. This means the existing developer workflow keeps working.

## Verification

`FOP_LOCAL_CI_DIRECT=1 make ci` clean exit-0 on the rebased HEAD. All lefthook pre-push gates green (no `--no-verify` bypass — discipline held per CLAUDE.md L237 and 2026-05-19 E4 incident memory).

## Follow-up

A parallel PR will mirror this workflow to parkhub-rust (task #11.2). Once landed and validated, the 8 stuck PRs above can proceed through their auto-merge paths.