### PR TITLE
fix(ci): bump wolfi-base digest — old digest GC'd by Chainguard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,7 +476,7 @@ jobs:
           # registry, so the Dockerfile defaults are correct there.
           build-args: |
             NODE_BASE=docker.io/library/node:22-slim@sha256:868499d55378719bffa87b0ed1f099591823c029b543043c09c2483468e93201
-            WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639
+            WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda
 
   integration:
     name: Integration tests

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,7 +77,7 @@ jobs:
           # for local + gitea-runner builds.
           build-args: |
             NODE_BASE=docker.io/library/node:22-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
-            WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639
+            WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -104,7 +104,7 @@ jobs:
           # Same public-registry override as the scan build above.
           build-args: |
             NODE_BASE=docker.io/library/node:22-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
-            WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639
+            WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda
 
       - name: Attest image provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@
 #
 # NODE_BASE / WOLFI_BASE are parameterized so cloud CI (GitHub Actions) can
 # pass --build-arg NODE_BASE=docker.io/library/node:22-slim@sha256:689c1104...
-# and --build-arg WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639 while
+# and --build-arg WOLFI_BASE=cgr.dev/chainguard/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda while
 # local + gitea-runner builds default to the LAN mirror. Same images either
 # way, just different ingress to them.
 # ---------------------------------------------------------------------------
 ARG NODE_BASE=192.168.178.250:5000/node:22-slim@sha256:689c11043dad91472750cd824c97dd5e2318e9dd6f954e492fe7af0135d33ceb
-ARG WOLFI_BASE=192.168.178.250:5000/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639
+ARG WOLFI_BASE=192.168.178.250:5000/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda
 
 FROM ${NODE_BASE} AS frontend
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ x-build: &build
   context: .
   args:
     NODE_BASE: ${NODE_BASE:-192.168.178.250:5000/node:22-slim@sha256:aa8ccf90d87e2e60804816ddd256480a42f5cf3cafadf30618be606e4b894104}
-    WOLFI_BASE: ${WOLFI_BASE:-192.168.178.250:5000/wolfi-base@sha256:4973aa3c2ccbe13fe2049aab539b0ab342ec584bd5b54a269d55d4891091c639}
+    WOLFI_BASE: ${WOLFI_BASE:-192.168.178.250:5000/wolfi-base@sha256:865267010fd5c6a45c7ab456848573010ec521b0d2677a0a966f3f2211b71eda}
 
 services:
   app:


### PR DESCRIPTION
Chainguard garbage-collected the pinned wolfi-base digest, breaking every Docker build on main (and the README CI badge). Bumps all 4 reference sites to the current `wolfi-base:latest` digest (`sha256:865267…`). Digest pinning stays per the supply-chain policy; follow-up candidate: scheduled digest-freshness check so GC'd pins surface before they break main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)