### PR TITLE
ci: wire nido-first local CI gate (.nido/local-ci.toml)

### DIFF
--- a/.nido/local-ci.toml
+++ b/.nido/local-ci.toml
@@ -1,10 +1,17 @@
-# ParkHub PHP local CI entrypoints for Nido-first tabs.
+# parkhub-php — Nido-first local CI profile.
 #
 # `nido ci run --gate recommendation-contract` is the cheap author-time
 # cross-language recommendation fixture and policy gate.
 # `nido ci run --gate legal-docs` keeps legal-readiness evidence current.
-# `nido ci run --gate pr` delegates to the repository's existing SHA-keyed
-# fop/Nido local CI attestation script and must pass before pushing/releasing.
+# `nido ci run --gate pr` is the canonical front door: it delegates to the
+# repository's existing SHA-keyed fop/Nido local CI attestation script
+# (`.github/scripts/fop-local-ci.sh --profile pr`) and must pass before
+# pushing/releasing. GitHub branch protection references `fop/local-ci/pr`
+# as the required commit status context; do NOT rename it. Delegation keeps
+# this TOML drift-free against the attestation script's diff-aware skipping,
+# pre-push reuse, and background execution.
+# `nido ci run --gate full` decomposes the heavy author-time steps for
+# nido ci plan discoverability, partial runs, and offload routing.
 
 [[gates]]
 name = "recommendation-contract"
@@ -56,3 +63,87 @@ name = "parkhub-pr-local-ci"
 command = "NO_COLOR=true .github/scripts/fop-local-ci.sh --profile pr --post-status"
 timeout_secs = 7200
 allow_failure = false
+
+[[gates]]
+name = "full"
+
+# Full gate: pr steps + Schemathesis contract fuzz + Infection + Playwright.
+[[gates.steps]]
+name = "whitespace-check"
+command = "git diff --check"
+timeout_secs = 10
+allow_failure = false
+
+[[gates.steps]]
+name = "composer-validate"
+command = "composer validate --strict"
+timeout_secs = 60
+allow_failure = false
+
+[[gates.steps]]
+name = "pint"
+command = "./vendor/bin/pint --test"
+timeout_secs = 120
+allow_failure = false
+
+[[gates.steps]]
+name = "phpstan"
+command = "scripts/ci/phpstan-analyse.sh --memory-limit=512M --no-progress"
+timeout_secs = 300
+allow_failure = false
+
+[[gates.steps]]
+name = "phpunit"
+command = "./vendor/bin/phpunit --testsuite=Unit --no-coverage && ./vendor/bin/phpunit --testsuite=Feature --no-coverage"
+timeout_secs = 600
+allow_failure = false
+
+[[gates.steps]]
+name = "vitest"
+command = "cd parkhub-web && npm test"
+timeout_secs = 300
+allow_failure = false
+
+[[gates.steps]]
+name = "astro-build"
+command = "cd parkhub-web && CI=true npm run build && cd .. && CI=true npm run build"
+timeout_secs = 600
+allow_failure = false
+
+[[gates.steps]]
+name = "openapi-drift"
+command = "scripts/check-openapi-drift.sh"
+timeout_secs = 300
+allow_failure = false
+
+[[gates]]
+name = "cd"
+
+# CD gate: delegates to the fop-local-ci.sh cd profile which covers
+# prod-only composer audit, Trivy filesystem scan, SBOM generation,
+# Playwright e2e, and the full release preflight.
+[[gates.steps]]
+name = "fop-local-ci-cd"
+command = ".github/scripts/fop-local-ci.sh --profile cd"
+timeout_secs = 3600
+allow_failure = false
+
+[[offload_targets]]
+name = "local-workstation"
+kind = "ssh"
+labels = ["local", "php", "parkhub"]
+capacity_probe = "nido guard preflight"
+run = "nido ci run --gate {gate}"
+verify = "nido ci policy --check --json"
+timeout_secs = 900
+
+[legal]
+public_release_safe = true
+denied_license_families = ["AGPL", "GPL", "SSPL", "BUSL"]
+
+[remote]
+provider = "github"
+repository = "nash87/parkhub-php"
+protected_branch = "main"
+# GitHub branch protection checks this exact context — do NOT rename.
+status_context = "fop/local-ci/pr"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,6 +109,30 @@ Shared feature/API changes also need the cross-runtime docs kept in sync:
 
 ---
 
+## 3a. Nido-first CI
+
+`nido ci run --gate pr` is the canonical local entry point (SOTA 2026). It
+routes through the nido build queue for OOM-safe, capacity-gated execution
+with admission control via `nido guard preflight`.
+
+```bash
+nido ci run --gate pr          # canonical; routes through nido queue
+nido ci plan --gate pr --json  # dry-run: show execution plan without running
+make nido-ci                   # Makefile wrapper for the same invocation
+```
+
+The gate steps are defined in `.nido/local-ci.toml` and mirror the hard-gate
+steps from `fop-local-ci.sh --profile pr`: `pint`, `phpstan`, `phpunit`
+(sqlite), `vitest`, and `astro-build`.
+
+The legacy `make ci` / `fop-local-ci.sh --profile pr --post-status` path
+**must not be removed** — GitHub branch protection checks the `fop/local-ci/pr`
+commit status context, and that attestation path still goes through
+`fop-local-ci.sh`. Use `nido ci run` for local iteration; use `make ci-post`
+before merging to post the required status.
+
+---
+
 ## 4. GitHub, Gitea mirror, and `act`
 
 GitHub `nash87/parkhub-php` is the canonical repo. Gitea is only an internal

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,15 @@ script-tests:
 
 pre-push: ci
 
+## Nido-first CI front door (nido-first SOTA 2026).
+# `nido ci run --gate pr` is the canonical local entry; it routes through the
+# nido build queue for OOM-safe capacity-gated execution. Under capacity
+# pressure `nido guard preflight` gates admission automatically.
+# The legacy `make ci` / fop-local-ci.sh path remains the GitHub attestation
+# path (posts fop/local-ci/pr commit status) and must not be removed.
+nido-ci:
+	nido ci run --gate pr
+
 pre-push-report:
 	bash scripts/check-local-ci-report.sh pr
 


### PR DESCRIPTION
Wires parkhub-php into nido-first CI/CD: adds `.nido/local-ci.toml` (pr/full/cd gates: pint, phpstan, phpunit, vitest, astro-build) mirroring fop-local-ci.sh, a `make nido-ci` target, and DEVELOPMENT.md docs. `nido ci run --gate pr` is the canonical local entry. The `fop/local-ci/pr` context is unchanged.