### PR TITLE
feat: add no-show auto-release and waitlist auto-promotion

### DIFF
--- a/app/Http/Controllers/Api/BookingCheckInController.php
+++ b/app/Http/Controllers/Api/BookingCheckInController.php
@@ -36,6 +36,50 @@ class BookingCheckInController extends Controller
         return BookingResource::make($booking->fresh());
     }
 
+    /**
+     * POST /api/v1/bookings/{id}/check-in (idempotent, hyphenated path per API contract).
+     *
+     * Marks the booking as checked-in. If already checked in, returns 200 without
+     * error (idempotent). Rejects bookings that are not in a checkable state.
+     *
+     * Named `checkInAction` to avoid a PHP case-insensitive collision with the
+     * existing `checkin` method (`checkin` == `checkIn` in PHP).
+     */
+    public function checkInAction(Request $request, string $id): JsonResponse
+    {
+        $booking = Booking::findOrFail($id);
+        $this->authorize('update', $booking);
+
+        $nonCheckableStatuses = [
+            Booking::STATUS_CANCELLED,
+            Booking::STATUS_COMPLETED,
+            Booking::STATUS_RELEASED_NO_SHOW,
+        ];
+
+        if (in_array($booking->status, $nonCheckableStatuses, true)) {
+            return response()->json([
+                'success' => false, 'data' => null,
+                'error' => ['code' => 'BOOKING_NOT_CHECKABLE', 'message' => 'Booking cannot be checked in.'],
+            ], 422);
+        }
+
+        // Idempotent: already checked in — return current state without re-stamping
+        if ($booking->checked_in_at !== null) {
+            return response()->json(['success' => true, 'data' => BookingResource::make($booking)]);
+        }
+
+        $booking->update(['checked_in_at' => now(), 'status' => Booking::STATUS_ACTIVE]);
+
+        AuditLog::log([
+            'user_id' => $request->user()->id,
+            'username' => $request->user()->username,
+            'action' => 'booking_checkin',
+            'details' => ['booking_id' => $id],
+        ]);
+
+        return response()->json(['success' => true, 'data' => BookingResource::make($booking->fresh())]);
+    }
+
     public function extend(ExtendBookingRequest $request, string $id): JsonResponse
     {
         $validated = $request->validated();

--- a/app/Http/Controllers/Api/WaitlistOfferController.php
+++ b/app/Http/Controllers/Api/WaitlistOfferController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\BookingResource;
+use App\Http\Resources\WaitlistOfferResource;
+use App\Models\WaitlistOffer;
+use App\Services\NoShow\NoShowReleaseService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Endpoints for waitlist slot offers created by the no-show auto-release job.
+ *
+ * GET  /api/v1/waitlist/offers         — list the caller's pending offers
+ * POST /api/v1/waitlist/offers/{id}/claim — convert offer to booking
+ */
+class WaitlistOfferController extends Controller
+{
+    public function __construct(private readonly NoShowReleaseService $service) {}
+
+    /**
+     * GET /api/v1/waitlist/offers
+     *
+     * Returns all pending (not expired) offers for the authenticated user.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $offers = WaitlistOffer::where('user_id', $request->user()->id)
+            ->where('status', WaitlistOffer::STATUS_PENDING)
+            ->where('expires_at', '>', now())
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        return response()->json([
+            'success' => true,
+            'data' => WaitlistOfferResource::collection($offers),
+        ]);
+    }
+
+    /**
+     * POST /api/v1/waitlist/offers/{id}/claim
+     *
+     * Claim the offer within its window. Creates a confirmed booking for the
+     * freed slot. Idempotent: returns 409 if already claimed by another process.
+     */
+    public function claim(Request $request, string $id): JsonResponse
+    {
+        $offer = WaitlistOffer::findOrFail($id);
+
+        try {
+            $booking = $this->service->claimOffer($offer, $request->user()->id);
+        } catch (\RuntimeException $e) {
+            return match ($e->getMessage()) {
+                'FORBIDDEN' => response()->json([
+                    'success' => false, 'data' => null,
+                    'error' => ['code' => 'FORBIDDEN', 'message' => 'This offer does not belong to you.'],
+                ], 403),
+                'OFFER_NOT_PENDING' => response()->json([
+                    'success' => false, 'data' => null,
+                    'error' => ['code' => 'OFFER_NOT_PENDING', 'message' => 'Offer is no longer pending.'],
+                ], 409),
+                'OFFER_EXPIRED' => response()->json([
+                    'success' => false, 'data' => null,
+                    'error' => ['code' => 'OFFER_EXPIRED', 'message' => 'Offer has expired.'],
+                ], 410),
+                'SLOT_NO_LONGER_AVAILABLE' => response()->json([
+                    'success' => false, 'data' => null,
+                    'error' => ['code' => 'SLOT_NO_LONGER_AVAILABLE', 'message' => 'The slot is no longer available.'],
+                ], 409),
+                default => response()->json([
+                    'success' => false, 'data' => null,
+                    'error' => ['code' => 'CLAIM_FAILED', 'message' => 'Failed to claim offer.'],
+                ], 500),
+            };
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'offer' => WaitlistOfferResource::make($offer->fresh()),
+                'booking' => BookingResource::make($booking),
+            ],
+        ], 201);
+    }
+}

--- a/app/Http/Resources/WaitlistOfferResource.php
+++ b/app/Http/Resources/WaitlistOfferResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\WaitlistOffer;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin WaitlistOffer
+ */
+class WaitlistOfferResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'lot_id' => $this->lot_id,
+            'slot_id' => $this->slot_id,
+            'status' => $this->status,
+            'expires_at' => $this->expires_at->toISOString(),
+            'claimed_booking_id' => $this->claimed_booking_id,
+            'created_at' => $this->created_at->toISOString(),
+        ];
+    }
+}

--- a/app/Jobs/NoShowReleaseJob.php
+++ b/app/Jobs/NoShowReleaseJob.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Services\NoShow\NoShowReleaseService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Runs every 5 minutes to:
+ * 1. Release past-deadline un-checked-in bookings (per-lot config).
+ * 2. Expire stale pending offers and promote the next FIFO waitlist entry.
+ */
+class NoShowReleaseJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle(NoShowReleaseService $service): void
+    {
+        $released = $service->releaseNoShows();
+        $service->expireStaleOffers();
+
+        Log::info('NoShowReleaseJob: complete', ['released' => $released]);
+    }
+}

--- a/app/Mail/WaitlistOfferMail.php
+++ b/app/Mail/WaitlistOfferMail.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Models\ParkingLot;
+use App\Models\Setting;
+use App\Models\User;
+use App\Models\WaitlistOffer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Sent when a no-show release promotes a waitlist entry to a concrete offer.
+ * Informs the user of the claim window and offer ID.
+ */
+class WaitlistOfferMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly User $recipient,
+        public readonly ParkingLot $lot,
+        public readonly WaitlistOffer $offer,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        $company = Setting::get('company_name', 'ParkHub');
+
+        return new Envelope(
+            subject: "[{$company}] Stellplatz-Angebot – {$this->lot->name}",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            htmlString: $this->buildHtml(),
+        );
+    }
+
+    private function buildHtml(): string
+    {
+        $company = e(Setting::get('company_name', 'ParkHub'));
+        $name = e($this->recipient->name);
+        $lotName = e($this->lot->name);
+        $expiresAt = $this->offer->expires_at->format('H:i \U\h\r');
+        $offerId = e($this->offer->id);
+
+        return <<<HTML
+<!DOCTYPE html><html lang="de"><head><meta charset="UTF-8"></head>
+<body style="font-family:Arial,sans-serif;background:#f5f5f5;margin:0;padding:32px;">
+  <div style="max-width:560px;margin:0 auto;background:white;border-radius:12px;overflow:hidden;box-shadow:0 2px 16px rgba(0,0,0,.08);">
+    <div style="background:#d97706;padding:32px;text-align:center;">
+      <h1 style="color:white;margin:0;font-size:24px;font-weight:700;">{$company}</h1>
+      <p style="color:rgba(255,255,255,.85);margin:8px 0 0;font-size:14px;">Stellplatz-Angebot</p>
+    </div>
+    <div style="padding:32px;">
+      <p style="color:#374151;font-size:16px;">Hallo {$name},</p>
+      <p style="color:#374151;font-size:14px;line-height:1.6;">
+        ein Stellplatz in <strong>{$lotName}</strong> ist jetzt für Sie reserviert.
+        Das Angebot läuft um <strong>{$expiresAt}</strong> ab.
+      </p>
+      <p style="color:#374151;font-size:14px;line-height:1.6;">
+        Nehmen Sie das Angebot über die App an:
+        <code style="background:#f3f4f6;padding:2px 6px;border-radius:4px;font-size:12px;">POST /api/v1/waitlist/offers/{$offerId}/claim</code>
+      </p>
+    </div>
+    <div style="background:#f9fafb;padding:16px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+      <p style="color:#9ca3af;font-size:12px;margin:0;">{$company} · ParkHub Open Source Parking Platform</p>
+    </div>
+  </div>
+</body></html>
+HTML;
+    }
+}

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -55,6 +55,8 @@ class Booking extends Model
 
     const STATUS_NO_SHOW = 'no_show';
 
+    const STATUS_RELEASED_NO_SHOW = 'released_no_show';
+
     protected $fillable = [
         'user_id', 'lot_id', 'slot_id', 'booking_type', 'lot_name', 'slot_number',
         'vehicle_plate', 'start_time', 'end_time', 'status', 'notes',

--- a/app/Models/ParkingLot.php
+++ b/app/Models/ParkingLot.php
@@ -32,6 +32,8 @@ use Illuminate\Support\Carbon;
  * @property string $currency
  * @property ?array<string, mixed> $operating_hours
  * @property ?array<string, mixed> $dynamic_pricing_rules
+ * @property ?int $check_in_deadline_minutes
+ * @property ?int $claim_window_minutes
  * @property ?string $tenant_id
  * @property Carbon $created_at
  * @property Carbon $updated_at
@@ -44,7 +46,7 @@ class ParkingLot extends Model
 {
     use BelongsToTenant, HasFactory, HasUuids;
 
-    protected $fillable = ['name', 'address', 'latitude', 'longitude', 'center_lat', 'center_lng', 'geofence_radius_m', 'total_slots', 'available_slots', 'layout', 'status', 'hourly_rate', 'daily_max', 'monthly_pass', 'currency', 'operating_hours', 'dynamic_pricing_rules', 'tenant_id'];
+    protected $fillable = ['name', 'address', 'latitude', 'longitude', 'center_lat', 'center_lng', 'geofence_radius_m', 'total_slots', 'available_slots', 'layout', 'status', 'hourly_rate', 'daily_max', 'monthly_pass', 'currency', 'operating_hours', 'dynamic_pricing_rules', 'check_in_deadline_minutes', 'claim_window_minutes', 'tenant_id'];
 
     protected function casts(): array
     {
@@ -62,6 +64,8 @@ class ParkingLot extends Model
             'monthly_pass' => 'decimal:2',
             'operating_hours' => 'array',
             'dynamic_pricing_rules' => 'array',
+            'check_in_deadline_minutes' => 'integer',
+            'claim_window_minutes' => 'integer',
         ];
     }
 

--- a/app/Models/WaitlistEntry.php
+++ b/app/Models/WaitlistEntry.php
@@ -20,8 +20,8 @@ use Illuminate\Support\Carbon;
  * @property ?string $accepted_booking_id
  * @property Carbon $created_at
  * @property Carbon $updated_at
- * @property-read User $user
- * @property-read ParkingLot $lot
+ * @property-read ?User $user
+ * @property-read ?ParkingLot $lot
  * @property-read ?ParkingSlot $slot
  */
 class WaitlistEntry extends Model

--- a/app/Models/WaitlistOffer.php
+++ b/app/Models/WaitlistOffer.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * A concrete slot offer created when a no-show booking is released and the
+ * waitlist is promoted. Tracks the specific slot and expiry window.
+ *
+ * @property string $id
+ * @property string $waitlist_entry_id
+ * @property string $released_booking_id
+ * @property string $lot_id
+ * @property string $slot_id
+ * @property string $user_id
+ * @property string $status pending|claimed|expired|declined
+ * @property Carbon $expires_at
+ * @property ?string $claimed_booking_id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class WaitlistOffer extends Model
+{
+    use HasUuids;
+
+    const STATUS_PENDING = 'pending';
+
+    const STATUS_CLAIMED = 'claimed';
+
+    const STATUS_EXPIRED = 'expired';
+
+    const STATUS_DECLINED = 'declined';
+
+    protected $fillable = [
+        'waitlist_entry_id',
+        'released_booking_id',
+        'lot_id',
+        'slot_id',
+        'user_id',
+        'status',
+        'expires_at',
+        'claimed_booking_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    public function waitlistEntry(): BelongsTo
+    {
+        return $this->belongsTo(WaitlistEntry::class);
+    }
+
+    public function releasedBooking(): BelongsTo
+    {
+        return $this->belongsTo(Booking::class, 'released_booking_id');
+    }
+
+    public function claimedBooking(): BelongsTo
+    {
+        return $this->belongsTo(Booking::class, 'claimed_booking_id');
+    }
+
+    public function lot(): BelongsTo
+    {
+        return $this->belongsTo(ParkingLot::class, 'lot_id');
+    }
+
+    public function slot(): BelongsTo
+    {
+        return $this->belongsTo(ParkingSlot::class, 'slot_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function isPending(): bool
+    {
+        return $this->status === self::STATUS_PENDING && $this->expires_at->isFuture();
+    }
+}

--- a/app/Services/NoShow/NoShowReleaseService.php
+++ b/app/Services/NoShow/NoShowReleaseService.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\NoShow;
+
+use App\Mail\WaitlistOfferMail;
+use App\Models\AuditLog;
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\WaitlistEntry;
+use App\Models\WaitlistOffer;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * No-show auto-release + waitlist FIFO promotion.
+ *
+ * Promotion order (FIFO):
+ *   1. priority ASC (lower number = higher priority, matching the existing
+ *      waitlist ordering convention in WaitlistController::lotWaitlist)
+ *   2. created_at ASC (tie-break: first-in wins)
+ *
+ * Transaction safety: each booking release + offer creation runs in its own
+ * DB transaction so a partial failure on one booking does not prevent others
+ * from being processed.
+ */
+final class NoShowReleaseService
+{
+    private const DEFAULT_DEADLINE_MINUTES = 30;
+
+    private const DEFAULT_CLAIM_WINDOW_MINUTES = 15;
+
+    /**
+     * Scan all lots for past-deadline un-checked-in bookings and release them.
+     *
+     * @return int number of bookings released
+     */
+    public function releaseNoShows(): int
+    {
+        $released = 0;
+
+        $lots = ParkingLot::all(['id', 'check_in_deadline_minutes', 'claim_window_minutes']);
+
+        foreach ($lots as $lot) {
+            $deadlineMinutes = $lot->check_in_deadline_minutes ?? self::DEFAULT_DEADLINE_MINUTES;
+
+            if ($deadlineMinutes === 0) {
+                continue; // feature disabled for this lot
+            }
+
+            $cutoff = now()->subMinutes($deadlineMinutes);
+
+            $staleBookings = Booking::where('lot_id', $lot->id)
+                ->whereIn('status', [Booking::STATUS_CONFIRMED, Booking::STATUS_ACTIVE])
+                ->where('start_time', '<=', $cutoff)
+                ->whereNull('checked_in_at')
+                ->get();
+
+            foreach ($staleBookings as $booking) {
+                try {
+                    $this->releaseBooking($booking, $lot);
+                    $released++;
+                } catch (\Throwable $e) {
+                    Log::error('noshow_release: failed to release booking', [
+                        'booking_id' => $booking->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        }
+
+        return $released;
+    }
+
+    /**
+     * Release a single booking as no-show and promote the next waitlist entry.
+     */
+    private function releaseBooking(Booking $booking, ParkingLot $lot): void
+    {
+        DB::transaction(function () use ($booking, $lot) {
+            // Re-read inside transaction to guard against concurrent release
+            $fresh = Booking::lockForUpdate()->find($booking->id);
+            if ($fresh === null) {
+                return;
+            }
+            if (! in_array($fresh->status, [Booking::STATUS_CONFIRMED, Booking::STATUS_ACTIVE], true)) {
+                return; // already released by another process
+            }
+            if ($fresh->checked_in_at !== null) {
+                return; // user checked in just before we ran
+            }
+
+            $fresh->update(['status' => Booking::STATUS_RELEASED_NO_SHOW]);
+
+            AuditLog::log([
+                'action' => 'booking_released_no_show',
+                'details' => [
+                    'booking_id' => $fresh->id,
+                    'lot_id' => $lot->id,
+                    'slot_id' => $fresh->slot_id,
+                    'retention_deletion_class' => 'booking_history',
+                ],
+            ]);
+
+            Log::info('noshow_release: released booking', ['booking_id' => $fresh->id]);
+
+            $this->promoteNextWaitlistEntry($fresh, $lot);
+        });
+    }
+
+    /**
+     * Offer the freed slot to the next FIFO waitlist entry.
+     * FIFO order: priority ASC, then created_at ASC.
+     */
+    private function promoteNextWaitlistEntry(Booking $booking, ParkingLot $lot): void
+    {
+        $next = WaitlistEntry::where('lot_id', $lot->id)
+            ->where('status', 'waiting')
+            ->orderBy('priority', 'asc')
+            ->orderBy('created_at', 'asc')
+            ->lockForUpdate()
+            ->first();
+
+        if ($next === null) {
+            return;
+        }
+
+        $claimWindowMinutes = $lot->claim_window_minutes ?? self::DEFAULT_CLAIM_WINDOW_MINUTES;
+        $expiresAt = now()->addMinutes($claimWindowMinutes);
+
+        $next->update([
+            'status' => 'offered',
+            'notified_at' => now(),
+            'offer_expires_at' => $expiresAt,
+        ]);
+
+        $offer = WaitlistOffer::create([
+            'waitlist_entry_id' => $next->id,
+            'released_booking_id' => $booking->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $booking->slot_id,
+            'user_id' => $next->user_id,
+            'status' => WaitlistOffer::STATUS_PENDING,
+            'expires_at' => $expiresAt,
+        ]);
+
+        $user = $next->user;
+        if ($user !== null) {
+            Mail::to($user->email)->queue(new WaitlistOfferMail($user, $lot, $offer));
+        }
+
+        Log::info('noshow_release: promoted waitlist entry', [
+            'entry_id' => $next->id,
+            'offer_id' => $offer->id,
+            'expires_at' => $expiresAt,
+        ]);
+    }
+
+    /**
+     * Expire pending offers whose window has closed and pass to the next entry.
+     * Called by the same NoShowReleaseJob to keep the queue moving.
+     */
+    public function expireStaleOffers(): void
+    {
+        $expired = WaitlistOffer::where('status', WaitlistOffer::STATUS_PENDING)
+            ->where('expires_at', '<=', now())
+            ->with(['lot', 'waitlistEntry'])
+            ->get();
+
+        foreach ($expired as $offer) {
+            try {
+                DB::transaction(function () use ($offer) {
+                    $fresh = WaitlistOffer::lockForUpdate()->find($offer->id);
+                    if ($fresh === null || $fresh->status !== WaitlistOffer::STATUS_PENDING) {
+                        return;
+                    }
+                    $fresh->update(['status' => WaitlistOffer::STATUS_EXPIRED]);
+
+                    if ($fresh->waitlistEntry !== null) {
+                        $fresh->waitlistEntry->update(['status' => 'expired']);
+                    }
+
+                    Log::info('noshow_release: offer expired', ['offer_id' => $fresh->id]);
+
+                    // Promote next entry if a lot is available
+                    $lot = ParkingLot::find($fresh->lot_id);
+                    if ($lot !== null) {
+                        // Retrieve the released booking to re-use its slot
+                        $releasedBooking = Booking::find($fresh->released_booking_id);
+                        if ($releasedBooking !== null) {
+                            $this->promoteNextWaitlistEntry($releasedBooking, $lot);
+                        }
+                    }
+                });
+            } catch (\Throwable $e) {
+                Log::error('noshow_release: failed to expire offer', [
+                    'offer_id' => $offer->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Claim an offer: create a booking for the freed slot.
+     * Transaction-safe — rejects double-claims atomically.
+     *
+     * @throws \RuntimeException on validation failures (caller wraps in HTTP response)
+     */
+    public function claimOffer(WaitlistOffer $offer, string $userId): Booking
+    {
+        return DB::transaction(function () use ($offer, $userId) {
+            $fresh = WaitlistOffer::lockForUpdate()->findOrFail($offer->id);
+
+            if ($fresh->user_id !== $userId) {
+                throw new \RuntimeException('FORBIDDEN');
+            }
+
+            if ($fresh->status !== WaitlistOffer::STATUS_PENDING) {
+                throw new \RuntimeException('OFFER_NOT_PENDING');
+            }
+
+            if ($fresh->expires_at->isPast()) {
+                $fresh->update(['status' => WaitlistOffer::STATUS_EXPIRED]);
+                throw new \RuntimeException('OFFER_EXPIRED');
+            }
+
+            // Lock the slot to prevent double-booking
+            $slot = ParkingSlot::lockForUpdate()->findOrFail($fresh->slot_id);
+
+            // Verify the slot is actually free (no active booking after our release)
+            $conflict = Booking::where('slot_id', $slot->id)
+                ->whereIn('status', [Booking::STATUS_CONFIRMED, Booking::STATUS_ACTIVE])
+                ->lockForUpdate()
+                ->exists();
+
+            if ($conflict) {
+                throw new \RuntimeException('SLOT_NO_LONGER_AVAILABLE');
+            }
+
+            // Find the released booking to inherit time window
+            $released = Booking::find($fresh->released_booking_id);
+            $startTime = now();
+            $endTime = $released ? $released->end_time : now()->addHours(8);
+
+            $booking = Booking::create([
+                'user_id' => $userId,
+                'lot_id' => $fresh->lot_id,
+                'slot_id' => $slot->id,
+                'start_time' => $startTime,
+                'end_time' => $endTime,
+                'status' => Booking::STATUS_CONFIRMED,
+                'booking_type' => 'single',
+            ]);
+
+            $fresh->update([
+                'status' => WaitlistOffer::STATUS_CLAIMED,
+                'claimed_booking_id' => $booking->id,
+            ]);
+
+            if ($fresh->waitlistEntry !== null) {
+                WaitlistEntry::find($fresh->waitlist_entry_id)?->update([
+                    'status' => 'accepted',
+                    'accepted_booking_id' => $booking->id,
+                ]);
+            }
+
+            AuditLog::log([
+                'user_id' => $userId,
+                'action' => 'waitlist_offer_claimed',
+                'details' => [
+                    'offer_id' => $fresh->id,
+                    'booking_id' => $booking->id,
+                    'lot_id' => $fresh->lot_id,
+                    'slot_id' => $slot->id,
+                    'retention_deletion_class' => 'booking_history',
+                ],
+            ]);
+
+            return $booking;
+        });
+    }
+}

--- a/config/modules.php
+++ b/config/modules.php
@@ -105,6 +105,11 @@ return [
     // audit purge, and deletion-evidence log. Enabled by default.
     'retention' => env('MODULE_RETENTION', true),
 
+    // No-show auto-release + waitlist FIFO auto-promotion (P1-1/P1-2).
+    // Per-lot check_in_deadline_minutes (default 30, 0=disabled) and
+    // claim_window_minutes (default 15). Enabled by default.
+    'noshow_waitlist' => env('MODULE_NOSHOW_WAITLIST', true),
+
     // ── Enterprise (disabled by default — opt-in) ──────────────────
     'multi_tenant' => env('MODULE_MULTI_TENANT', false),
     'dynamic_pricing' => env('MODULE_DYNAMIC_PRICING', false),

--- a/database/migrations/2026_06_10_000001_add_noshow_release_config_and_offers.php
+++ b/database/migrations/2026_06_10_000001_add_noshow_release_config_and_offers.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * P1-1/P1-2 — No-show auto-release + waitlist auto-promotion.
+ *
+ * 1. Per-lot config columns on parking_lots:
+ *    - check_in_deadline_minutes: minutes after start_time before a
+ *      un-checked-in booking is released as no-show (null = global default 30,
+ *      0 = feature disabled for this lot).
+ *    - claim_window_minutes: minutes a waitlist offer stays open before it
+ *      expires and propagates to the next FIFO entry (null = default 15).
+ *
+ * 2. waitlist_offers table: tracks a concrete slot offer to one waitlist
+ *    entrant after a no-show release. A separate model avoids overloading
+ *    WaitlistEntry (which tracks queue position) with ephemeral offer state.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('parking_lots', function (Blueprint $table) {
+            $table->unsignedSmallInteger('check_in_deadline_minutes')->nullable()->after('dynamic_pricing_rules');
+            $table->unsignedSmallInteger('claim_window_minutes')->nullable()->after('check_in_deadline_minutes');
+        });
+
+        Schema::create('waitlist_offers', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('waitlist_entry_id')->constrained('waitlist_entries')->cascadeOnDelete();
+            $table->foreignUuid('released_booking_id')->constrained('bookings')->cascadeOnDelete();
+            $table->foreignUuid('lot_id')->constrained('parking_lots')->cascadeOnDelete();
+            $table->foreignUuid('slot_id')->constrained('parking_slots')->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            // pending → claimed | expired | declined
+            $table->string('status', 20)->default('pending');
+            $table->timestamp('expires_at');
+            $table->foreignUuid('claimed_booking_id')->nullable()->constrained('bookings')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index(['user_id', 'status']);
+            $table->index(['lot_id', 'status']);
+            $table->index('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('waitlist_offers');
+
+        Schema::table('parking_lots', function (Blueprint $table) {
+            $table->dropColumn(['check_in_deadline_minutes', 'claim_window_minutes']);
+        });
+    }
+};

--- a/docs/openapi/php.json
+++ b/docs/openapi/php.json
@@ -1573,6 +1573,18 @@
               "null"
             ]
           },
+          "check_in_deadline_minutes": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "claim_window_minutes": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "created_at": {
             "format": "date-time",
             "type": [
@@ -1684,7 +1696,9 @@
           "tenant_id",
           "center_lat",
           "center_lng",
-          "geofence_radius_m"
+          "geofence_radius_m",
+          "check_in_deadline_minutes",
+          "claim_window_minutes"
         ],
         "title": "ParkingLot",
         "type": "object"
@@ -4458,6 +4472,48 @@
           "updated_at"
         ],
         "title": "WaitlistEntryResource",
+        "type": "object"
+      },
+      "WaitlistOfferResource": {
+        "properties": {
+          "claimed_booking_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "lot_id": {
+            "type": "string"
+          },
+          "slot_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "lot_id",
+          "slot_id",
+          "status",
+          "expires_at",
+          "claimed_booking_id",
+          "created_at"
+        ],
+        "title": "WaitlistOfferResource",
         "type": "object"
       },
       "WaitlistSubscribeRequest": {
@@ -25496,6 +25552,96 @@
         "summary": "Tier-2 item 9 — single-booking .ics download.\nGET /api/v1/bookings/{id}.ics → RFC5545 VCALENDAR with one VEVENT",
         "tags": [
           "BookingCalendar"
+        ]
+      }
+    },
+    "/v1/bookings/{id}/check-in": {
+      "post": {
+        "description": "Marks the booking as checked-in. If already checked in, returns 200 without\nerror (idempotent). Rejects bookings that are not in a checkable state.\n\nNamed `checkInAction` to avoid a PHP case-insensitive collision with the\nexisting `checkin` method (`checkin` == `checkIn` in PHP).",
+        "operationId": "bookingCheckIn.checkInAction",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/BookingResource"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          },
+          "403": {
+            "$ref": "#/components/responses/AuthorizationException"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "null"
+                    },
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "const": "BOOKING_NOT_CHECKABLE",
+                          "type": "string"
+                        },
+                        "message": {
+                          "const": "Booking cannot be checked in.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "POST /api/v1/bookings/{id}/check-in (idempotent, hyphenated path per API contract)",
+        "tags": [
+          "BookingCheckIn"
         ]
       }
     },
@@ -52254,6 +52400,302 @@
         "summary": "POST /api/v1/waitlist — legacy: join waitlist for a lot",
         "tags": [
           "Waitlist"
+        ]
+      }
+    },
+    "/v1/waitlist/offers": {
+      "get": {
+        "description": "Returns all pending (not expired) offers for the authenticated user.",
+        "operationId": "waitlistOffer.index",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "$ref": "#/components/schemas/WaitlistOfferResource"
+                      },
+                      "type": "array"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          }
+        },
+        "summary": "GET /api/v1/waitlist/offers",
+        "tags": [
+          "WaitlistOffer"
+        ]
+      }
+    },
+    "/v1/waitlist/offers/{id}/claim": {
+      "post": {
+        "description": "Claim the offer within its window. Creates a confirmed booking for the\nfreed slot. Idempotent: returns 409 if already claimed by another process.",
+        "operationId": "waitlistOffer.claim",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "booking": {
+                          "$ref": "#/components/schemas/BookingResource"
+                        },
+                        "offer": {
+                          "$ref": "#/components/schemas/WaitlistOfferResource"
+                        }
+                      },
+                      "required": [
+                        "offer",
+                        "booking"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "null"
+                    },
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "const": "FORBIDDEN",
+                          "type": "string"
+                        },
+                        "message": {
+                          "const": "This offer does not belong to you.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "null"
+                        },
+                        "error": {
+                          "properties": {
+                            "code": {
+                              "const": "OFFER_NOT_PENDING",
+                              "type": "string"
+                            },
+                            "message": {
+                              "const": "Offer is no longer pending.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "code",
+                            "message"
+                          ],
+                          "type": "object"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "data",
+                        "error"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "null"
+                        },
+                        "error": {
+                          "properties": {
+                            "code": {
+                              "const": "SLOT_NO_LONGER_AVAILABLE",
+                              "type": "string"
+                            },
+                            "message": {
+                              "const": "The slot is no longer available.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "code",
+                            "message"
+                          ],
+                          "type": "object"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "data",
+                        "error"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": ""
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "null"
+                    },
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "const": "OFFER_EXPIRED",
+                          "type": "string"
+                        },
+                        "message": {
+                          "const": "Offer has expired.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "null"
+                    },
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "const": "CLAIM_FAILED",
+                          "type": "string"
+                        },
+                        "message": {
+                          "const": "Failed to claim offer.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "POST /api/v1/waitlist/offers/{id}/claim",
+        "tags": [
+          "WaitlistOffer"
         ]
       }
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -199,12 +199,6 @@ parameters:
 			path: app/Http/Controllers/Api/BillingController.php
 
 		-
-			message: '#^Left side of && is always true\.$#'
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: app/Http/Controllers/Api/BookingController.php
-
-		-
 			message: '#^Relation ''user'' is not found in App\\Models\\WaitlistEntry model\.$#'
 			identifier: larastan.relationExistence
 			count: 1
@@ -623,12 +617,6 @@ parameters:
 			identifier: nullCoalesce.offset
 			count: 2
 			path: app/Jobs/AggregateSystemMetricsJob.php
-
-		-
-			message: '#^Left side of && is always true\.$#'
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: app/Jobs/AutoReleaseBookingsJob.php
 
 		-
 			message: '#^Relation ''user'' is not found in App\\Models\\RecurringBooking model\.$#'

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -332,3 +332,4 @@ module_routes('mobile', 'mobile.php');
 
 // v5.x features
 module_routes('retention', 'retention.php');
+module_routes('noshow_waitlist', 'noshow_waitlist.php');

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,7 @@
 use App\Jobs\AggregateSystemMetricsJob;
 use App\Jobs\AutoReleaseBookingsJob;
 use App\Jobs\ExpandRecurringBookingsJob;
+use App\Jobs\NoShowReleaseJob;
 use App\Services\Retention\RetentionEngine;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
@@ -11,6 +12,16 @@ use Illuminate\Support\Facades\Schedule;
 
 Schedule::job(new AutoReleaseBookingsJob)->everyFiveMinutes();
 Schedule::job(new AggregateSystemMetricsJob)->everyFiveMinutes();
+
+// No-show auto-release + waitlist FIFO auto-promotion (P1-1/P1-2).
+// Only when the module is enabled. ~5 min cadence matches the check-in deadline
+// granularity; withoutOverlapping prevents pile-up under DB pressure.
+if (module_enabled('noshow_waitlist')) {
+    Schedule::job(new NoShowReleaseJob)
+        ->everyFiveMinutes()
+        ->withoutOverlapping()
+        ->onOneServer();
+}
 Schedule::job(new ExpandRecurringBookingsJob)->dailyAt('01:00');
 Schedule::command('sanctum:prune-expired', ['--hours' => 168])->daily();
 Schedule::command('credits:refill-monthly')->monthlyOn(1, '00:00');

--- a/routes/modules/noshow_waitlist.php
+++ b/routes/modules/noshow_waitlist.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * No-show auto-release + waitlist auto-promotion module routes (api/v1).
+ * Loaded only when MODULE_NOSHOW_WAITLIST=true.
+ *
+ * FIFO promotion order: priority ASC, then created_at ASC.
+ */
+
+use App\Http\Controllers\Api\BookingCheckInController;
+use App\Http\Controllers\Api\WaitlistOfferController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:noshow_waitlist', 'auth:sanctum', 'throttle:api'])->group(function () {
+    // Idempotent check-in (hyphenated path per API contract)
+    Route::post('/bookings/{id}/check-in', [BookingCheckInController::class, 'checkInAction']);
+
+    // Waitlist offer endpoints
+    Route::get('/waitlist/offers', [WaitlistOfferController::class, 'index']);
+    Route::post('/waitlist/offers/{id}/claim', [WaitlistOfferController::class, 'claim']);
+});

--- a/tests/Feature/ModuleSystemExtendedTest.php
+++ b/tests/Feature/ModuleSystemExtendedTest.php
@@ -130,7 +130,7 @@ class ModuleSystemExtendedTest extends TestCase
     public function test_module_service_provider_all_returns_current_count(): void
     {
         $all = ModuleServiceProvider::all();
-        $this->assertCount(70, $all);
+        $this->assertCount(71, $all);
     }
 
     public function test_modules_endpoint_is_always_public(): void

--- a/tests/Feature/ModuleSystemTest.php
+++ b/tests/Feature/ModuleSystemTest.php
@@ -350,11 +350,11 @@ class ModuleSystemTest extends TestCase
             ->assertOk();
     }
 
-    public function test_all_70_modules_in_config(): void
+    public function test_all_71_modules_in_config(): void
     {
         $modules = config('modules');
 
-        $this->assertCount(70, $modules);
+        $this->assertCount(71, $modules);
     }
 
     public function test_disabled_accessible_module_returns_404(): void

--- a/tests/Feature/NoShowWaitlistTest.php
+++ b/tests/Feature/NoShowWaitlistTest.php
@@ -1,0 +1,585 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Jobs\NoShowReleaseJob;
+use App\Mail\WaitlistOfferMail;
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\User;
+use App\Models\WaitlistEntry;
+use App\Models\WaitlistOffer;
+use App\Services\NoShow\NoShowReleaseService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * TDD suite for P1-1 (no-show auto-release) and P1-2 (waitlist auto-promotion).
+ *
+ * FIFO promotion order: priority ASC, created_at ASC (tie-break).
+ */
+class NoShowWaitlistTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeLot(array $attrs = []): ParkingLot
+    {
+        return ParkingLot::create(array_merge([
+            'name' => 'Test Lot',
+            'total_slots' => 5,
+            'available_slots' => 5,
+            'status' => 'open',
+        ], $attrs));
+    }
+
+    private function makeSlot(ParkingLot $lot, string $number = 'A1'): ParkingSlot
+    {
+        return ParkingSlot::create([
+            'lot_id' => $lot->id,
+            'slot_number' => $number,
+            'status' => 'available',
+        ]);
+    }
+
+    private function makeBooking(User $user, ParkingLot $lot, ParkingSlot $slot, array $attrs = []): Booking
+    {
+        return Booking::create(array_merge([
+            'user_id' => $user->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'start_time' => now()->subHour(),
+            'end_time' => now()->addHour(),
+            'status' => Booking::STATUS_CONFIRMED,
+            'booking_type' => 'single',
+        ], $attrs));
+    }
+
+    private function makeWaitlistEntry(User $user, ParkingLot $lot, array $attrs = []): WaitlistEntry
+    {
+        return WaitlistEntry::create(array_merge([
+            'user_id' => $user->id,
+            'lot_id' => $lot->id,
+            'priority' => 3,
+            'status' => 'waiting',
+        ], $attrs));
+    }
+
+    // ── 1. No-show release timing ────────────────────────────────────────
+
+    public function test_booking_past_deadline_without_checkin_is_released(): void
+    {
+        $lot = $this->makeLot(['check_in_deadline_minutes' => 30]);
+        $slot = $this->makeSlot($lot);
+        $user = User::factory()->create();
+
+        // start_time 31 min ago, no check-in
+        $booking = $this->makeBooking($user, $lot, $slot, [
+            'start_time' => now()->subMinutes(31),
+            'end_time' => now()->addHour(),
+        ]);
+
+        $service = app(NoShowReleaseService::class);
+        $released = $service->releaseNoShows();
+
+        $this->assertSame(1, $released);
+        $this->assertDatabaseHas('bookings', [
+            'id' => $booking->id,
+            'status' => Booking::STATUS_RELEASED_NO_SHOW,
+        ]);
+    }
+
+    public function test_booking_within_deadline_is_not_released(): void
+    {
+        $lot = $this->makeLot(['check_in_deadline_minutes' => 30]);
+        $slot = $this->makeSlot($lot);
+        $user = User::factory()->create();
+
+        // start_time only 10 min ago — within deadline
+        $booking = $this->makeBooking($user, $lot, $slot, [
+            'start_time' => now()->subMinutes(10),
+        ]);
+
+        $service = app(NoShowReleaseService::class);
+        $service->releaseNoShows();
+
+        $this->assertDatabaseHas('bookings', [
+            'id' => $booking->id,
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+    }
+
+    // ── 2. Check-in prevents release ────────────────────────────────────
+
+    public function test_checked_in_booking_is_not_released(): void
+    {
+        $lot = $this->makeLot(['check_in_deadline_minutes' => 30]);
+        $slot = $this->makeSlot($lot);
+        $user = User::factory()->create();
+
+        $booking = $this->makeBooking($user, $lot, $slot, [
+            'start_time' => now()->subMinutes(45),
+            'checked_in_at' => now()->subMinutes(40),
+            'status' => Booking::STATUS_ACTIVE,
+        ]);
+
+        $service = app(NoShowReleaseService::class);
+        $released = $service->releaseNoShows();
+
+        $this->assertSame(0, $released);
+        $this->assertDatabaseHas('bookings', [
+            'id' => $booking->id,
+            'status' => Booking::STATUS_ACTIVE,
+        ]);
+    }
+
+    // ── 3. Offer + notify on release ────────────────────────────────────
+
+    public function test_waitlist_entry_receives_offer_on_no_show_release(): void
+    {
+        Mail::fake();
+
+        $lot = $this->makeLot(['check_in_deadline_minutes' => 30, 'claim_window_minutes' => 15]);
+        $slot = $this->makeSlot($lot);
+        $booker = User::factory()->create();
+        $waiter = User::factory()->create();
+
+        $this->makeBooking($booker, $lot, $slot, ['start_time' => now()->subMinutes(35)]);
+        $entry = $this->makeWaitlistEntry($waiter, $lot);
+
+        $service = app(NoShowReleaseService::class);
+        $service->releaseNoShows();
+
+        // WaitlistEntry promoted to offered
+        $this->assertDatabaseHas('waitlist_entries', [
+            'id' => $entry->id,
+            'status' => 'offered',
+        ]);
+
+        // WaitlistOffer created
+        $offer = WaitlistOffer::where('user_id', $waiter->id)->first();
+        $this->assertNotNull($offer);
+        $this->assertSame(WaitlistOffer::STATUS_PENDING, $offer->status);
+        $this->assertTrue($offer->expires_at->isFuture());
+
+        // Mail queued
+        Mail::assertQueued(WaitlistOfferMail::class, function ($mail) use ($waiter) {
+            return $mail->recipient->id === $waiter->id;
+        });
+    }
+
+    // ── 4. Claim within window creates booking ───────────────────────────
+
+    public function test_claim_within_window_creates_booking(): void
+    {
+        $lot = $this->makeLot(['claim_window_minutes' => 15]);
+        $slot = $this->makeSlot($lot);
+        $booker = User::factory()->create();
+        $waiter = User::factory()->create();
+
+        $releasedBooking = $this->makeBooking($booker, $lot, $slot, [
+            'status' => Booking::STATUS_RELEASED_NO_SHOW,
+        ]);
+
+        $entry = $this->makeWaitlistEntry($waiter, $lot, ['status' => 'offered']);
+        $offer = WaitlistOffer::create([
+            'waitlist_entry_id' => $entry->id,
+            'released_booking_id' => $releasedBooking->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'user_id' => $waiter->id,
+            'status' => WaitlistOffer::STATUS_PENDING,
+            'expires_at' => now()->addMinutes(14),
+        ]);
+
+        $token = $waiter->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson("/api/v1/waitlist/offers/{$offer->id}/claim");
+
+        $response->assertStatus(201)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.offer.status', WaitlistOffer::STATUS_CLAIMED);
+
+        $this->assertDatabaseHas('waitlist_offers', [
+            'id' => $offer->id,
+            'status' => WaitlistOffer::STATUS_CLAIMED,
+        ]);
+
+        // New booking created
+        $newBookingId = $response->json('data.booking.id');
+        $this->assertNotNull($newBookingId);
+        $this->assertDatabaseHas('bookings', [
+            'id' => $newBookingId,
+            'user_id' => $waiter->id,
+            'lot_id' => $lot->id,
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+    }
+
+    // ── 5. Expiry passes to next FIFO entry ──────────────────────────────
+
+    public function test_expired_offer_promotes_next_fifo_entry(): void
+    {
+        Mail::fake();
+
+        $lot = $this->makeLot(['claim_window_minutes' => 15]);
+        $slot = $this->makeSlot($lot);
+        $booker = User::factory()->create();
+        $waiter1 = User::factory()->create();
+        $waiter2 = User::factory()->create();
+
+        $releasedBooking = $this->makeBooking($booker, $lot, $slot, [
+            'status' => Booking::STATUS_RELEASED_NO_SHOW,
+        ]);
+
+        // waiter1 got offered but window already passed
+        $entry1 = $this->makeWaitlistEntry($waiter1, $lot, ['status' => 'offered', 'priority' => 1]);
+        $expiredOffer = WaitlistOffer::create([
+            'waitlist_entry_id' => $entry1->id,
+            'released_booking_id' => $releasedBooking->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'user_id' => $waiter1->id,
+            'status' => WaitlistOffer::STATUS_PENDING,
+            'expires_at' => now()->subMinute(), // already past
+        ]);
+
+        // waiter2 is next in queue
+        $entry2 = $this->makeWaitlistEntry($waiter2, $lot, ['priority' => 2]);
+
+        $service = app(NoShowReleaseService::class);
+        $service->expireStaleOffers();
+
+        // waiter1 entry expired
+        $this->assertDatabaseHas('waitlist_offers', [
+            'id' => $expiredOffer->id,
+            'status' => WaitlistOffer::STATUS_EXPIRED,
+        ]);
+
+        // waiter2 entry promoted
+        $this->assertDatabaseHas('waitlist_entries', [
+            'id' => $entry2->id,
+            'status' => 'offered',
+        ]);
+
+        // New offer created for waiter2
+        $this->assertDatabaseHas('waitlist_offers', [
+            'user_id' => $waiter2->id,
+            'status' => WaitlistOffer::STATUS_PENDING,
+        ]);
+
+        Mail::assertQueued(WaitlistOfferMail::class, fn ($m) => $m->recipient->id === $waiter2->id);
+    }
+
+    // ── 6. Double-claim rejected ─────────────────────────────────────────
+
+    public function test_double_claim_rejected(): void
+    {
+        $lot = $this->makeLot();
+        $slot = $this->makeSlot($lot);
+        $booker = User::factory()->create();
+        $waiter = User::factory()->create();
+
+        $releasedBooking = $this->makeBooking($booker, $lot, $slot, [
+            'status' => Booking::STATUS_RELEASED_NO_SHOW,
+        ]);
+        $entry = $this->makeWaitlistEntry($waiter, $lot, ['status' => 'offered']);
+        $offer = WaitlistOffer::create([
+            'waitlist_entry_id' => $entry->id,
+            'released_booking_id' => $releasedBooking->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'user_id' => $waiter->id,
+            'status' => WaitlistOffer::STATUS_CLAIMED, // already claimed
+            'expires_at' => now()->addMinutes(10),
+        ]);
+
+        $token = $waiter->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson("/api/v1/waitlist/offers/{$offer->id}/claim");
+
+        $response->assertStatus(409)
+            ->assertJsonPath('error.code', 'OFFER_NOT_PENDING');
+    }
+
+    // ── 7. Disabled lots untouched ───────────────────────────────────────
+
+    public function test_lot_with_deadline_zero_is_skipped(): void
+    {
+        $lot = $this->makeLot(['check_in_deadline_minutes' => 0]); // disabled
+        $slot = $this->makeSlot($lot);
+        $user = User::factory()->create();
+
+        $booking = $this->makeBooking($user, $lot, $slot, [
+            'start_time' => now()->subHours(2),
+        ]);
+
+        $service = app(NoShowReleaseService::class);
+        $released = $service->releaseNoShows();
+
+        $this->assertSame(0, $released);
+        $this->assertDatabaseHas('bookings', [
+            'id' => $booking->id,
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+    }
+
+    // ── 8. RBAC: unauthenticated cannot access offer endpoints ───────────
+
+    public function test_unauthenticated_cannot_list_offers(): void
+    {
+        $this->getJson('/api/v1/waitlist/offers')->assertStatus(401);
+    }
+
+    public function test_unauthenticated_cannot_claim_offer(): void
+    {
+        $this->postJson('/api/v1/waitlist/offers/fake-id/claim')->assertStatus(401);
+    }
+
+    public function test_user_cannot_claim_another_users_offer(): void
+    {
+        $lot = $this->makeLot();
+        $slot = $this->makeSlot($lot);
+        $owner = User::factory()->create();
+        $attacker = User::factory()->create();
+        $booker = User::factory()->create();
+
+        $releasedBooking = $this->makeBooking($booker, $lot, $slot, [
+            'status' => Booking::STATUS_RELEASED_NO_SHOW,
+        ]);
+        $entry = $this->makeWaitlistEntry($owner, $lot, ['status' => 'offered']);
+        $offer = WaitlistOffer::create([
+            'waitlist_entry_id' => $entry->id,
+            'released_booking_id' => $releasedBooking->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'user_id' => $owner->id,
+            'status' => WaitlistOffer::STATUS_PENDING,
+            'expires_at' => now()->addMinutes(10),
+        ]);
+
+        $token = $attacker->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson("/api/v1/waitlist/offers/{$offer->id}/claim");
+
+        $response->assertStatus(403);
+    }
+
+    // ── 9. GET /waitlist/offers list ─────────────────────────────────────
+
+    public function test_list_offers_returns_only_pending_non_expired(): void
+    {
+        $lot = $this->makeLot();
+        $slot = $this->makeSlot($lot);
+        $booker = User::factory()->create();
+        $user = User::factory()->create();
+
+        $released = $this->makeBooking($booker, $lot, $slot, [
+            'status' => Booking::STATUS_RELEASED_NO_SHOW,
+        ]);
+        $entry = $this->makeWaitlistEntry($user, $lot, ['status' => 'offered']);
+
+        // pending, not yet expired
+        WaitlistOffer::create([
+            'waitlist_entry_id' => $entry->id,
+            'released_booking_id' => $released->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'user_id' => $user->id,
+            'status' => WaitlistOffer::STATUS_PENDING,
+            'expires_at' => now()->addMinutes(10),
+        ]);
+
+        // already expired — should not appear
+        WaitlistOffer::create([
+            'waitlist_entry_id' => $entry->id,
+            'released_booking_id' => $released->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'user_id' => $user->id,
+            'status' => WaitlistOffer::STATUS_PENDING,
+            'expires_at' => now()->subMinute(),
+        ]);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/waitlist/offers');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonCount(1, 'data');
+    }
+
+    // ── 10. Idempotent check-in (POST /check-in) ─────────────────────────
+
+    public function test_check_in_is_idempotent(): void
+    {
+        $lot = $this->makeLot();
+        $slot = $this->makeSlot($lot);
+        $user = User::factory()->create();
+
+        $booking = $this->makeBooking($user, $lot, $slot, [
+            'checked_in_at' => now()->subMinutes(5),
+            'status' => Booking::STATUS_ACTIVE,
+        ]);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson("/api/v1/bookings/{$booking->id}/check-in");
+
+        $response->assertStatus(200)->assertJsonPath('success', true);
+
+        // checked_in_at unchanged
+        $this->assertDatabaseHas('bookings', [
+            'id' => $booking->id,
+            'status' => Booking::STATUS_ACTIVE,
+        ]);
+    }
+
+    public function test_check_in_marks_confirmed_booking_active(): void
+    {
+        $lot = $this->makeLot();
+        $slot = $this->makeSlot($lot);
+        $user = User::factory()->create();
+
+        $booking = $this->makeBooking($user, $lot, $slot, [
+            'start_time' => now()->subMinutes(5),
+            'status' => Booking::STATUS_CONFIRMED,
+        ]);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson("/api/v1/bookings/{$booking->id}/check-in");
+
+        $response->assertStatus(200)->assertJsonPath('success', true);
+        $this->assertDatabaseHas('bookings', [
+            'id' => $booking->id,
+            'status' => Booking::STATUS_ACTIVE,
+        ]);
+        $this->assertNotNull(Booking::find($booking->id)->checked_in_at);
+    }
+
+    public function test_check_in_rejected_for_released_no_show(): void
+    {
+        $lot = $this->makeLot();
+        $slot = $this->makeSlot($lot);
+        $user = User::factory()->create();
+
+        $booking = $this->makeBooking($user, $lot, $slot, [
+            'status' => Booking::STATUS_RELEASED_NO_SHOW,
+        ]);
+
+        $token = $user->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson("/api/v1/bookings/{$booking->id}/check-in");
+
+        $response->assertStatus(422)
+            ->assertJsonPath('error.code', 'BOOKING_NOT_CHECKABLE');
+    }
+
+    // ── 11. FIFO order is respected ──────────────────────────────────────
+
+    public function test_fifo_promotion_respects_priority_then_created_at(): void
+    {
+        Mail::fake();
+
+        $lot = $this->makeLot(['check_in_deadline_minutes' => 30]);
+        $slot = $this->makeSlot($lot);
+        $booker = User::factory()->create();
+        $waiterHigh = User::factory()->create(); // priority 1 (higher)
+        $waiterLow = User::factory()->create();  // priority 5 (lower)
+
+        $this->makeBooking($booker, $lot, $slot, ['start_time' => now()->subMinutes(35)]);
+
+        // Lower priority created first — should NOT be promoted
+        $this->makeWaitlistEntry($waiterLow, $lot, ['priority' => 5,
+            'created_at' => now()->subHours(2)]);
+
+        // Higher priority created second — SHOULD be promoted
+        $this->makeWaitlistEntry($waiterHigh, $lot, ['priority' => 1,
+            'created_at' => now()->subHour()]);
+
+        $service = app(NoShowReleaseService::class);
+        $service->releaseNoShows();
+
+        Mail::assertQueued(WaitlistOfferMail::class, fn ($m) => $m->recipient->id === $waiterHigh->id);
+        Mail::assertNotQueued(WaitlistOfferMail::class, fn ($m) => $m->recipient->id === $waiterLow->id);
+    }
+
+    // ── 12. AuditLog stamped on release ─────────────────────────────────
+
+    public function test_audit_log_created_on_release(): void
+    {
+        $lot = $this->makeLot(['check_in_deadline_minutes' => 30]);
+        $slot = $this->makeSlot($lot);
+        $user = User::factory()->create();
+
+        $booking = $this->makeBooking($user, $lot, $slot, ['start_time' => now()->subMinutes(35)]);
+
+        $service = app(NoShowReleaseService::class);
+        $service->releaseNoShows();
+
+        $this->assertDatabaseHas('audit_log', [
+            'action' => 'booking_released_no_show',
+        ]);
+    }
+
+    // ── 13. Module disabled: routes return 404 ───────────────────────────
+
+    public function test_disabled_module_returns_404_for_offers(): void
+    {
+        config(['modules.noshow_waitlist' => false]);
+
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/waitlist/offers')
+            ->assertStatus(404);
+    }
+
+    // ── 14. Job dispatches service ───────────────────────────────────────
+
+    public function test_job_runs_without_error(): void
+    {
+        // Just verify no exceptions — functional logic tested via service tests
+        $job = new NoShowReleaseJob;
+        $job->handle(app(NoShowReleaseService::class));
+
+        $this->assertTrue(true);
+    }
+
+    // ── 15. Claim expired offer returns 410 ─────────────────────────────
+
+    public function test_claim_expired_offer_returns_gone(): void
+    {
+        $lot = $this->makeLot();
+        $slot = $this->makeSlot($lot);
+        $booker = User::factory()->create();
+        $waiter = User::factory()->create();
+
+        $releasedBooking = $this->makeBooking($booker, $lot, $slot, [
+            'status' => Booking::STATUS_RELEASED_NO_SHOW,
+        ]);
+        $entry = $this->makeWaitlistEntry($waiter, $lot, ['status' => 'offered']);
+        $offer = WaitlistOffer::create([
+            'waitlist_entry_id' => $entry->id,
+            'released_booking_id' => $releasedBooking->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'user_id' => $waiter->id,
+            'status' => WaitlistOffer::STATUS_PENDING,
+            'expires_at' => now()->subMinute(), // expired
+        ]);
+
+        $token = $waiter->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson("/api/v1/waitlist/offers/{$offer->id}/claim");
+
+        $response->assertStatus(410)
+            ->assertJsonPath('error.code', 'OFFER_EXPIRED');
+    }
+}


### PR DESCRIPTION
## What

Twin of the parkhub-rust slice (matching API contract), roadmap P1-1+2: per-lot check-in deadlines + claim windows, scheduled no-show release (frees past-deadline unclaimed bookings, notifies, audits as `booking_history`), FIFO waitlist auto-promotion with claim offers, expiry pass-along, transaction-safe claims.

API: `POST /bookings/{id}/check-in`, `GET /waitlist/offers`, `POST /waitlist/offers/{id}/claim`; scramble OpenAPI snapshot regenerated and committed.

## Verification

TDD: 20 tests; phpstan level 5 clean (incl. fixing a non-nullable `@property-read` on `WaitlistEntry::user` and two stale baseline entries); pint clean; full genuine local CI green for HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)