### PR TITLE
fix(a11y): AA contrast for text-primary-700 on light surfaces + static gate extension

### DIFF
--- a/RESUME.md
+++ b/RESUME.md
@@ -1,0 +1,62 @@
+# E7 Dependabot fop/local-ci/pr bridge — RESUME
+
+## Status
+
+Authored and staged. Commit `f1727364eab62c8da8ba471b981b66b4bbde4b7e` ready. Push blocked by 2 pre-existing parkhub-php gate issues, neither caused by this PR.
+
+## What was done
+
+New GHA + Gitea-Actions workflow that auto-posts `fop/local-ci/pr: success|failure` commit status on Dependabot-authored PRs. Detects `github.event.pull_request.user.login == 'dependabot[bot]'`, runs the headless equivalent of `make ci` (composer-audit hard, npm-audit advisory, gitleaks secret scan hard, osv-scanner advisory, typos advisory), posts via `gh api POST /repos/.../statuses/{sha}`.
+
+Closes the architectural gap that's keeping these 8 PRs in MERGEABLE+BLOCKED state:
+- parkhub-php: #493, #496, #498
+- parkhub-rust: #638, #639, #640, #641, #642 (parallel PR needed for rust later)
+
+Workflow uses SHA-pinned actions reused from `security.yml` + `ci.yml`. Both `.github/workflows/dependabot-local-ci-bridge.yml` (GHA) and `.gitea/workflows/dependabot-local-ci-bridge.yaml` (Gitea mirror) committed.
+
+## Push blockers (pre-existing, NOT introduced by this PR)
+
+### Blocker 1: `image-scan` lefthook gate — devalue 5.6.4 HIGH CVE
+
+```
+image-scan: Container image scan surfaced CRITICAL/HIGH vulnerabilities.
+─────────────────────────────────────────────────────────────────────────────
+Total: 1 (HIGH: 1, CRITICAL: 0)
+devalue  CVE-2026-42570  HIGH  fixed  5.6.4  5.8.1
+Svelte devalue: DoS via sparse array deserialization
+```
+
+- `parkhub-web/package.json` has `"devalue": "^5.6.4"` (caret range).
+- A fresh `npm install` would resolve to `5.8.1`+ on most networks, but the LOCAL image cache holds a build pinned at 5.6.4.
+- **Fix**: either (a) bump package.json pin to `"devalue": "^5.8.1"` so any rebuild forces ≥5.8.1, or (b) operator runs `docker build` + `scripts/local-image-scan.sh` to refresh the local image cache.
+
+### Blocker 2: `local-ci` gate — `make ci` itself failing
+
+`make ci` exits non-zero because the image-scan step (blocker 1) inside it fails. The lefthook gate sees the resulting `.fop/reports/local-ci-pr-f172736….json` state as `failure` and refuses the push.
+
+This is downstream of blocker 1. Fixing devalue unblocks both.
+
+## Push commands (run after blockers cleared)
+
+```bash
+cd /home/florian/dev/parkhub-php.t-dependabot-local-ci-bridge
+# Refresh image cache OR bump devalue first, then:
+FOP_LOCAL_CI_DIRECT=1 make ci   # regenerate local-ci report at state=success
+git push github HEAD
+flatpak-spawn --host gh -R nash87/parkhub-php pr create --base main \
+  --head t-dependabot-local-ci-bridge \
+  --title "feat(ci): bridge fop/local-ci/pr status for Dependabot PRs (unblock 8 stuck PRs)" \
+  --body-file PR_BODY.md
+```
+
+## Why this is NOT a `--no-verify` bypass
+
+Per CLAUDE.md L237 + the 2026-05-19 E4 incident memory, bypassing lefthook pre-push is forbidden. The right path when blocked by unrelated pre-existing failures is to STOP and let the operator address the upstream issue — exactly what this RESUME.md documents.
+
+Sibling fix-forward branches checked (`git branch -r --no-merged origin/main | head`): none address the devalue image-scan issue.
+
+## Cross-references
+
+- Memory `feedback_subagent_no_verify_misuse_e4_schemathesis_2026_05_19.md` — the discipline this resume honors.
+- Memory `feedback_parkhub_rust_prepush_layered_gates_2026_05_19.md` — analogous parkhub-rust pattern.
+- Task #11 / #20 in the fop task board.

--- a/parkhub-web/src/styles/global.css
+++ b/parkhub-web/src/styles/global.css
@@ -330,6 +330,21 @@ p { line-height: 1.6; }
   background: var(--color-primary-600);
 }
 
+/* WCAG AA: amber TEXT on light surfaces. The securanido --color-primary-700
+   (#ab7220) reads at 4.07:1 on white (axe color-contrast, serious — caught
+   on the login links in parkhub-rust #679). Dozens of call sites use
+   text-primary-700 on light backgrounds, so fix the utility's computed
+   color once instead of touching every view: --color-primary-800 (#7d5316)
+   → 6.729:1 on white ✓. :not(.dark) scoping keeps dark-mode variants
+   (dark:text-primary-400) authoritative. Backgrounds/borders/rings keep
+   the palette value. Design-debt: migrate call sites to a semantic
+   on-surface accent token. Parity with parkhub-rust design-v5-warm. */
+@layer utilities {
+  :root:not(.dark) .text-primary-700 {
+    color: var(--color-primary-800);
+  }
+}
+
 @utility btn-secondary {
   background: var(--theme-bg-muted);
   color: var(--theme-text);

--- a/scripts/check-btn-contrast.py
+++ b/scripts/check-btn-contrast.py
@@ -118,6 +118,8 @@ def main() -> int:
         if ratio < AA_NORMAL:
             failures.append(f"{mode}: {ratio:.3f}:1 < {AA_NORMAL}:1 ({fg} on {bg})")
 
+    failures.extend(check_amber_text_on_light())
+
     if failures:
         print("FAIL: .btn-primary violates WCAG AA contrast:", file=sys.stderr)
         for f in failures:
@@ -126,6 +128,35 @@ def main() -> int:
     print("ParkHub btn-primary contrast contract OK.")
     return 0
 
+
+
+
+def check_amber_text_on_light() -> list[str]:
+    """text-primary-700 on light surfaces must meet AA.
+
+    The palette's --color-primary-700 (#ab7220) reads 4.01:1 on white —
+    axe caught it on the login links (parkhub-rust #679). The fix is a
+    light-mode-scoped @layer utilities override mapping the utility to
+    --color-primary-800. This check computes the EFFECTIVE light-mode
+    color of .text-primary-700 (override if present, else palette) and
+    fails below AA on white.
+    """
+    table = parse_vars(VENDOR_CSS, BRIDGE_CSS)
+    css = GLOBAL_CSS.read_text()
+    m = re.search(
+        r":root:not\(\.dark\)\s+\.text-primary-700\s*\{[^}]*color\s*:\s*([^;]+);",
+        css,
+    )
+    effective_raw = m.group(1).strip() if m else "var(--color-primary-700)"
+    fg = resolve(effective_raw, table)
+    if fg is None:
+        return [f"text-primary-700: cannot resolve effective color {effective_raw!r}"]
+    ratio = contrast(fg, "#ffffff")
+    status = "OK " if ratio >= AA_NORMAL else "FAIL"
+    print(f"{status} text-primary-700 [light, on white] {fg} = {ratio:.3f}:1 (AA needs {AA_NORMAL}:1)")
+    if ratio < AA_NORMAL:
+        return [f"text-primary-700 light: {ratio:.3f}:1 < {AA_NORMAL}:1 ({fg} on #ffffff)"]
+    return []
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## What

Parity port of the parkhub-rust #679 axe finding: `text-primary-700` on white reads **4.07:1** (< 4.5 AA) under the vendored securanido amber palette. One light-mode-scoped `@layer utilities` override maps the text utility to `--color-primary-800` (6.729:1 ✓) instead of touching dozens of call sites; `dark:text-primary-*` variants stay authoritative via `:root:not(.dark)` scoping.

Note: php's `@theme` palette is teal while the vendored v5 palette is amber — which one the browser resolves depends on load order per surface. The override is contrast-safe under **both** palettes (primary-800 is dark in each).

Extends `scripts/check-btn-contrast.py` with `check_amber_text_on_light()` — computes the *effective* light-mode color of `.text-primary-700` (override if present, else palette). Reproduced 4.070:1 RED before the fix, 6.729:1 GREEN after; runs in every `make ci` via the ui-polish contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)