### PR TITLE
fix(ci): drop unsupported php from CodeQL matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,9 +67,12 @@ jobs:
           # both Astro 5 + React 19 frontend + Vitest specs.
           - language: javascript-typescript
             build-mode: none
-          # PHP analysis covers the Laravel backend.
-          - language: php
-            build-mode: none
+          # NOTE: CodeQL does not support PHP (and never has) — older
+          # codeql-action versions silently tolerated the unknown matrix
+          # entry; v4.36+ fails init with "Did not recognize the following
+          # languages: php" (broke dependabot #529). PHP SAST coverage
+          # comes from PHPStan level 5 in local CI + the security.yml
+          # composer-audit/osv gates instead.
 
     steps:
       - name: Checkout


### PR DESCRIPTION
CodeQL has never supported PHP; codeql-action v4.36+ hard-fails init with `Did not recognize the following languages: php` (surfaced by #529's action bump — older versions tolerated the unknown matrix entry). JS/TS analysis stays; PHP SAST = PHPStan level 5 + composer-audit/osv gates. Unblocks #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)