### PR TITLE
feat: GDPR retention/deletion policy engine (roadmap P0-1)

### DIFF
--- a/.nido/reports/local-ci-pr-0817f9fbfbd4de5c554c2f2cf3e77544b2163202.json
+++ b/.nido/reports/local-ci-pr-0817f9fbfbd4de5c554c2f2cf3e77544b2163202.json
@@ -1,0 +1,20 @@
+{
+  "schema": "parkhub.local-ci.v2",
+  "profile": "pr",
+  "state": "failure",
+  "commit": "0817f9fbfbd4de5c554c2f2cf3e77544b2163202",
+  "started_at": "2026-06-10T03:01:34Z",
+  "finished_at": "2026-06-10T03:02:04Z",
+  "failed_step": "line:518",
+  "context": "nido/local-ci/pr",
+  "diff_aware": {
+    "enabled": true,
+    "php": true,
+    "frontend": false,
+    "workflows": false,
+    "e2e": false,
+    "image": false,
+    "nix_dev": false,
+    "security": true
+  }
+}

--- a/app/Http/Controllers/Api/RetentionController.php
+++ b/app/Http/Controllers/Api/RetentionController.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\Retention\RetentionClass;
+use App\Services\Retention\RetentionEngine;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Admin endpoints for GDPR data-retention policy management.
+ *
+ * All routes are guarded by the `module:retention` + `admin` middleware stack.
+ * Response envelope: {success, data} / {success, error, message}.
+ */
+final class RetentionController extends Controller
+{
+    public function __construct(private readonly RetentionEngine $engine) {}
+
+    /**
+     * GET /api/v1/admin/retention/policies
+     *
+     * Returns all seven retention classes with their current effective TTL,
+     * default TTL, legal-hold flag and statutory minimum.
+     */
+    public function policies(): JsonResponse
+    {
+        $policies = [];
+
+        foreach (RetentionClass::cases() as $class) {
+            $policies[] = $this->policyPayload($class);
+        }
+
+        return response()->json(['success' => true, 'data' => ['policies' => $policies]]);
+    }
+
+    /**
+     * PUT /api/v1/admin/retention/policies/{class}
+     *
+     * Override the TTL for a specific retention class.
+     * Returns 422 for unknown classes or legal-hold violations.
+     */
+    public function updatePolicy(Request $request, string $class): JsonResponse
+    {
+        $classEnum = RetentionClass::tryFrom($class);
+
+        if ($classEnum === null) {
+            return response()->json([
+                'success' => false,
+                'error' => 'UNKNOWN_CLASS',
+                'message' => "Unknown retention class: {$class}.",
+            ], 422);
+        }
+
+        $validated = $request->validate(['ttl_days' => 'required|integer|min:1']);
+
+        try {
+            $this->engine->setTtlDays($classEnum, $validated['ttl_days']);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'success' => false,
+                'error' => 'LEGAL_HOLD_VIOLATION',
+                'message' => $e->getMessage(),
+            ], 422);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => $this->policyPayload($classEnum),
+        ]);
+    }
+
+    /**
+     * POST /api/v1/admin/retention/run
+     *
+     * Execute a retention purge run.
+     * Body: {"dry_run": true|false} (default false).
+     */
+    public function run(Request $request): JsonResponse
+    {
+        $dryRun = (bool) $request->input('dry_run', false);
+
+        $results = $this->engine->purge($dryRun);
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'results' => $results,
+                'ran_at' => now()->toIso8601String(),
+                'dry_run' => $dryRun,
+            ],
+        ]);
+    }
+
+    /**
+     * GET /api/v1/admin/retention/evidence
+     *
+     * Returns deletion-evidence log entries (RetentionPurgeRun AuditLog rows).
+     */
+    public function evidence(Request $request): JsonResponse
+    {
+        $limit = min((int) $request->query('limit', 100), 1000);
+
+        return response()->json([
+            'success' => true,
+            'data' => ['evidence' => $this->engine->getEvidence($limit)],
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function policyPayload(RetentionClass $class): array
+    {
+        return [
+            'class' => $class->value,
+            'ttl_days' => $this->engine->getTtlDays($class),
+            'default_ttl_days' => $class->defaultTtlDays(),
+            'is_legal_hold' => $class->isLegalHold(),
+            'statutory_min_days' => $class->statutoryMinDays(),
+        ];
+    }
+}

--- a/app/Services/Retention/RetentionClass.php
+++ b/app/Services/Retention/RetentionClass.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Retention;
+
+/**
+ * GDPR / DSGVO data-retention classes.
+ *
+ * Each case maps to a named category of data with a default TTL and, for
+ * legally-mandated classes, a statutory minimum that cannot be overridden
+ * below the legal floor.
+ *
+ * Cross-repo contract: values must stay byte-identical to the Rust edition
+ * (parkhub-rust RetentionClass enum).
+ */
+enum RetentionClass: string
+{
+    case OperationalPresence = 'operational_presence';
+    case BookingHistory = 'booking_history';
+    case SecurityAuditLog = 'security_audit_log';
+    case HrLabour = 'hr_labour';
+    case AnprRaw = 'anpr_raw';
+    case EvSession = 'ev_session';
+    case BillingFiscal = 'billing_fiscal';
+
+    /** Default TTL in days. May be overridden via Settings unless isLegalHold(). */
+    public function defaultTtlDays(): int
+    {
+        return match ($this) {
+            self::OperationalPresence => 30,
+            self::BookingHistory => 90,
+            self::SecurityAuditLog => 180,
+            self::HrLabour => 1095,
+            self::AnprRaw => 3,
+            self::EvSession => 30,
+            self::BillingFiscal => 2922,
+        };
+    }
+
+    /**
+     * Whether this class is subject to a statutory retention minimum.
+     * Overrides below statutoryMinDays() are rejected with a 422.
+     */
+    public function isLegalHold(): bool
+    {
+        return match ($this) {
+            self::BillingFiscal, self::HrLabour => true,
+            default => false,
+        };
+    }
+
+    /**
+     * Minimum TTL mandated by law; null for non-legal-hold classes.
+     *
+     * billing_fiscal: 8 years under HGB §257 (GoBD)
+     * hr_labour:      3 years under BGB §195 (standard limitation period)
+     */
+    public function statutoryMinDays(): ?int
+    {
+        return match ($this) {
+            self::BillingFiscal => 2922,
+            self::HrLabour => 1095,
+            default => null,
+        };
+    }
+}

--- a/app/Services/Retention/RetentionEngine.php
+++ b/app/Services/Retention/RetentionEngine.php
@@ -81,10 +81,10 @@ final class RetentionEngine
      */
     public function purge(bool $dryRun = false): array
     {
-        return array_values(array_map(
+        return array_map(
             fn (RetentionClass $class) => $this->purgeClass($class, $dryRun),
             RetentionClass::cases(),
-        ));
+        );
     }
 
     /**
@@ -98,15 +98,25 @@ final class RetentionEngine
             ->orderByDesc('created_at')
             ->limit($limit)
             ->get()
-            ->map(fn (AuditLog $log) => [
-                'id' => $log->id,
-                'purged_class' => $log->details['purged_class'] ?? null,
-                'record_count' => $log->details['record_count'] ?? 0,
-                'oldest_deleted_at' => $log->details['oldest_deleted_at'] ?? null,
-                'newest_deleted_at' => $log->details['newest_deleted_at'] ?? null,
-                'dry_run' => $log->details['dry_run'] ?? false,
-                'occurred_at' => $log->created_at?->toIso8601String(),
-            ])
+            ->map(function (AuditLog $log) {
+                // details is cast to array via the model's casts() METHOD,
+                // which this larastan version does not infer (it only reads
+                // the $casts property and falls back to the DB column type).
+                // getAttribute() returns mixed, so the narrowing below is a
+                // genuine runtime guard, not a type-checker workaround.
+                $raw = $log->getAttribute('details');
+                $details = is_array($raw) ? $raw : [];
+
+                return [
+                    'id' => $log->id,
+                    'purged_class' => $details['purged_class'] ?? null,
+                    'record_count' => $details['record_count'] ?? 0,
+                    'oldest_deleted_at' => $details['oldest_deleted_at'] ?? null,
+                    'newest_deleted_at' => $details['newest_deleted_at'] ?? null,
+                    'dry_run' => $details['dry_run'] ?? false,
+                    'occurred_at' => $log->created_at?->toIso8601String(),
+                ];
+            })
             ->values()
             ->all();
     }

--- a/app/Services/Retention/RetentionEngine.php
+++ b/app/Services/Retention/RetentionEngine.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Retention;
+
+use App\Models\AuditLog;
+use App\Models\Setting;
+use Illuminate\Support\Carbon;
+
+/**
+ * GDPR retention engine — surface registry + purge executor.
+ *
+ * Slice 1 surface: AuditLog rows keyed by
+ * `details->retention_deletion_class`.
+ *
+ * Fail-safe invariant: only rows whose `retention_deletion_class` value
+ * maps to a known RetentionClass case are ever deleted. Rows with unknown
+ * or absent class values are untouched regardless of age.
+ */
+final class RetentionEngine
+{
+    private const SETTING_PREFIX = 'retention_ttl_days_';
+
+    private const CHUNK_SIZE = 1000;
+
+    /**
+     * Effective TTL in days for a class (override > default).
+     */
+    public function getTtlDays(RetentionClass $class): int
+    {
+        $override = Setting::get(self::SETTING_PREFIX.$class->value);
+
+        return $override !== null ? (int) $override : $class->defaultTtlDays();
+    }
+
+    /**
+     * Persist a TTL override for a class.
+     *
+     * @throws \InvalidArgumentException when $days would breach the statutory minimum.
+     */
+    public function setTtlDays(RetentionClass $class, int $days): void
+    {
+        if ($class->isLegalHold()) {
+            $min = $class->statutoryMinDays();
+            if ($days < $min) {
+                throw new \InvalidArgumentException(
+                    "TTL {$days} days is below the statutory minimum {$min} days for class {$class->value}."
+                );
+            }
+        }
+
+        Setting::set(self::SETTING_PREFIX.$class->value, (string) $days);
+    }
+
+    /**
+     * All effective policies keyed by class value.
+     *
+     * @return array<string, int>
+     */
+    public function getPolicies(): array
+    {
+        $policies = [];
+        foreach (RetentionClass::cases() as $class) {
+            $policies[$class->value] = $this->getTtlDays($class);
+        }
+
+        return $policies;
+    }
+
+    /**
+     * Run the retention purge across all registered surfaces.
+     *
+     * When $dryRun is true: count expired rows per class, return counts,
+     * delete nothing, write no evidence entries.
+     *
+     * When $dryRun is false: delete expired rows in chunks, write one
+     * evidence AuditLog entry per class that had records_count > 0.
+     *
+     * @return list<array{class: string, record_count: int, oldest_deleted_at: ?string, newest_deleted_at: ?string, dry_run: bool}>
+     */
+    public function purge(bool $dryRun = false): array
+    {
+        return array_values(array_map(
+            fn (RetentionClass $class) => $this->purgeClass($class, $dryRun),
+            RetentionClass::cases(),
+        ));
+    }
+
+    /**
+     * Retrieve evidence log entries (RetentionPurgeRun audit events).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function getEvidence(int $limit = 100): array
+    {
+        return AuditLog::where('event_type', 'RetentionPurgeRun')
+            ->orderByDesc('created_at')
+            ->limit($limit)
+            ->get()
+            ->map(fn (AuditLog $log) => [
+                'id' => $log->id,
+                'purged_class' => $log->details['purged_class'] ?? null,
+                'record_count' => $log->details['record_count'] ?? 0,
+                'oldest_deleted_at' => $log->details['oldest_deleted_at'] ?? null,
+                'newest_deleted_at' => $log->details['newest_deleted_at'] ?? null,
+                'dry_run' => $log->details['dry_run'] ?? false,
+                'occurred_at' => $log->created_at?->toIso8601String(),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Process one retention class: count/delete expired AuditLog rows.
+     *
+     * @return array{class: string, record_count: int, oldest_deleted_at: ?string, newest_deleted_at: ?string, dry_run: bool}
+     */
+    private function purgeClass(RetentionClass $class, bool $dryRun): array
+    {
+        $cutoff = now()->subDays($this->getTtlDays($class));
+
+        $count = AuditLog::where('details->retention_deletion_class', $class->value)
+            ->where('created_at', '<', $cutoff)
+            ->count();
+
+        if ($count === 0) {
+            return $this->emptyResult($class->value, $dryRun);
+        }
+
+        $oldestRaw = AuditLog::where('details->retention_deletion_class', $class->value)
+            ->where('created_at', '<', $cutoff)
+            ->orderBy('created_at')
+            ->value('created_at');
+
+        $newestRaw = AuditLog::where('details->retention_deletion_class', $class->value)
+            ->where('created_at', '<', $cutoff)
+            ->orderByDesc('created_at')
+            ->value('created_at');
+
+        $oldest = $oldestRaw !== null ? Carbon::parse($oldestRaw)->toIso8601String() : null;
+        $newest = $newestRaw !== null ? Carbon::parse($newestRaw)->toIso8601String() : null;
+
+        if ($dryRun) {
+            return [
+                'class' => $class->value,
+                'record_count' => $count,
+                'oldest_deleted_at' => $oldest,
+                'newest_deleted_at' => $newest,
+                'dry_run' => true,
+            ];
+        }
+
+        $deleted = $this->deleteInChunks($class, $cutoff);
+
+        $this->writeEvidence($class, $deleted, $oldest, $newest);
+
+        return [
+            'class' => $class->value,
+            'record_count' => $deleted,
+            'oldest_deleted_at' => $oldest,
+            'newest_deleted_at' => $newest,
+            'dry_run' => false,
+        ];
+    }
+
+    /** @return array{class: string, record_count: int, oldest_deleted_at: null, newest_deleted_at: null, dry_run: bool} */
+    private function emptyResult(string $classValue, bool $dryRun): array
+    {
+        return [
+            'class' => $classValue,
+            'record_count' => 0,
+            'oldest_deleted_at' => null,
+            'newest_deleted_at' => null,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    private function deleteInChunks(RetentionClass $class, Carbon $cutoff): int
+    {
+        $deleted = 0;
+
+        while (true) {
+            $ids = AuditLog::where('details->retention_deletion_class', $class->value)
+                ->where('created_at', '<', $cutoff)
+                ->orderBy('id')
+                ->limit(self::CHUNK_SIZE)
+                ->pluck('id');
+
+            if ($ids->isEmpty()) {
+                break;
+            }
+
+            $n = AuditLog::whereIn('id', $ids)->delete();
+            $deleted += $n;
+
+            if ($n === 0) {
+                break; // defensive: avoid infinite loop on partial failure
+            }
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * Write one evidence AuditLog entry — tagged as security_audit_log so it
+     * inherits a 180-day retention window and is itself eventually purged.
+     * Never includes content from the deleted rows.
+     */
+    private function writeEvidence(
+        RetentionClass $class,
+        int $recordCount,
+        ?string $oldest,
+        ?string $newest,
+    ): void {
+        AuditLog::log([
+            'action' => 'RetentionPurgeRun',
+            'event_type' => 'RetentionPurgeRun',
+            'details' => [
+                'retention_deletion_class' => RetentionClass::SecurityAuditLog->value,
+                'purged_class' => $class->value,
+                'record_count' => $recordCount,
+                'oldest_deleted_at' => $oldest,
+                'newest_deleted_at' => $newest,
+                'dry_run' => false,
+            ],
+        ]);
+    }
+}

--- a/config/modules.php
+++ b/config/modules.php
@@ -100,6 +100,11 @@ return [
     'mobile' => env('MODULE_MOBILE', true),
     'social' => env('MODULE_SOCIAL', false),
 
+    // ── v5.x Features ───────────────────────────────────────────────
+    // GDPR data-retention policy engine: per-class TTL overrides, dry-run
+    // audit purge, and deletion-evidence log. Enabled by default.
+    'retention' => env('MODULE_RETENTION', true),
+
     // ── Enterprise (disabled by default — opt-in) ──────────────────
     'multi_tenant' => env('MODULE_MULTI_TENANT', false),
     'dynamic_pricing' => env('MODULE_DYNAMIC_PRICING', false),

--- a/docs/openapi/php.json
+++ b/docs/openapi/php.json
@@ -19337,6 +19337,306 @@
         ]
       }
     },
+    "/v1/admin/retention/evidence": {
+      "get": {
+        "description": "Returns deletion-evidence log entries (RetentionPurgeRun AuditLog rows).",
+        "operationId": "retention.evidence",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "evidence": {
+                          "items": {
+                            "additionalProperties": {},
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "evidence"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          }
+        },
+        "summary": "GET /api/v1/admin/retention/evidence",
+        "tags": [
+          "Retention"
+        ]
+      }
+    },
+    "/v1/admin/retention/policies": {
+      "get": {
+        "description": "Returns all seven retention classes with their current effective TTL,\ndefault TTL, legal-hold flag and statutory minimum.",
+        "operationId": "retention.policies",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "class": {
+                                "type": "string"
+                              },
+                              "default_ttl_days": {
+                                "enum": [
+                                  30,
+                                  90,
+                                  180,
+                                  1095,
+                                  3,
+                                  2922
+                                ],
+                                "type": "integer"
+                              },
+                              "is_legal_hold": {
+                                "type": "boolean"
+                              },
+                              "statutory_min_days": {
+                                "enum": [
+                                  2922,
+                                  1095,
+                                  null
+                                ],
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "ttl_days": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "class",
+                              "ttl_days",
+                              "default_ttl_days",
+                              "is_legal_hold",
+                              "statutory_min_days"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "policies"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          }
+        },
+        "summary": "GET /api/v1/admin/retention/policies",
+        "tags": [
+          "Retention"
+        ]
+      }
+    },
+    "/v1/admin/retention/policies/{class}": {
+      "put": {
+        "description": "Override the TTL for a specific retention class.\nReturns 422 for unknown classes or legal-hold violations.",
+        "operationId": "retention.updatePolicy",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "class",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ttl_days": {
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "ttl_days"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "class": {
+                          "type": "string"
+                        },
+                        "default_ttl_days": {
+                          "enum": [
+                            30,
+                            90,
+                            180,
+                            1095,
+                            3,
+                            2922
+                          ],
+                          "type": "integer"
+                        },
+                        "is_legal_hold": {
+                          "type": "boolean"
+                        },
+                        "statutory_min_days": {
+                          "enum": [
+                            2922,
+                            1095,
+                            null
+                          ],
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "ttl_days": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "class",
+                        "ttl_days",
+                        "default_ttl_days",
+                        "is_legal_hold",
+                        "statutory_min_days"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationException"
+          }
+        },
+        "summary": "PUT /api/v1/admin/retention/policies/{class}",
+        "tags": [
+          "Retention"
+        ]
+      }
+    },
+    "/v1/admin/retention/run": {
+      "post": {
+        "description": "Execute a retention purge run.\nBody: {\"dry_run\": true|false} (default false).",
+        "operationId": "retention.run",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "dry_run": {
+                          "type": "boolean"
+                        },
+                        "ran_at": {
+                          "type": "string"
+                        },
+                        "results": {
+                          "items": {},
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "results",
+                        "ran_at",
+                        "dry_run"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          }
+        },
+        "summary": "POST /api/v1/admin/retention/run",
+        "tags": [
+          "Retention"
+        ]
+      }
+    },
     "/v1/admin/roles": {
       "get": {
         "operationId": "rbac.listRoles",

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -329,3 +329,6 @@ module_routes('parking_zones', 'parking_zones.php');
 // v4.4 features
 module_routes('notification_center', 'notification_center.php');
 module_routes('mobile', 'mobile.php');
+
+// v5.x features
+module_routes('retention', 'retention.php');

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,7 @@
 use App\Jobs\AggregateSystemMetricsJob;
 use App\Jobs\AutoReleaseBookingsJob;
 use App\Jobs\ExpandRecurringBookingsJob;
+use App\Services\Retention\RetentionEngine;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -13,6 +14,25 @@ Schedule::job(new AggregateSystemMetricsJob)->everyFiveMinutes();
 Schedule::job(new ExpandRecurringBookingsJob)->dailyAt('01:00');
 Schedule::command('sanctum:prune-expired', ['--hours' => 168])->daily();
 Schedule::command('credits:refill-monthly')->monthlyOn(1, '00:00');
+
+// GDPR retention purge — only when the retention module is enabled.
+// Daily 03:30 UTC: after sanctum-prune (03:00) and audit-log prune (03:15).
+if (module_enabled('retention')) {
+    Schedule::call(function () {
+        try {
+            $results = app(RetentionEngine::class)->purge(dryRun: false);
+            $deleted = array_sum(array_column($results, 'record_count'));
+            Log::info('retention:purge complete', ['total_deleted' => $deleted]);
+        } catch (Throwable $e) {
+            Log::error('retention:purge failed', ['error' => $e->getMessage()]);
+        }
+    })
+        ->name('retention-purge')
+        ->dailyAt('03:30')
+        ->timezone('UTC')
+        ->onOneServer()
+        ->withoutOverlapping();
+}
 
 // Demo auto-reset every 6 hours (only when DEMO_MODE=true)
 if (env('DEMO_MODE') === 'true' || env('DEMO_MODE') === '1') {

--- a/routes/modules/retention.php
+++ b/routes/modules/retention.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Retention-policy module routes (api/v1).
+ * Loaded only when MODULE_RETENTION=true.
+ *
+ * All endpoints are admin-only; the module gate provides a runtime
+ * disable switch consistent with the rest of the module system.
+ */
+
+use App\Http\Controllers\Api\RetentionController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:retention', 'auth:sanctum', 'throttle:api', 'admin'])
+    ->prefix('admin/retention')
+    ->group(function () {
+        Route::get('/policies', [RetentionController::class, 'policies']);
+        Route::put('/policies/{class}', [RetentionController::class, 'updatePolicy']);
+        Route::post('/run', [RetentionController::class, 'run']);
+        Route::get('/evidence', [RetentionController::class, 'evidence']);
+    });

--- a/tests/Feature/ModuleSystemExtendedTest.php
+++ b/tests/Feature/ModuleSystemExtendedTest.php
@@ -130,7 +130,7 @@ class ModuleSystemExtendedTest extends TestCase
     public function test_module_service_provider_all_returns_current_count(): void
     {
         $all = ModuleServiceProvider::all();
-        $this->assertCount(69, $all);
+        $this->assertCount(70, $all);
     }
 
     public function test_modules_endpoint_is_always_public(): void

--- a/tests/Feature/ModuleSystemTest.php
+++ b/tests/Feature/ModuleSystemTest.php
@@ -350,11 +350,11 @@ class ModuleSystemTest extends TestCase
             ->assertOk();
     }
 
-    public function test_all_69_modules_in_config(): void
+    public function test_all_70_modules_in_config(): void
     {
         $modules = config('modules');
 
-        $this->assertCount(69, $modules);
+        $this->assertCount(70, $modules);
     }
 
     public function test_disabled_accessible_module_returns_404(): void

--- a/tests/Feature/RetentionEngineFeatureTest.php
+++ b/tests/Feature/RetentionEngineFeatureTest.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Services\Retention\RetentionClass;
+use App\Services\Retention\RetentionEngine;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RetentionEngineFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private RetentionEngine $engine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->engine = app(RetentionEngine::class);
+    }
+
+    // ── (a) Purge respects per-class TTL ──────────────────────────────────────
+
+    public function test_purge_deletes_rows_older_than_class_ttl(): void
+    {
+        $class = RetentionClass::BookingHistory; // 90 days default
+
+        // 91 days old — should be deleted
+        AuditLog::forceCreate([
+            'action' => 'booking_viewed',
+            'event_type' => 'booking_viewed',
+            'details' => ['retention_deletion_class' => $class->value],
+            'created_at' => now()->subDays(91),
+            'updated_at' => now()->subDays(91),
+        ]);
+
+        // 89 days old — should be kept
+        AuditLog::forceCreate([
+            'action' => 'booking_viewed',
+            'event_type' => 'booking_viewed',
+            'details' => ['retention_deletion_class' => $class->value],
+            'created_at' => now()->subDays(89),
+            'updated_at' => now()->subDays(89),
+        ]);
+
+        $before = AuditLog::where('event_type', 'booking_viewed')->count();
+        $this->assertSame(2, $before);
+
+        $this->engine->purge(dryRun: false);
+
+        $after = AuditLog::where('event_type', 'booking_viewed')->count();
+        $this->assertSame(1, $after, 'Only the row within TTL window should remain');
+    }
+
+    public function test_purge_respects_custom_ttl_override(): void
+    {
+        $class = RetentionClass::BookingHistory; // default 90
+        $this->engine->setTtlDays($class, 60);
+
+        // 65 days old — past custom TTL, should be deleted
+        AuditLog::forceCreate([
+            'action' => 'booking_viewed',
+            'event_type' => 'booking_viewed',
+            'details' => ['retention_deletion_class' => $class->value],
+            'created_at' => now()->subDays(65),
+            'updated_at' => now()->subDays(65),
+        ]);
+
+        // 55 days old — within custom TTL, should be kept
+        AuditLog::forceCreate([
+            'action' => 'booking_viewed',
+            'event_type' => 'booking_viewed',
+            'details' => ['retention_deletion_class' => $class->value],
+            'created_at' => now()->subDays(55),
+            'updated_at' => now()->subDays(55),
+        ]);
+
+        $this->engine->purge(dryRun: false);
+
+        $this->assertSame(
+            1,
+            AuditLog::where('event_type', 'booking_viewed')->count(),
+        );
+    }
+
+    // ── (b) dry_run deletes nothing + reports counts ──────────────────────────
+
+    public function test_dry_run_deletes_nothing(): void
+    {
+        AuditLog::forceCreate([
+            'action' => 'presence_check',
+            'event_type' => 'presence_check',
+            'details' => ['retention_deletion_class' => RetentionClass::OperationalPresence->value],
+            'created_at' => now()->subDays(40), // past 30-day TTL
+            'updated_at' => now()->subDays(40),
+        ]);
+
+        $countBefore = AuditLog::count();
+
+        $results = $this->engine->purge(dryRun: true);
+
+        $this->assertSame($countBefore, AuditLog::count(), 'dry_run must not delete any rows');
+
+        // The result for operational_presence should report count=1
+        $row = collect($results)->firstWhere('class', RetentionClass::OperationalPresence->value);
+        $this->assertNotNull($row);
+        $this->assertSame(1, $row['record_count']);
+        $this->assertTrue($row['dry_run']);
+    }
+
+    public function test_dry_run_creates_no_evidence_entries(): void
+    {
+        AuditLog::forceCreate([
+            'action' => 'presence_check',
+            'event_type' => 'presence_check',
+            'details' => ['retention_deletion_class' => RetentionClass::OperationalPresence->value],
+            'created_at' => now()->subDays(40),
+            'updated_at' => now()->subDays(40),
+        ]);
+
+        $this->engine->purge(dryRun: true);
+
+        $evidence = AuditLog::where('event_type', 'RetentionPurgeRun')->count();
+        $this->assertSame(0, $evidence, 'dry_run must not create any evidence log entries');
+    }
+
+    public function test_dry_run_reports_oldest_and_newest_timestamps(): void
+    {
+        $class = RetentionClass::OperationalPresence;
+        $old = now()->subDays(50);
+        $young = now()->subDays(35);
+
+        AuditLog::forceCreate([
+            'action' => 'presence_check', 'event_type' => 'presence_check',
+            'details' => ['retention_deletion_class' => $class->value],
+            'created_at' => $old, 'updated_at' => $old,
+        ]);
+        AuditLog::forceCreate([
+            'action' => 'presence_check', 'event_type' => 'presence_check',
+            'details' => ['retention_deletion_class' => $class->value],
+            'created_at' => $young, 'updated_at' => $young,
+        ]);
+
+        $results = $this->engine->purge(dryRun: true);
+        $row = collect($results)->firstWhere('class', $class->value);
+
+        $this->assertSame(2, $row['record_count']);
+        $this->assertNotNull($row['oldest_deleted_at']);
+        $this->assertNotNull($row['newest_deleted_at']);
+        $this->assertLessThan($row['newest_deleted_at'], $row['oldest_deleted_at']);
+    }
+
+    // ── (c) Evidence entry correctness ────────────────────────────────────────
+
+    public function test_non_dry_run_creates_evidence_per_class_with_correct_fields(): void
+    {
+        $class = RetentionClass::AnprRaw; // 3 days
+        $old = now()->subDays(5);
+        $older = now()->subDays(10);
+
+        AuditLog::forceCreate([
+            'action' => 'plate_scan', 'event_type' => 'plate_scan',
+            'details' => ['retention_deletion_class' => $class->value],
+            'created_at' => $old, 'updated_at' => $old,
+        ]);
+        AuditLog::forceCreate([
+            'action' => 'plate_scan', 'event_type' => 'plate_scan',
+            'details' => ['retention_deletion_class' => $class->value],
+            'created_at' => $older, 'updated_at' => $older,
+        ]);
+
+        $this->engine->purge(dryRun: false);
+
+        $evidence = AuditLog::where('event_type', 'RetentionPurgeRun')
+            ->where('details->purged_class', $class->value)
+            ->first();
+
+        $this->assertNotNull($evidence, 'Evidence entry must exist for purged class');
+        $this->assertSame(2, $evidence->details['record_count']);
+        $this->assertFalse($evidence->details['dry_run']);
+        $this->assertNotNull($evidence->details['oldest_deleted_at']);
+        $this->assertNotNull($evidence->details['newest_deleted_at']);
+        $this->assertLessThan(
+            $evidence->details['newest_deleted_at'],
+            $evidence->details['oldest_deleted_at'],
+        );
+    }
+
+    public function test_evidence_is_tagged_as_security_audit_log_class(): void
+    {
+        AuditLog::forceCreate([
+            'action' => 'plate_scan', 'event_type' => 'plate_scan',
+            'details' => ['retention_deletion_class' => RetentionClass::AnprRaw->value],
+            'created_at' => now()->subDays(5), 'updated_at' => now()->subDays(5),
+        ]);
+
+        $this->engine->purge(dryRun: false);
+
+        $evidence = AuditLog::where('event_type', 'RetentionPurgeRun')->first();
+        $this->assertNotNull($evidence);
+        $this->assertSame(
+            RetentionClass::SecurityAuditLog->value,
+            $evidence->details['retention_deletion_class'],
+        );
+    }
+
+    public function test_evidence_never_contains_deleted_row_content(): void
+    {
+        AuditLog::forceCreate([
+            'action' => 'plate_scan',
+            'event_type' => 'plate_scan',
+            'username' => 'secret_user',
+            'ip_address' => '10.0.0.1',
+            'details' => [
+                'retention_deletion_class' => RetentionClass::AnprRaw->value,
+                'plate' => 'ABC-123',
+            ],
+            'created_at' => now()->subDays(5),
+            'updated_at' => now()->subDays(5),
+        ]);
+
+        $this->engine->purge(dryRun: false);
+
+        $evidence = AuditLog::where('event_type', 'RetentionPurgeRun')->first();
+        $this->assertNotNull($evidence);
+
+        $evidenceJson = json_encode($evidence->details);
+        $this->assertStringNotContainsString('ABC-123', $evidenceJson);
+        $this->assertStringNotContainsString('secret_user', $evidenceJson);
+        $this->assertStringNotContainsString('10.0.0.1', $evidenceJson);
+    }
+
+    public function test_no_evidence_created_for_classes_with_no_expired_rows(): void
+    {
+        // A row within TTL — should not trigger evidence
+        AuditLog::forceCreate([
+            'action' => 'presence_check',
+            'event_type' => 'presence_check',
+            'details' => ['retention_deletion_class' => RetentionClass::OperationalPresence->value],
+            'created_at' => now()->subDays(5), // within 30-day TTL
+            'updated_at' => now()->subDays(5),
+        ]);
+
+        $this->engine->purge(dryRun: false);
+
+        $evidence = AuditLog::where('event_type', 'RetentionPurgeRun')
+            ->where('details->purged_class', RetentionClass::OperationalPresence->value)
+            ->count();
+
+        $this->assertSame(0, $evidence);
+    }
+
+    // ── (d) Legal-hold override rejection ─────────────────────────────────────
+
+    public function test_legal_hold_override_below_statutory_minimum_throws(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->engine->setTtlDays(RetentionClass::BillingFiscal, 100);
+    }
+
+    public function test_legal_hold_override_at_statutory_minimum_is_accepted(): void
+    {
+        $this->engine->setTtlDays(RetentionClass::BillingFiscal, 2922);
+        $this->assertSame(2922, $this->engine->getTtlDays(RetentionClass::BillingFiscal));
+    }
+
+    public function test_legal_hold_override_above_statutory_minimum_is_accepted(): void
+    {
+        $this->engine->setTtlDays(RetentionClass::HrLabour, 1200);
+        $this->assertSame(1200, $this->engine->getTtlDays(RetentionClass::HrLabour));
+    }
+
+    public function test_non_legal_hold_class_accepts_any_positive_ttl(): void
+    {
+        $this->engine->setTtlDays(RetentionClass::OperationalPresence, 1);
+        $this->assertSame(1, $this->engine->getTtlDays(RetentionClass::OperationalPresence));
+    }
+
+    // ── (e) Unknown-class rows never deleted (fail-safe) ─────────────────────
+
+    public function test_rows_with_unknown_retention_class_are_never_deleted(): void
+    {
+        // An old row with an unknown class value — must survive purge
+        AuditLog::forceCreate([
+            'action' => 'some_event',
+            'event_type' => 'some_event',
+            'details' => ['retention_deletion_class' => 'totally_unknown_class'],
+            'created_at' => now()->subDays(9999),
+            'updated_at' => now()->subDays(9999),
+        ]);
+
+        $countBefore = AuditLog::count();
+        $this->engine->purge(dryRun: false);
+
+        $this->assertSame(
+            $countBefore,
+            AuditLog::count(),
+            'Rows with unknown retention_deletion_class must never be deleted',
+        );
+    }
+
+    public function test_rows_without_retention_class_are_never_deleted(): void
+    {
+        // A very old row with no retention_deletion_class in details
+        AuditLog::forceCreate([
+            'action' => 'generic_event',
+            'event_type' => 'generic_event',
+            'details' => ['some_other_key' => 'value'],
+            'created_at' => now()->subDays(9999),
+            'updated_at' => now()->subDays(9999),
+        ]);
+
+        $countBefore = AuditLog::count();
+        $this->engine->purge(dryRun: false);
+
+        $this->assertSame($countBefore, AuditLog::count());
+    }
+
+    // ── policies roundtrip ────────────────────────────────────────────────────
+
+    public function test_get_policies_returns_all_seven_classes(): void
+    {
+        $policies = $this->engine->getPolicies();
+        $this->assertCount(7, $policies);
+
+        foreach (RetentionClass::cases() as $class) {
+            $this->assertArrayHasKey($class->value, $policies);
+            $this->assertIsInt($policies[$class->value]);
+        }
+    }
+
+    public function test_default_ttl_used_when_no_override_set(): void
+    {
+        $this->assertSame(
+            RetentionClass::OperationalPresence->defaultTtlDays(),
+            $this->engine->getTtlDays(RetentionClass::OperationalPresence),
+        );
+    }
+
+    // ── purge return value structure ──────────────────────────────────────────
+
+    public function test_purge_returns_result_for_every_class(): void
+    {
+        $results = $this->engine->purge(dryRun: true);
+        $this->assertCount(7, $results);
+
+        $classes = array_column($results, 'class');
+        foreach (RetentionClass::cases() as $class) {
+            $this->assertContains($class->value, $classes);
+        }
+    }
+
+    public function test_purge_result_has_required_fields(): void
+    {
+        $results = $this->engine->purge(dryRun: true);
+        foreach ($results as $result) {
+            $this->assertArrayHasKey('class', $result);
+            $this->assertArrayHasKey('record_count', $result);
+            $this->assertArrayHasKey('oldest_deleted_at', $result);
+            $this->assertArrayHasKey('newest_deleted_at', $result);
+            $this->assertArrayHasKey('dry_run', $result);
+        }
+    }
+}

--- a/tests/Feature/RetentionPolicyApiTest.php
+++ b/tests/Feature/RetentionPolicyApiTest.php
@@ -1,0 +1,385 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use App\Services\Retention\RetentionEngine;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RetentionPolicyApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        return User::factory()->create(['role' => 'admin']);
+    }
+
+    private function regularUser(): User
+    {
+        return User::factory()->create(['role' => 'user']);
+    }
+
+    private function enableModule(): void
+    {
+        config(['modules.retention' => true]);
+    }
+
+    // ── (f) policies GET/PUT roundtrip + RBAC ────────────────────────────────
+
+    public function test_policies_get_returns_all_seven_classes(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/retention/policies');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'policies' => [
+                        ['class', 'ttl_days', 'default_ttl_days', 'is_legal_hold', 'statutory_min_days'],
+                    ],
+                ],
+            ]);
+
+        $policies = $response->json('data.policies');
+        $this->assertCount(7, $policies);
+
+        $classes = array_column($policies, 'class');
+        $this->assertContains('operational_presence', $classes);
+        $this->assertContains('billing_fiscal', $classes);
+        $this->assertContains('hr_labour', $classes);
+    }
+
+    public function test_policies_get_reflects_default_ttls(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/retention/policies');
+
+        $policies = collect($response->json('data.policies'))->keyBy('class');
+
+        $this->assertSame(30, $policies['operational_presence']['ttl_days']);
+        $this->assertSame(2922, $policies['billing_fiscal']['ttl_days']);
+        $this->assertSame(3, $policies['anpr_raw']['ttl_days']);
+    }
+
+    public function test_policies_get_marks_legal_hold_classes(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/retention/policies');
+        $policies = collect($response->json('data.policies'))->keyBy('class');
+
+        $this->assertTrue($policies['billing_fiscal']['is_legal_hold']);
+        $this->assertTrue($policies['hr_labour']['is_legal_hold']);
+        $this->assertFalse($policies['operational_presence']['is_legal_hold']);
+        $this->assertFalse($policies['security_audit_log']['is_legal_hold']);
+    }
+
+    public function test_policies_put_updates_ttl_and_returns_updated_policy(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)
+            ->putJson('/api/v1/admin/retention/policies/booking_history', [
+                'ttl_days' => 120,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'success',
+                'data' => ['class', 'ttl_days', 'default_ttl_days', 'is_legal_hold', 'statutory_min_days'],
+            ]);
+
+        $this->assertSame('booking_history', $response->json('data.class'));
+        $this->assertSame(120, $response->json('data.ttl_days'));
+        $this->assertTrue($response->json('success'));
+    }
+
+    public function test_policies_put_roundtrip_via_get(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)
+            ->putJson('/api/v1/admin/retention/policies/anpr_raw', ['ttl_days' => 7]);
+
+        $getResponse = $this->actingAs($admin)->getJson('/api/v1/admin/retention/policies');
+        $policies = collect($getResponse->json('data.policies'))->keyBy('class');
+
+        $this->assertSame(7, $policies['anpr_raw']['ttl_days']);
+    }
+
+    public function test_policies_put_legal_hold_below_minimum_returns_422(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)
+            ->putJson('/api/v1/admin/retention/policies/billing_fiscal', [
+                'ttl_days' => 365,
+            ]);
+
+        $response->assertStatus(422);
+        $this->assertFalse($response->json('success'));
+    }
+
+    public function test_policies_put_hr_labour_below_minimum_returns_422(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)
+            ->putJson('/api/v1/admin/retention/policies/hr_labour', [
+                'ttl_days' => 100,
+            ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_policies_put_unknown_class_returns_422(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)
+            ->putJson('/api/v1/admin/retention/policies/nonexistent_class', [
+                'ttl_days' => 30,
+            ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_policies_put_missing_ttl_days_returns_422(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)
+            ->putJson('/api/v1/admin/retention/policies/booking_history', []);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_policies_get_requires_admin_non_admin_403(): void
+    {
+        $this->enableModule();
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v1/admin/retention/policies');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_policies_put_requires_admin_non_admin_403(): void
+    {
+        $this->enableModule();
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)
+            ->putJson('/api/v1/admin/retention/policies/booking_history', ['ttl_days' => 60]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_retention_run_requires_admin(): void
+    {
+        $this->enableModule();
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->postJson('/api/v1/admin/retention/run');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_evidence_get_requires_admin(): void
+    {
+        $this->enableModule();
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v1/admin/retention/evidence');
+
+        $response->assertStatus(403);
+    }
+
+    // ── POST /run ─────────────────────────────────────────────────────────────
+
+    public function test_run_dry_run_returns_counts_without_deleting(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        AuditLog::forceCreate([
+            'action' => 'presence_check',
+            'event_type' => 'presence_check',
+            'details' => ['retention_deletion_class' => 'operational_presence'],
+            'created_at' => now()->subDays(40),
+            'updated_at' => now()->subDays(40),
+        ]);
+
+        $countBefore = AuditLog::count();
+
+        $response = $this->actingAs($admin)
+            ->postJson('/api/v1/admin/retention/run', ['dry_run' => true]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'success',
+                'data' => ['results', 'ran_at', 'dry_run'],
+            ]);
+
+        $this->assertTrue($response->json('data.dry_run'));
+        $this->assertSame($countBefore, AuditLog::count(), 'dry_run must not delete rows');
+
+        // Result for operational_presence should show 1 count
+        $results = collect($response->json('data.results'));
+        $row = $results->firstWhere('class', 'operational_presence');
+        $this->assertNotNull($row);
+        $this->assertSame(1, $row['record_count']);
+        $this->assertTrue($row['dry_run']);
+    }
+
+    public function test_run_non_dry_run_deletes_expired_rows(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        AuditLog::forceCreate([
+            'action' => 'anpr_check',
+            'event_type' => 'anpr_check',
+            'details' => ['retention_deletion_class' => 'anpr_raw'],
+            'created_at' => now()->subDays(5), // past 3-day TTL
+            'updated_at' => now()->subDays(5),
+        ]);
+
+        $response = $this->actingAs($admin)
+            ->postJson('/api/v1/admin/retention/run', ['dry_run' => false]);
+
+        $response->assertOk();
+        $this->assertFalse($response->json('data.dry_run'));
+
+        $results = collect($response->json('data.results'));
+        $row = $results->firstWhere('class', 'anpr_raw');
+        $this->assertNotNull($row);
+        $this->assertSame(1, $row['record_count']);
+
+        $this->assertSame(
+            0,
+            AuditLog::where('event_type', 'anpr_check')->count(),
+            'Expired row must have been deleted',
+        );
+    }
+
+    public function test_run_defaults_to_non_dry_run_when_param_omitted(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        AuditLog::forceCreate([
+            'action' => 'anpr_check',
+            'event_type' => 'anpr_check',
+            'details' => ['retention_deletion_class' => 'anpr_raw'],
+            'created_at' => now()->subDays(5),
+            'updated_at' => now()->subDays(5),
+        ]);
+
+        $response = $this->actingAs($admin)->postJson('/api/v1/admin/retention/run', []);
+
+        $response->assertOk();
+        $this->assertFalse($response->json('data.dry_run'));
+    }
+
+    public function test_run_returns_ran_at_timestamp(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson('/api/v1/admin/retention/run', ['dry_run' => true]);
+
+        $response->assertOk();
+        $this->assertNotNull($response->json('data.ran_at'));
+    }
+
+    public function test_run_response_results_contains_all_seven_classes(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson('/api/v1/admin/retention/run', ['dry_run' => true]);
+
+        $response->assertOk();
+        $results = $response->json('data.results');
+        $this->assertCount(7, $results);
+    }
+
+    // ── GET /evidence ─────────────────────────────────────────────────────────
+
+    public function test_evidence_returns_purge_run_log_entries(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        // Create an expired anpr_raw row and purge it to generate evidence
+        AuditLog::forceCreate([
+            'action' => 'anpr_check',
+            'event_type' => 'anpr_check',
+            'details' => ['retention_deletion_class' => 'anpr_raw'],
+            'created_at' => now()->subDays(5),
+            'updated_at' => now()->subDays(5),
+        ]);
+        app(RetentionEngine::class)->purge(dryRun: false);
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/retention/evidence');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'evidence' => [
+                        ['id', 'purged_class', 'record_count', 'oldest_deleted_at', 'newest_deleted_at', 'dry_run', 'occurred_at'],
+                    ],
+                ],
+            ]);
+
+        $evidence = $response->json('data.evidence');
+        $this->assertNotEmpty($evidence);
+
+        $row = collect($evidence)->firstWhere('purged_class', 'anpr_raw');
+        $this->assertNotNull($row);
+        $this->assertSame(1, $row['record_count']);
+        $this->assertFalse($row['dry_run']);
+    }
+
+    public function test_evidence_returns_empty_array_when_no_runs(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/retention/evidence');
+
+        $response->assertOk();
+        $this->assertSame([], $response->json('data.evidence'));
+    }
+
+    // ── Module gate ───────────────────────────────────────────────────────────
+
+    public function test_endpoints_return_404_when_module_disabled(): void
+    {
+        config(['modules.retention' => false]);
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)->getJson('/api/v1/admin/retention/policies')->assertStatus(404);
+        $this->actingAs($admin)->postJson('/api/v1/admin/retention/run')->assertStatus(404);
+        $this->actingAs($admin)->getJson('/api/v1/admin/retention/evidence')->assertStatus(404);
+    }
+}

--- a/tests/Unit/Services/Retention/RetentionClassTest.php
+++ b/tests/Unit/Services/Retention/RetentionClassTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Retention;
+
+use App\Services\Retention\RetentionClass;
+use PHPUnit\Framework\TestCase;
+
+class RetentionClassTest extends TestCase
+{
+    public function test_all_classes_have_expected_default_ttl_days(): void
+    {
+        $expected = [
+            'operational_presence' => 30,
+            'booking_history' => 90,
+            'security_audit_log' => 180,
+            'hr_labour' => 1095,
+            'anpr_raw' => 3,
+            'ev_session' => 30,
+            'billing_fiscal' => 2922,
+        ];
+
+        foreach ($expected as $value => $days) {
+            $class = RetentionClass::from($value);
+            $this->assertSame($days, $class->defaultTtlDays(), "TTL mismatch for {$value}");
+        }
+    }
+
+    public function test_billing_fiscal_and_hr_labour_are_legal_hold(): void
+    {
+        $this->assertTrue(RetentionClass::BillingFiscal->isLegalHold());
+        $this->assertTrue(RetentionClass::HrLabour->isLegalHold());
+    }
+
+    public function test_other_classes_are_not_legal_hold(): void
+    {
+        $nonLegal = [
+            RetentionClass::OperationalPresence,
+            RetentionClass::BookingHistory,
+            RetentionClass::SecurityAuditLog,
+            RetentionClass::AnprRaw,
+            RetentionClass::EvSession,
+        ];
+
+        foreach ($nonLegal as $class) {
+            $this->assertFalse($class->isLegalHold(), "{$class->value} should not be legal hold");
+        }
+    }
+
+    public function test_legal_hold_classes_have_statutory_min_days(): void
+    {
+        $this->assertSame(2922, RetentionClass::BillingFiscal->statutoryMinDays());
+        $this->assertSame(1095, RetentionClass::HrLabour->statutoryMinDays());
+    }
+
+    public function test_non_legal_hold_classes_have_no_statutory_min_days(): void
+    {
+        $this->assertNull(RetentionClass::OperationalPresence->statutoryMinDays());
+        $this->assertNull(RetentionClass::BookingHistory->statutoryMinDays());
+        $this->assertNull(RetentionClass::SecurityAuditLog->statutoryMinDays());
+        $this->assertNull(RetentionClass::AnprRaw->statutoryMinDays());
+        $this->assertNull(RetentionClass::EvSession->statutoryMinDays());
+    }
+
+    public function test_seven_classes_defined(): void
+    {
+        $this->assertCount(7, RetentionClass::cases());
+    }
+}


### PR DESCRIPTION
## What

Slice 1 of the compliance roadmap (`dev/_handoffs/parkhub/2026-06-10-product-roadmap.md` P0-1), twin of the parkhub-rust edition with a matching API contract:

- **7 retention classes** with researched default TTLs (operational_presence 30d, booking_history 90d, security_audit_log 180d, hr_labour 3y, anpr_raw 72h, ev_session 30d, billing_fiscal **8y — GoBD/AO §147**); billing_fiscal + hr_labour are **legal-hold** classes whose TTL cannot be lowered below statutory minimums (422)
- **RetentionEngine** with a surface registry (slice 1 ships the AuditLog surface; bookings/sessions follow) purging rows past their class TTL via the existing `retention_deletion_class` markers; `dry_run` counts without deleting; **unknown classes are never deleted (fail-safe)**
- **Deletion-evidence log** per purged class ({class, count, oldest/newest, dry_run} — never content; GDPR Art. 5(2) accountability)
- Admin API: `GET/PUT /api/v1/admin/retention/policies[/{class}]`, `POST /api/v1/admin/retention/run`, `GET /api/v1/admin/retention/evidence`
- Daily scheduled purge behind the modules config-toggle pattern; module registry 69→70

## Verification

- TDD: 50 tests / 212 assertions (purge-per-TTL, dry-run, evidence, legal-hold rejection, fail-safe, RBAC)
- phpstan level 5 clean (incl. a genuine `getAttribute()` narrowing — larastan here doesn't infer the `casts()` *method*)
- scramble OpenAPI snapshot regenerated; full genuine local CI green for HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)