### PR TITLE
feat: add AI Act article 50 transparency for algorithmic allocation

### DIFF
--- a/app/Http/Controllers/Api/AiActTransparencyController.php
+++ b/app/Http/Controllers/Api/AiActTransparencyController.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AuditLog;
+use App\Models\Setting;
+use App\Services\ModuleRegistry;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Admin endpoints for EU AI Act Art. 50 transparency configuration.
+ *
+ * Setting `allocation_transparency_mode`:
+ *  - `algorithmic` (default): weighted scoring / exact-cover solver runs;
+ *    every response carries an `automated_decision` transparency notice.
+ *  - `fifo_only`: algorithmic endpoints return 409 ALGORITHMIC_DISABLED so
+ *    operators can opt their deployment out of the AI Act scope entirely
+ *    (FIFO waitlist already exists as the rule-based alternative).
+ *
+ * Routes are guarded by `module:aiact` + `admin` middleware.
+ */
+final class AiActTransparencyController extends Controller
+{
+    public const string SETTING_KEY_SUFFIX = 'allocation_transparency_mode';
+
+    public const string MODE_ALGORITHMIC = 'algorithmic';
+
+    public const string MODE_FIFO_ONLY = 'fifo_only';
+
+    public const array VALID_MODES = [self::MODE_ALGORITHMIC, self::MODE_FIFO_ONLY];
+
+    /**
+     * GET /api/v1/admin/aiact/transparency-mode
+     *
+     * Returns the current allocation transparency mode and its description.
+     */
+    public function getMode(): JsonResponse
+    {
+        $mode = $this->currentMode();
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'mode' => $mode,
+                'description' => $this->modeDescription($mode),
+                'valid_modes' => self::VALID_MODES,
+                'law_applies_from' => '2026-08-02',
+                'article' => 'EU AI Act Art. 50',
+            ],
+            'error' => null,
+        ]);
+    }
+
+    /**
+     * PUT /api/v1/admin/aiact/transparency-mode
+     *
+     * Updates the allocation transparency mode. Requires admin role.
+     * Writes an audit log entry on every successful change.
+     */
+    public function putMode(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'mode' => ['required', 'string', 'in:'.implode(',', self::VALID_MODES)],
+        ]);
+
+        $mode = $validated['mode'];
+        $previous = $this->currentMode();
+
+        Setting::set(
+            ModuleRegistry::configSettingKey('aiact', self::SETTING_KEY_SUFFIX),
+            $mode
+        );
+
+        $actor = $request->user();
+        AuditLog::log([
+            'user_id' => $actor?->id,
+            'username' => $actor === null ? null : ($actor->email ?: $actor->username),
+            'action' => 'aiact_transparency_mode_updated',
+            'event_type' => 'AiActTransparencyModeUpdated',
+            'target_type' => 'aiact_settings',
+            'target_id' => null,
+            'ip_address' => $request->ip(),
+            'details' => [
+                'previous_mode' => $previous,
+                'new_mode' => $mode,
+                'setting_key' => ModuleRegistry::configSettingKey('aiact', self::SETTING_KEY_SUFFIX),
+            ],
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'mode' => $mode,
+                'description' => $this->modeDescription($mode),
+            ],
+            'error' => null,
+        ]);
+    }
+
+    /**
+     * Read the current mode from settings, defaulting to `algorithmic`.
+     */
+    public static function currentMode(): string
+    {
+        $raw = Setting::get(
+            ModuleRegistry::configSettingKey('aiact', self::SETTING_KEY_SUFFIX)
+        );
+        $mode = is_string($raw) ? trim($raw) : '';
+
+        return in_array($mode, self::VALID_MODES, true) ? $mode : self::MODE_ALGORITHMIC;
+    }
+
+    private function modeDescription(string $mode): string
+    {
+        return match ($mode) {
+            self::MODE_FIFO_ONLY => 'Algorithmic allocation endpoints are disabled. All allocation follows deterministic FIFO rules (Art. 50 opt-out).',
+            default => 'Algorithmic allocation is active. Every decision response carries an automated_decision transparency notice per EU AI Act Art. 50.',
+        };
+    }
+}

--- a/app/Http/Controllers/Api/RecommendationController.php
+++ b/app/Http/Controllers/Api/RecommendationController.php
@@ -31,6 +31,19 @@ class RecommendationController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
+        $transparencyMode = AiActTransparencyController::currentMode();
+        if ($transparencyMode === AiActTransparencyController::MODE_FIFO_ONLY) {
+            return response()->json([
+                'success' => false,
+                'data' => null,
+                'error' => [
+                    'code' => 'ALGORITHMIC_DISABLED',
+                    'message' => 'Algorithmic allocation is disabled (fifo_only mode). Use the FIFO waitlist endpoint instead.',
+                    'mode' => $transparencyMode,
+                ],
+            ], 409);
+        }
+
         $user = $request->user();
         $lotId = $request->query('lot_id');
         $engine = $this->recommendationEngineConfig();
@@ -160,6 +173,15 @@ class RecommendationController extends Controller
             'data' => $top,
             'error' => null,
             'meta' => null,
+            'automated_decision' => $this->automatedDecisionPayload(
+                'weighted_slot_recommendation',
+                [
+                    'booking_history_considered: '.$bookings->count(),
+                    'available_slot_candidates: '.$candidates->count(),
+                    'scoring_factors: booking_frequency, slot_availability, lot_hourly_rate, slot_proximity',
+                ],
+                $transparencyMode
+            ),
         ]);
     }
 
@@ -210,6 +232,19 @@ class RecommendationController extends Controller
      */
     public function exactCoverAllocation(Request $request, ExactCoverAllocator $allocator): JsonResponse
     {
+        $transparencyMode = AiActTransparencyController::currentMode();
+        if ($transparencyMode === AiActTransparencyController::MODE_FIFO_ONLY) {
+            return response()->json([
+                'success' => false,
+                'data' => null,
+                'error' => [
+                    'code' => 'ALGORITHMIC_DISABLED',
+                    'message' => 'Algorithmic allocation is disabled (fifo_only mode). Use the FIFO waitlist endpoint instead.',
+                    'mode' => $transparencyMode,
+                ],
+            ], 409);
+        }
+
         $validated = $request->validate([
             'required_constraints' => ['present', 'array', 'max:256'],
             'required_constraints.*' => ['string', 'max:128'],
@@ -280,6 +315,17 @@ class RecommendationController extends Controller
                     'execution_allowed' => false,
                     'disclaimer' => 'exact_cover_v1 is operational scheduling support; attorney review, citation verification, client authorization, and final legal judgment remain required before customer-facing legal or profiling claims ship.',
                 ],
+                'automated_decision' => $this->automatedDecisionPayload(
+                    'exact_cover_allocation',
+                    [
+                        'required_constraint_count: '.count($validated['required_constraints']),
+                        'option_count: '.count($validated['options']),
+                        'max_options_limit: '.$effectiveLimits['exact_cover_max_options'],
+                        'max_search_nodes_limit: '.$effectiveLimits['exact_cover_max_search_nodes'],
+                        'solver: exact_cover_v1 (Algorithm X / dancing links)',
+                    ],
+                    $transparencyMode
+                ),
             ],
             'error' => null,
         ]);
@@ -939,5 +985,23 @@ class RecommendationController extends Controller
         $number = is_numeric($value) ? (int) $value : $min;
 
         return max($min, min($max, $number));
+    }
+
+    /**
+     * Build the EU AI Act Art. 50 automated-decision transparency object.
+     *
+     * @param  array<int, string>  $basis  Truthful per-request inputs used in this decision.
+     * @return array{is_automated: true, decision_type: string, basis: array<int, string>, review_contact: string, art22_review_available: true, mode: string}
+     */
+    private function automatedDecisionPayload(string $decisionType, array $basis, string $mode): array
+    {
+        return [
+            'is_automated' => true,
+            'decision_type' => $decisionType,
+            'basis' => $basis,
+            'review_contact' => 'administrator',
+            'art22_review_available' => true,
+            'mode' => $mode,
+        ];
     }
 }

--- a/config/modules.php
+++ b/config/modules.php
@@ -110,6 +110,11 @@ return [
     // claim_window_minutes (default 15). Enabled by default.
     'noshow_waitlist' => env('MODULE_NOSHOW_WAITLIST', true),
 
+    // EU AI Act Art. 50 transparency (applies 2026-08-02).
+    // Adds automated_decision notice to algorithmic endpoints and exposes
+    // admin toggle for algorithmic | fifo_only mode. Enabled by default.
+    'aiact' => env('MODULE_AIACT', true),
+
     // ── Enterprise (disabled by default — opt-in) ──────────────────
     'multi_tenant' => env('MODULE_MULTI_TENANT', false),
     'dynamic_pricing' => env('MODULE_DYNAMIC_PRICING', false),

--- a/docs/openapi/php.json
+++ b/docs/openapi/php.json
@@ -11846,6 +11846,169 @@
         ]
       }
     },
+    "/v1/admin/aiact/transparency-mode": {
+      "get": {
+        "description": "Returns the current allocation transparency mode and its description.",
+        "operationId": "aiActTransparency.getMode",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "article": {
+                          "const": "EU AI Act Art. 50",
+                          "type": "string"
+                        },
+                        "description": {
+                          "enum": [
+                            "Algorithmic allocation endpoints are disabled. All allocation follows deterministic FIFO rules (Art. 50 opt-out).",
+                            "Algorithmic allocation is active. Every decision response carries an automated_decision transparency notice per EU AI Act Art. 50."
+                          ],
+                          "type": "string"
+                        },
+                        "law_applies_from": {
+                          "const": "2026-08-02",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "type": "string"
+                        },
+                        "valid_modes": {
+                          "additionalItems": false,
+                          "maxItems": 2,
+                          "minItems": 2,
+                          "prefixItems": [
+                            {
+                              "const": "algorithmic",
+                              "type": "string"
+                            },
+                            {
+                              "const": "fifo_only",
+                              "type": "string"
+                            }
+                          ],
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "description",
+                        "valid_modes",
+                        "law_applies_from",
+                        "article"
+                      ],
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "null"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          }
+        },
+        "summary": "GET /api/v1/admin/aiact/transparency-mode",
+        "tags": [
+          "AiActTransparency"
+        ]
+      },
+      "put": {
+        "description": "Updates the allocation transparency mode. Requires admin role.\nWrites an audit log entry on every successful change.",
+        "operationId": "aiActTransparency.putMode",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "mode": {
+                    "enum": [
+                      ""
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mode"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "description": {
+                          "enum": [
+                            "Algorithmic allocation endpoints are disabled. All allocation follows deterministic FIFO rules (Art. 50 opt-out).",
+                            "Algorithmic allocation is active. Every decision response carries an automated_decision transparency notice per EU AI Act Art. 50."
+                          ],
+                          "type": "string"
+                        },
+                        "mode": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "description"
+                      ],
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "null"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationException"
+          }
+        },
+        "summary": "PUT /api/v1/admin/aiact/transparency-mode",
+        "tags": [
+          "AiActTransparency"
+        ]
+      }
+    },
     "/v1/admin/analytics/occupancy": {
       "get": {
         "description": "Hourly occupancy rates for the last 7 days, grouped by hour of day.\nReturns 24 bins (hours 0–23) with average active booking count per hour.",
@@ -25022,6 +25185,54 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "automated_decision": {
+                      "properties": {
+                        "art22_review_available": {
+                          "type": "boolean"
+                        },
+                        "basis": {
+                          "additionalItems": false,
+                          "maxItems": 3,
+                          "minItems": 3,
+                          "prefixItems": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "const": "scoring_factors: booking_frequency, slot_availability, lot_hourly_rate, slot_proximity",
+                              "type": "string"
+                            }
+                          ],
+                          "type": "array"
+                        },
+                        "decision_type": {
+                          "const": "weighted_slot_recommendation",
+                          "type": "string"
+                        },
+                        "is_automated": {
+                          "type": "boolean"
+                        },
+                        "mode": {
+                          "type": "string"
+                        },
+                        "review_contact": {
+                          "const": "administrator",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "is_automated",
+                        "decision_type",
+                        "basis",
+                        "review_contact",
+                        "art22_review_available",
+                        "mode"
+                      ],
+                      "type": "object"
+                    },
                     "data": {
                       "items": {
                         "type": "string"
@@ -25042,7 +25253,8 @@
                     "success",
                     "data",
                     "error",
-                    "meta"
+                    "meta",
+                    "automated_decision"
                   ],
                   "type": "object"
                 }
@@ -25052,6 +25264,50 @@
           },
           "401": {
             "$ref": "#/components/responses/AuthenticationException"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "null"
+                    },
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "const": "ALGORITHMIC_DISABLED",
+                          "type": "string"
+                        },
+                        "message": {
+                          "const": "Algorithmic allocation is disabled (fifo_only mode). Use the FIFO waitlist endpoint instead.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "mode"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
           }
         },
         "summary": "GET /api/v1/bookings/recommendations",
@@ -34787,6 +35043,60 @@
                         "allocation_trace_id": {
                           "type": "string"
                         },
+                        "automated_decision": {
+                          "properties": {
+                            "art22_review_available": {
+                              "type": "boolean"
+                            },
+                            "basis": {
+                              "additionalItems": false,
+                              "maxItems": 5,
+                              "minItems": 5,
+                              "prefixItems": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "const": "solver: exact_cover_v1 (Algorithm X / dancing links)",
+                                  "type": "string"
+                                }
+                              ],
+                              "type": "array"
+                            },
+                            "decision_type": {
+                              "const": "exact_cover_allocation",
+                              "type": "string"
+                            },
+                            "is_automated": {
+                              "type": "boolean"
+                            },
+                            "mode": {
+                              "type": "string"
+                            },
+                            "review_contact": {
+                              "const": "administrator",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "is_automated",
+                            "decision_type",
+                            "basis",
+                            "review_contact",
+                            "art22_review_available",
+                            "mode"
+                          ],
+                          "type": "object"
+                        },
                         "legal_boundary": {
                           "properties": {
                             "attorney_review_status": {
@@ -34977,7 +35287,8 @@
                       "required": [
                         "allocation_trace_id",
                         "result",
-                        "legal_boundary"
+                        "legal_boundary",
+                        "automated_decision"
                       ],
                       "type": "object"
                     },
@@ -35001,6 +35312,50 @@
           },
           "401": {
             "$ref": "#/components/responses/AuthenticationException"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "null"
+                    },
+                    "error": {
+                      "properties": {
+                        "code": {
+                          "const": "ALGORITHMIC_DISABLED",
+                          "type": "string"
+                        },
+                        "message": {
+                          "const": "Algorithmic allocation is disabled (fifo_only mode). Use the FIFO waitlist endpoint instead.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message",
+                        "mode"
+                      ],
+                      "type": "object"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "data",
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
           },
           "422": {
             "$ref": "#/components/responses/ValidationException"

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -333,3 +333,4 @@ module_routes('mobile', 'mobile.php');
 // v5.x features
 module_routes('retention', 'retention.php');
 module_routes('noshow_waitlist', 'noshow_waitlist.php');
+module_routes('aiact', 'aiact.php');

--- a/routes/modules/aiact.php
+++ b/routes/modules/aiact.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * EU AI Act Art. 50 transparency module routes (api/v1).
+ * Loaded only when MODULE_AIACT=true.
+ *
+ * Admin-only endpoints for reading and updating the allocation
+ * transparency mode (algorithmic | fifo_only).
+ */
+
+use App\Http\Controllers\Api\AiActTransparencyController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['module:aiact', 'auth:sanctum', 'throttle:api', 'admin'])
+    ->prefix('admin/aiact')
+    ->group(function () {
+        Route::get('/transparency-mode', [AiActTransparencyController::class, 'getMode']);
+        Route::put('/transparency-mode', [AiActTransparencyController::class, 'putMode']);
+    });

--- a/tests/Feature/AiActTransparencyTest.php
+++ b/tests/Feature/AiActTransparencyTest.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\Api\AiActTransparencyController;
+use App\Models\AuditLog;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\Setting;
+use App\Models\User;
+use App\Services\ModuleRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * EU AI Act Art. 50 transparency slice — PHP twin of the Rust edition.
+ *
+ * Contract:
+ *  - Every algorithmic-decision response carries an `automated_decision` notice.
+ *  - `fifo_only` mode makes algorithmic endpoints return 409 ALGORITHMIC_DISABLED.
+ *  - Admin GET/PUT round-trip for the mode setting with RBAC enforcement.
+ *  - Existing `legal_boundary` assertions are never weakened.
+ */
+class AiActTransparencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private function adminUser(): User
+    {
+        return User::factory()->create(['role' => 'admin']);
+    }
+
+    private function regularUser(): User
+    {
+        return User::factory()->create(['role' => 'user']);
+    }
+
+    private function enableModule(): void
+    {
+        config(['modules.aiact' => true]);
+        config(['modules.recommendations' => true]);
+    }
+
+    private function setTransparencyMode(string $mode): void
+    {
+        Setting::set(
+            ModuleRegistry::configSettingKey('aiact', AiActTransparencyController::SETTING_KEY_SUFFIX),
+            $mode
+        );
+    }
+
+    /** Create a lot with $n available slots and return the lot. */
+    private function createLotWithSlots(int $n, float $hourlyRate = 5.0): ParkingLot
+    {
+        $lot = ParkingLot::create([
+            'name' => 'Test Lot',
+            'total_slots' => $n,
+            'available_slots' => $n,
+            'status' => 'open',
+            'hourly_rate' => $hourlyRate,
+        ]);
+        for ($i = 1; $i <= $n; $i++) {
+            ParkingSlot::create([
+                'lot_id' => $lot->id,
+                'slot_number' => (string) $i,
+                'status' => 'available',
+            ]);
+        }
+
+        return $lot;
+    }
+
+    // ── automated_decision block present + truthful basis ──────────────────────
+
+    public function test_automated_decision_block_present_on_recommendations(): void
+    {
+        $this->createLotWithSlots(2);
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v1/bookings/recommendations');
+
+        $response->assertOk()
+            ->assertJsonPath('automated_decision.is_automated', true)
+            ->assertJsonPath('automated_decision.art22_review_available', true)
+            ->assertJsonPath('automated_decision.review_contact', 'administrator')
+            ->assertJsonPath('automated_decision.mode', AiActTransparencyController::MODE_ALGORITHMIC);
+
+        $basis = $response->json('automated_decision.basis');
+        $this->assertIsArray($basis);
+        $this->assertNotEmpty($basis);
+    }
+
+    public function test_automated_decision_basis_truthfully_reflects_inputs(): void
+    {
+        $this->createLotWithSlots(3);
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v1/bookings/recommendations');
+
+        $response->assertOk();
+        $basis = $response->json('automated_decision.basis');
+
+        // Basis must mention the scoring factors actually used
+        $basisStr = implode(' ', $basis);
+        $this->assertStringContainsString('booking_history', $basisStr);
+        $this->assertStringContainsString('available_slot', $basisStr);
+    }
+
+    public function test_automated_decision_present_on_exact_cover_allocation(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson('/api/v1/recommendations/allocation/exact-cover', [
+            'required_constraints' => ['slot:A', 'slot:B'],
+            'options' => [
+                ['id' => 'opt-1', 'covers' => ['slot:A', 'slot:B']],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.automated_decision.is_automated', true)
+            ->assertJsonPath('data.automated_decision.art22_review_available', true)
+            ->assertJsonPath('data.automated_decision.review_contact', 'administrator')
+            ->assertJsonPath('data.automated_decision.mode', AiActTransparencyController::MODE_ALGORITHMIC);
+
+        $basis = $response->json('data.automated_decision.basis');
+        $this->assertIsArray($basis);
+        $basisStr = implode(' ', $basis);
+        $this->assertStringContainsString('required_constraint_count', $basisStr);
+        $this->assertStringContainsString('option_count', $basisStr);
+    }
+
+    // ── default mode is algorithmic ────────────────────────────────────────────
+
+    public function test_default_mode_is_algorithmic_when_no_setting_exists(): void
+    {
+        // No Setting row — should default to algorithmic
+        $mode = AiActTransparencyController::currentMode();
+
+        $this->assertSame(AiActTransparencyController::MODE_ALGORITHMIC, $mode);
+    }
+
+    public function test_default_mode_yields_automated_decision_on_recommendations(): void
+    {
+        // No Setting row set — algorithmic mode is the default
+        $this->createLotWithSlots(1);
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v1/bookings/recommendations');
+
+        $response->assertOk()
+            ->assertJsonPath('automated_decision.mode', AiActTransparencyController::MODE_ALGORITHMIC);
+    }
+
+    // ── fifo_only 409 enforcement ──────────────────────────────────────────────
+
+    public function test_fifo_only_mode_returns_409_on_recommendations(): void
+    {
+        $this->setTransparencyMode(AiActTransparencyController::MODE_FIFO_ONLY);
+        $this->createLotWithSlots(2);
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v1/bookings/recommendations');
+
+        $response->assertStatus(409)
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error.code', 'ALGORITHMIC_DISABLED')
+            ->assertJsonPath('error.mode', AiActTransparencyController::MODE_FIFO_ONLY);
+    }
+
+    public function test_fifo_only_mode_returns_409_on_exact_cover(): void
+    {
+        $this->setTransparencyMode(AiActTransparencyController::MODE_FIFO_ONLY);
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson('/api/v1/recommendations/allocation/exact-cover', [
+            'required_constraints' => ['slot:A'],
+            'options' => [
+                ['id' => 'opt-1', 'covers' => ['slot:A']],
+            ],
+        ]);
+
+        $response->assertStatus(409)
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error.code', 'ALGORITHMIC_DISABLED')
+            ->assertJsonPath('error.mode', AiActTransparencyController::MODE_FIFO_ONLY);
+    }
+
+    public function test_fifo_only_mode_does_not_affect_stats_endpoint(): void
+    {
+        $this->setTransparencyMode(AiActTransparencyController::MODE_FIFO_ONLY);
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/recommendations/stats');
+
+        // Stats is analytics, not a decision — must remain available in fifo_only mode
+        $response->assertOk()
+            ->assertJsonPath('success', true);
+    }
+
+    // ── admin GET/PUT round-trip + RBAC ────────────────────────────────────────
+
+    public function test_admin_get_mode_returns_algorithmic_by_default(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/aiact/transparency-mode');
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.mode', AiActTransparencyController::MODE_ALGORITHMIC)
+            ->assertJsonStructure(['data' => ['mode', 'description', 'valid_modes', 'law_applies_from', 'article']]);
+    }
+
+    public function test_admin_put_mode_updates_setting(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->putJson('/api/v1/admin/aiact/transparency-mode', [
+            'mode' => AiActTransparencyController::MODE_FIFO_ONLY,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.mode', AiActTransparencyController::MODE_FIFO_ONLY);
+    }
+
+    public function test_admin_put_mode_roundtrip(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        // Set to fifo_only
+        $this->actingAs($admin)->putJson('/api/v1/admin/aiact/transparency-mode', [
+            'mode' => AiActTransparencyController::MODE_FIFO_ONLY,
+        ])->assertOk();
+
+        // Read it back
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/aiact/transparency-mode');
+        $response->assertOk()
+            ->assertJsonPath('data.mode', AiActTransparencyController::MODE_FIFO_ONLY);
+
+        // Switch back to algorithmic
+        $this->actingAs($admin)->putJson('/api/v1/admin/aiact/transparency-mode', [
+            'mode' => AiActTransparencyController::MODE_ALGORITHMIC,
+        ])->assertOk();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/aiact/transparency-mode');
+        $response->assertOk()
+            ->assertJsonPath('data.mode', AiActTransparencyController::MODE_ALGORITHMIC);
+    }
+
+    public function test_admin_put_mode_rbac_non_admin_forbidden(): void
+    {
+        $this->enableModule();
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->putJson('/api/v1/admin/aiact/transparency-mode', [
+            'mode' => AiActTransparencyController::MODE_FIFO_ONLY,
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_admin_get_mode_rbac_non_admin_forbidden(): void
+    {
+        $this->enableModule();
+        $user = $this->regularUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v1/admin/aiact/transparency-mode');
+
+        $response->assertForbidden();
+    }
+
+    public function test_admin_put_mode_validates_invalid_value(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->putJson('/api/v1/admin/aiact/transparency-mode', [
+            'mode' => 'random_invalid_value',
+        ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_admin_put_mode_validates_missing_field(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->putJson('/api/v1/admin/aiact/transparency-mode', []);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_admin_put_mode_writes_audit_log(): void
+    {
+        $this->enableModule();
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)->putJson('/api/v1/admin/aiact/transparency-mode', [
+            'mode' => AiActTransparencyController::MODE_FIFO_ONLY,
+        ])->assertOk();
+
+        $entry = AuditLog::query()
+            ->where('action', 'aiact_transparency_mode_updated')
+            ->latest()
+            ->first();
+
+        $this->assertNotNull($entry);
+        $this->assertSame('AiActTransparencyModeUpdated', $entry->event_type);
+        $details = $entry->getAttribute('details');
+        $this->assertTrue(is_array($details));
+        $this->assertSame(AiActTransparencyController::MODE_FIFO_ONLY, $details['new_mode']);
+        $this->assertArrayHasKey('previous_mode', $details);
+    }
+
+    public function test_admin_module_disabled_returns_404(): void
+    {
+        config(['modules.aiact' => false]);
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/admin/aiact/transparency-mode');
+
+        $response->assertNotFound();
+    }
+
+    // ── legal_boundary assertions not weakened ─────────────────────────────────
+
+    public function test_legal_boundary_present_and_intact_on_recommendations_stats(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->getJson('/api/v1/recommendations/stats');
+
+        $response->assertOk()
+            ->assertJsonPath('data.legal_boundary.legal_review_required', true)
+            ->assertJsonPath('data.legal_boundary.attorney_review_status', 'required_before_customer_wording')
+            ->assertJsonPath('data.legal_boundary.execution_allowed', false);
+    }
+
+    public function test_legal_boundary_present_and_intact_on_exact_cover(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->postJson('/api/v1/recommendations/allocation/exact-cover', [
+            'required_constraints' => ['slot:X'],
+            'options' => [
+                ['id' => 'o1', 'covers' => ['slot:X']],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.legal_boundary.legal_review_required', true)
+            ->assertJsonPath('data.legal_boundary.attorney_review_status', 'required_before_customer_wording')
+            ->assertJsonPath('data.legal_boundary.execution_allowed', false)
+            ->assertJsonPath('data.legal_boundary.disclaimer', 'exact_cover_v1 is operational scheduling support; attorney review, citation verification, client authorization, and final legal judgment remain required before customer-facing legal or profiling claims ship.');
+    }
+
+    public function test_automated_decision_mode_field_reflects_current_setting(): void
+    {
+        $this->createLotWithSlots(1);
+        $user = $this->regularUser();
+
+        // Explicitly set algorithmic mode
+        $this->setTransparencyMode(AiActTransparencyController::MODE_ALGORITHMIC);
+
+        $response = $this->actingAs($user)->getJson('/api/v1/bookings/recommendations');
+
+        $response->assertOk()
+            ->assertJsonPath('automated_decision.mode', AiActTransparencyController::MODE_ALGORITHMIC);
+    }
+}

--- a/tests/Feature/ModuleSystemExtendedTest.php
+++ b/tests/Feature/ModuleSystemExtendedTest.php
@@ -130,7 +130,7 @@ class ModuleSystemExtendedTest extends TestCase
     public function test_module_service_provider_all_returns_current_count(): void
     {
         $all = ModuleServiceProvider::all();
-        $this->assertCount(71, $all);
+        $this->assertCount(72, $all);
     }
 
     public function test_modules_endpoint_is_always_public(): void

--- a/tests/Feature/ModuleSystemTest.php
+++ b/tests/Feature/ModuleSystemTest.php
@@ -350,11 +350,11 @@ class ModuleSystemTest extends TestCase
             ->assertOk();
     }
 
-    public function test_all_71_modules_in_config(): void
+    public function test_all_72_modules_in_config(): void
     {
         $modules = config('modules');
 
-        $this->assertCount(71, $modules);
+        $this->assertCount(72, $modules);
     }
 
     public function test_disabled_accessible_module_returns_404(): void


### PR DESCRIPTION
## What

Roadmap P0-3 — EU AI Act Art. 50 transparency duties apply from **2026-08-02**; twin of the parkhub-rust slice (same contract):

- **`automated_decision` disclosure block** on every algorithmic-decision response (recommendation stats, exact-cover allocation): `{is_automated, basis: [truthful per-endpoint inputs], review_contact, art22_review_available, mode}` — mirrors the `legal_boundary` pattern
- **`allocation_transparency_mode` setting** (`algorithmic` default | `fifo_only`): `fifo_only` makes algorithmic allocation endpoints return 409 `ALGORITHMIC_DISABLED`, letting a customer opt out of AI-Act scope entirely (rule-based FIFO via the waitlist stays available)
- Admin GET/PUT for the mode

## Verification

- TDD; full suite green (2052 tests); phpstan level 5 + pint clean; scramble OpenAPI snapshot regenerated; full genuine local CI for HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)