### PR TITLE
fix(a11y+design): WCAG AA btn-primary contrast, static contrast gate, finish purple→coral rename

### DIFF
--- a/parkhub-web/src/design-v5/primitives/Badge.stories.tsx
+++ b/parkhub-web/src/design-v5/primitives/Badge.stories.tsx
@@ -9,7 +9,7 @@ const VARIANTS: BadgeVariant[] = [
   'info',
   'gray',
   'ev',
-  'purple',
+  'coral',
 ];
 
 const meta: Meta<typeof Badge> = {

--- a/parkhub-web/src/design-v5/screens/Buchungen.tsx
+++ b/parkhub-web/src/design-v5/screens/Buchungen.tsx
@@ -16,7 +16,7 @@ const FILTERS: { key: FilterKey; label: string }[] = [
   { key: 'cancelled', label: 'Storniert' },
 ];
 
-type BadgeVariant = 'primary' | 'success' | 'warning' | 'error' | 'info' | 'gray' | 'ev' | 'purple';
+type BadgeVariant = 'primary' | 'success' | 'warning' | 'error' | 'info' | 'gray' | 'ev' | 'coral';
 
 function statusVariant(s: Booking['status']): BadgeVariant {
   switch (s) {

--- a/parkhub-web/src/design-v5/screens/Nutzer.tsx
+++ b/parkhub-web/src/design-v5/screens/Nutzer.tsx
@@ -17,7 +17,7 @@ const FILTERS: { key: FilterKey; label: string }[] = [
 
 function roleVariant(role: User['role']): BadgeVariant {
   switch (role) {
-    case 'superadmin': return 'purple';
+    case 'superadmin': return 'coral';
     case 'admin': return 'info';
     case 'premium': return 'warning';
     default: return 'gray';

--- a/parkhub-web/src/design-v5/screens/Profil.tsx
+++ b/parkhub-web/src/design-v5/screens/Profil.tsx
@@ -160,7 +160,7 @@ export function ProfilV5({ navigate: _navigate }: { navigate: (id: ScreenId) => 
     <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Mein Profil</span>
-        <Badge variant={user.role === 'admin' || user.role === 'superadmin' ? 'purple' : 'primary'}>
+        <Badge variant={user.role === 'admin' || user.role === 'superadmin' ? 'coral' : 'primary'}>
           {user.role}
         </Badge>
       </div>

--- a/parkhub-web/src/design-v5/screens/Rangliste.tsx
+++ b/parkhub-web/src/design-v5/screens/Rangliste.tsx
@@ -8,7 +8,7 @@ import type { ScreenId } from '../nav';
 interface BadgeDef {
   key: string;
   label: string;
-  variant: 'primary' | 'success' | 'warning' | 'info' | 'purple';
+  variant: 'primary' | 'success' | 'warning' | 'info' | 'coral';
 }
 
 interface LeaderboardEntry {
@@ -35,7 +35,7 @@ function computeBadges(stats: UserBookingStats): BadgeDef[] {
   if (stats.ev_count > 0) badges.push({ key: 'ev', label: 'EV', variant: 'success' });
   if (stats.morning_count > 0) badges.push({ key: 'early', label: 'Früh', variant: 'warning' });
   if (stats.swaps_accepted > 0) badges.push({ key: 'team', label: 'Teamplayer', variant: 'info' });
-  if (stats.this_month >= 10) badges.push({ key: 'frequent', label: 'Vielparker', variant: 'purple' });
+  if (stats.this_month >= 10) badges.push({ key: 'frequent', label: 'Vielparker', variant: 'coral' });
   return badges;
 }
 

--- a/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
+++ b/parkhub-web/src/design-v5/screens/Vorhersagen.tsx
@@ -178,7 +178,7 @@ export function VorhersagenV5({ navigate: _navigate }: { navigate: (id: ScreenId
     <div style={{ padding: 16, flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div className="v5-ani" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <span style={{ fontWeight: 700, fontSize: 15, color: 'var(--v5-txt)' }}>Vorhersagen</span>
-        <Badge variant="purple">Smart</Badge>
+        <Badge variant="coral">Smart</Badge>
       </div>
 
       {recommendation && (

--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -305,13 +305,29 @@ p { line-height: 1.6; }
 }
 
 @utility btn-primary {
-  background: var(--color-primary-700);
-  color: white;
+  /* WCAG AA fix: use design-system token pair instead of --color-primary-700 (#ab7220).
+     light (marble_light fallback): --v5-acc=#9e6208, --v5-accent-fg=#fff → 4.995:1 ✓
+     dark/void: --v5-acc=#f5b042, --v5-accent-fg=#0a0908 (dark ink) → 10.584:1 ✓
+     Fallback --color-primary-800 (#7d5316) gives 6.729:1 with white if v5 tokens absent.
+     Parity port of parkhub-rust design-v5-warm commit 598765d5. */
+  background: var(--v5-acc, var(--color-primary-800));
+  color: var(--v5-accent-fg, white);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
 .btn-primary:hover {
+  /* Light mode hover: --color-primary-800 (#7d5316) with white → 6.729:1 ✓ */
   background: var(--color-primary-800);
+}
+
+/* Earned-amber hover for dark/void modes: lighter amber shift while keeping dark ink */
+:root.dark[data-design-theme="marble"] .btn-primary:hover,
+:root[data-design-theme="marble"].dark .btn-primary:hover,
+:root[data-design-theme="void"] .btn-primary:hover,
+[data-ph-mode="marble_dark"] .btn-primary:hover,
+[data-ph-mode="void"] .btn-primary:hover {
+  /* --color-primary-600 (#d8942f) with dark ink (#0a0908) → 7.766:1 ✓ */
+  background: var(--color-primary-600);
 }
 
 @utility btn-secondary {

--- a/scripts/check-btn-contrast.py
+++ b/scripts/check-btn-contrast.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Static WCAG AA contrast gate for .btn-primary in parkhub-web.
+
+Caught live: white text on --color-primary-700 (#ab7220) = 4.07:1 < 4.5:1
+(axe color-contrast, serious) after the securanido token vendoring. This
+gate resolves the btn-primary bg/fg var chains against the vendored palette
+and the v5 bridge tokens and fails if any mode pair drops below AA for
+normal-size text. Pure stdlib; no browser needed, so it runs in local CI.
+
+Mirrors the parkhub-rust fix in design-v5-warm commit 598765d5.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GLOBAL_CSS = REPO / "parkhub-web/src/styles/global.css"
+BRIDGE_CSS = REPO / "parkhub-web/src/design-v5/main-app-bridge.css"
+VENDOR_CSS = REPO / "parkhub-web/src/design-v5/vendor/nido-securanido.css"
+
+AA_NORMAL = 4.5
+
+VAR_DECL = re.compile(r"(--[\w-]+)\s*:\s*([^;]+);")
+HEX_RE = re.compile(r"#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b")
+
+NAMED = {"white": "#ffffff", "black": "#000000"}
+
+
+def parse_vars(*files: Path) -> dict[str, str]:
+    table: dict[str, str] = {}
+    for f in files:
+        for name, value in VAR_DECL.findall(f.read_text()):
+            # First definition wins per file order (vendor :root first, bridge
+            # light-mode :root, then dark-mode blocks are handled separately).
+            table.setdefault(name, value.strip())
+    return table
+
+
+def parse_dark_vars(bridge: Path) -> dict[str, str]:
+    """Token overrides from the bridge's dark/void blocks (best effort)."""
+    text = bridge.read_text()
+    dark: dict[str, str] = {}
+    for block in re.findall(r"[^{}]*dark[^{}]*\{([^}]*)\}", text, re.IGNORECASE):
+        for name, value in VAR_DECL.findall(block):
+            dark[name] = value.strip()
+    return dark
+
+
+def resolve(value: str, table: dict[str, str], depth: int = 0) -> str | None:
+    if depth > 6:
+        return None
+    value = value.strip()
+    if value in NAMED:
+        return NAMED[value]
+    m = HEX_RE.search(value)
+    if m:
+        h = m.group(1)
+        if len(h) == 3:
+            h = "".join(c * 2 for c in h)
+        return "#" + h.lower()
+    var = re.match(r"var\(\s*(--[\w-]+)\s*(?:,\s*(.+))?\)", value)
+    if var:
+        name, fallback = var.group(1), var.group(2)
+        if name in table:
+            resolved = resolve(table[name], table, depth + 1)
+            if resolved:
+                return resolved
+        if fallback:
+            return resolve(fallback, table, depth + 1)
+    return None
+
+
+def luminance(hex_color: str) -> float:
+    rgb = [int(hex_color[i : i + 2], 16) / 255 for i in (1, 3, 5)]
+    lin = [c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in rgb]
+    return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2]
+
+
+def contrast(fg: str, bg: str) -> float:
+    l1, l2 = sorted((luminance(fg), luminance(bg)), reverse=True)
+    return (l1 + 0.05) / (l2 + 0.05)
+
+
+def btn_primary_pair(css: Path) -> tuple[str, str]:
+    text = css.read_text()
+    m = re.search(r"btn-primary\s*\{([^}]*)\}", text)
+    if not m:
+        sys.exit(f"FAIL: no btn-primary rule found in {css}")
+    body = m.group(1)
+    bg = re.search(r"background\s*:\s*([^;]+);", body)
+    fg = re.search(r"color\s*:\s*([^;]+);", body)
+    if not bg or not fg:
+        sys.exit(f"FAIL: btn-primary in {css} lacks explicit background/color")
+    return bg.group(1).strip(), fg.group(1).strip()
+
+
+def main() -> int:
+    base = parse_vars(VENDOR_CSS, BRIDGE_CSS)
+    dark_overrides = parse_dark_vars(BRIDGE_CSS)
+    bg_raw, fg_raw = btn_primary_pair(GLOBAL_CSS)
+
+    failures = []
+    for mode, table in (
+        ("light", base),
+        ("dark", {**base, **dark_overrides}),
+    ):
+        bg = resolve(bg_raw, table)
+        fg = resolve(fg_raw, table)
+        if bg is None or fg is None:
+            failures.append(f"{mode}: cannot resolve pair bg={bg_raw!r} fg={fg_raw!r}")
+            continue
+        ratio = contrast(fg, bg)
+        status = "OK " if ratio >= AA_NORMAL else "FAIL"
+        print(f"{status} btn-primary [{mode}] {fg} on {bg} = {ratio:.3f}:1 (AA needs {AA_NORMAL}:1)")
+        if ratio < AA_NORMAL:
+            failures.append(f"{mode}: {ratio:.3f}:1 < {AA_NORMAL}:1 ({fg} on {bg})")
+
+    if failures:
+        print("FAIL: .btn-primary violates WCAG AA contrast:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("ParkHub btn-primary contrast contract OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test-btn-contrast.sh
+++ b/scripts/tests/test-btn-contrast.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# WCAG AA contrast contract for .btn-primary (parkhub-web, vendored
+# securanido palette). Regression guard for the white-on-#ab7220 (4.07:1)
+# violation that shipped with the v5 token vendoring.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+echo "==> btn-primary WCAG AA contrast contract"
+python3 scripts/check-btn-contrast.py

--- a/scripts/tests/test-ui-polish-contract.sh
+++ b/scripts/tests/test-ui-polish-contract.sh
@@ -33,3 +33,6 @@ for phrase in "Coming soon" "Booking studio" "MARMOR GOVERNANCE STUDIO" "OPERATI
 done
 
 echo "ParkHub UI polish contract OK."
+
+# WCAG AA contrast contract for design-system token pairs (static, no browser).
+python3 scripts/check-btn-contrast.py


### PR DESCRIPTION
## What

Two regressions that shipped with the securanido token vendoring (#532), plus a permanent guard:

1. **WCAG AA fix**: `.btn-primary` rendered white on `--color-primary-700` (#ab7220) = 4.07:1 (< 4.5:1, axe `color-contrast` serious — caught by parkhub-rust's axe e2e on #679; php had no equivalent test). Now uses the design-system token pair: light 4.995:1, dark (dark ink on amber) 10.584:1, fallback 6.729:1, earned-amber dark-hover 7.766:1. Parity port of parkhub-rust `598765d5`.
2. **purple→coral crash fix**: the rename in `BadgeVariant`/`BADGE_COLORS` left call sites passing `'purple'` → `BADGE_COLORS[variant]` destructures `undefined`, crashing Rangliste/Vorhersagen/Buchungen/Nutzer/Profil at render (11 vitest failures on main). All design-v5 call sites renamed.
3. **Static WCAG contrast gate**: `scripts/check-btn-contrast.py` (stdlib-only, no browser) resolves the btn-primary var chains against the vendored palette per mode and fails below AA — wired into the always-on ui-polish contract. It reproduced axe's 4.070:1 exactly before the fix.

## Verification

- vitest: 175 files / 2507 tests green (was 11 failing on main)
- Full genuine local CI incl. Playwright design-smoke: passed (report for HEAD)
- tsc advisory: only 3 pre-existing Welcome.tsx hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)