### PR TITLE
fix(privacy): stop disclosing colleagues' names, sick leave and plates

### DIFF
--- a/app/Http/Controllers/Api/AbsenceController.php
+++ b/app/Http/Controllers/Api/AbsenceController.php
@@ -9,12 +9,16 @@ use App\Http\Requests\ImportIcalRequest;
 use App\Http\Requests\StoreAbsenceRequest;
 use App\Models\Absence;
 use App\Models\Setting;
+use App\Services\BookingVisibility;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class AbsenceController extends Controller
 {
+    /** Longest team-absence window a single request may ask for. */
+    private const int MAX_TEAM_ABSENCE_WINDOW_DAYS = 366;
+
     public function index(Request $request): JsonResponse
     {
         $absences = Absence::where('user_id', $request->user()->id)
@@ -61,21 +65,60 @@ class AbsenceController extends Controller
         return response()->json(['message' => 'Deleted']);
     }
 
+    /**
+     * Absences across the team for a bounded window.
+     *
+     * This used to spread `$a->toArray()` into the response — the entire
+     * absence row, including the free-text `note` — alongside the real name
+     * and username, with `from`/`to` taken off the query string
+     * unvalidated. `?from=1900-01-01&to=2999-12-31` returned every absence
+     * record the instance had ever held, to any authenticated user.
+     */
     public function teamAbsences(Request $request): JsonResponse
     {
-        $from = $request->from ?? now()->startOfMonth()->toDateString();
-        $to = $request->to ?? now()->endOfMonth()->toDateString();
+        $validated = $request->validate([
+            'from' => 'sometimes|date',
+            'to' => 'sometimes|date|after_or_equal:from',
+        ]);
+
+        $from = isset($validated['from'])
+            ? Carbon::parse($validated['from'])->startOfDay()
+            : now()->startOfMonth();
+        $to = isset($validated['to'])
+            ? Carbon::parse($validated['to'])->endOfDay()
+            : now()->endOfMonth();
+
+        // An unbounded window is a bulk export, not a team view.
+        if ($from->diffInDays($to) > self::MAX_TEAM_ABSENCE_WINDOW_DAYS) {
+            return response()->json([
+                'success' => false,
+                'data' => null,
+                'error' => [
+                    'code' => 'WINDOW_TOO_LARGE',
+                    'message' => 'Requested range exceeds '.self::MAX_TEAM_ABSENCE_WINDOW_DAYS.' days.',
+                ],
+                'meta' => null,
+            ], 422);
+        }
+
         $absences = Absence::with('user')
-            ->where('start_date', '<=', $to)
-            ->where('end_date', '>=', $from)
+            ->where('start_date', '<=', $to->toDateString())
+            ->where('end_date', '>=', $from->toDateString())
             ->get();
 
-        return response()->json($absences->map(function ($a) {
-            return array_merge($a->toArray(), [
-                'user_name' => $a->user?->name,
-                'username' => $a->user?->username,
-            ]);
-        })->values());
+        $mode = BookingVisibility::mode();
+        $isAdmin = $request->user()?->isAdmin() ?? false;
+
+        // Explicit allow-list. The private note is never included, and the
+        // reason is generalised for everyone but admins.
+        return response()->json($absences->map(fn ($a) => [
+            'id' => $a->id,
+            'user_id' => $a->user_id,
+            'user_name' => BookingVisibility::label($a->user?->name, $a->user?->username, $mode),
+            'absence_type' => BookingVisibility::absenceType($a->absence_type, $isAdmin),
+            'start_date' => $a->start_date,
+            'end_date' => $a->end_date,
+        ])->values());
     }
 
     public function getPattern(Request $request): JsonResponse

--- a/app/Http/Controllers/Api/LotController.php
+++ b/app/Http/Controllers/Api/LotController.php
@@ -10,6 +10,8 @@ use App\Http\Resources\ParkingLotResource;
 use App\Models\Booking;
 use App\Models\ParkingLot;
 use App\Models\ParkingSlot;
+use App\Models\User;
+use App\Services\BookingVisibility;
 use chillerlan\QRCode\Common\EccLevel;
 use chillerlan\QRCode\Output\QRMarkupSVG;
 use chillerlan\QRCode\QRCode;
@@ -78,7 +80,7 @@ class LotController extends Controller
         return ParkingLotResource::make($lot)->response()->setStatusCode(201);
     }
 
-    public function show(string $id)
+    public function show(Request $request, string $id)
     {
         $lot = ParkingLot::findOrFail($id);
         $lot->available_slots = $this->calculateAvailable($lot);
@@ -94,15 +96,40 @@ class LotController extends Controller
                 ->get()
                 ->keyBy('slot_id');
 
-            $slotConfigs = $slots->map(function ($slot) use ($activeBookings) {
+            // The layout answers "which slots are free right now". It does
+            // not need to name who is in the others, and it certainly does
+            // not need their licence plate: the plate is on the caller's
+            // own booking, and on nobody else's business. Callers see their
+            // own booking in full; everyone else's identity goes through
+            // the same `booking_visibility` policy as the team roster.
+            $viewerId = $request->user()?->id;
+            $mode = BookingVisibility::mode();
+
+            // Resolve owners through an explicit lookup rather than the
+            // relation: `User` soft-deletes, so a booking's owner genuinely
+            // may not resolve, and `Collection::get()` is honest about that.
+            $owners = User::query()
+                ->whereIn('id', $activeBookings->pluck('user_id')->unique()->all())
+                ->get(['id', 'name', 'username'])
+                ->keyBy('id');
+
+            $slotConfigs = $slots->map(function ($slot) use ($activeBookings, $viewerId, $mode, $owners) {
                 $booking = $activeBookings->get($slot->id);
+                $isOwn = $booking !== null && $booking->user_id === $viewerId;
+                $owner = $booking !== null ? $owners->get($booking->user_id) : null;
+
+                $bookedBy = match (true) {
+                    $booking === null => null,
+                    $isOwn => $owner?->name,
+                    default => BookingVisibility::label($owner?->name, $owner?->username, $mode, 'Occupied'),
+                };
 
                 return [
                     'id' => $slot->id,
                     'number' => $slot->slot_number,
-                    'status' => $booking ? 'occupied' : 'available',
-                    'vehiclePlate' => $booking?->vehicle_plate,
-                    'bookedBy' => $booking?->user?->name,
+                    'status' => $booking !== null ? 'occupied' : 'available',
+                    'vehiclePlate' => $isOwn ? $booking->vehicle_plate : null,
+                    'bookedBy' => $bookedBy,
                 ];
             })->values()->toArray();
 

--- a/app/Http/Controllers/Api/TeamController.php
+++ b/app/Http/Controllers/Api/TeamController.php
@@ -57,25 +57,52 @@ class TeamController extends Controller
     public function today(Request $request)
     {
         $today = now()->toDateString();
-        $absences = Absence::with('user')
+        $absences = Absence::query()
             ->where('start_date', '<=', $today)
             ->where('end_date', '>=', $today)
             ->get();
-        $bookings = Booking::with('user')
+        $bookings = Booking::query()
             ->whereDate('start_time', $today)
             ->whereIn('status', ['confirmed', 'active'])
             ->get();
+
+        // Resolve display identities in one query. `User` soft-deletes, so
+        // an owner genuinely may not resolve; `Collection::get()` is honest
+        // about that where the relation's PHPDoc is not, and a vanished
+        // user degrades to the anonymous label rather than a raw name.
+        $people = User::query()
+            ->whereIn('id', $absences->pluck('user_id')->merge($bookings->pluck('user_id'))->unique()->all())
+            ->get(['id', 'name', 'username'])
+            ->keyBy('id');
+
+        // The same disclosure policy the team roster uses. This endpoint
+        // returns the same population and ignored it entirely, so an
+        // operator who set `booking_visibility` and verified it on the
+        // roster was still publishing real names here.
+        $mode = BookingVisibility::mode();
+        $isAdmin = $request->user()?->isAdmin() ?? false;
 
         return response()->json([
             'date' => $today,
             'absences' => $absences->map(fn ($a) => [
                 'user_id' => $a->user_id,
-                'user_name' => $a->user?->name,
-                'absence_type' => $a->absence_type,
+                'user_name' => BookingVisibility::label(
+                    $people->get($a->user_id)?->name,
+                    $people->get($a->user_id)?->username,
+                    $mode,
+                ),
+                // *That* somebody is away is scheduling information; *why*
+                // is health data when the answer is `sick`, and the roster
+                // does not need it. Admins keep the detail.
+                'absence_type' => BookingVisibility::absenceType($a->absence_type, $isAdmin),
             ])->values(),
             'bookings' => $bookings->map(fn ($b) => [
                 'user_id' => $b->user_id,
-                'user_name' => $b->user?->name,
+                'user_name' => BookingVisibility::label(
+                    $people->get($b->user_id)?->name,
+                    $people->get($b->user_id)?->username,
+                    $mode,
+                ),
                 'slot' => $b->slot_number,
                 'lot' => $b->lot_name,
             ])->values(),

--- a/app/Services/BookingVisibility.php
+++ b/app/Services/BookingVisibility.php
@@ -36,6 +36,34 @@ final class BookingVisibility
         self::MODE_OCCUPIED,
     ];
 
+    /**
+     * Absence reasons a colleague may see as-is.
+     *
+     * "Who is around today" is ordinary workplace scheduling information,
+     * and `homeoffice` / `vacation` / `training` are part of that. `sick`
+     * is health data — special-category under GDPR Art. 9 — and `other` is
+     * effectively free-form, so neither is disclosed to colleagues. Admins
+     * see the real value.
+     */
+    public const array COLLEAGUE_VISIBLE_ABSENCE_TYPES = ['homeoffice', 'vacation', 'training'];
+
+    /** Generic label for an absence whose reason is not disclosed. */
+    public const string ABSENCE_UNDISCLOSED = 'absent';
+
+    /**
+     * The absence reason to show to $viewerIsAdmin, for a given raw type.
+     */
+    public static function absenceType(?string $type, bool $viewerIsAdmin): string
+    {
+        if ($viewerIsAdmin) {
+            return (string) $type;
+        }
+
+        return in_array($type, self::COLLEAGUE_VISIBLE_ABSENCE_TYPES, true)
+            ? (string) $type
+            : self::ABSENCE_UNDISCLOSED;
+    }
+
     /** The configured mode, falling back to the historical default. */
     public static function mode(): string
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: app/Http/Controllers/Api/AbsenceController.php
 
 		-
-			message: '#^Parameter \#1 \$callback of method Illuminate\\Database\\Eloquent\\Collection\<int,App\\Models\\Absence\>\:\:map\(\) contains unresolvable type\.$#'
-			identifier: argument.unresolvableType
-			count: 1
-			path: app/Http/Controllers/Api/AbsenceController.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Booking\:\:\$booking_count\.$#'
 			identifier: property.notFound
 			count: 2
@@ -533,24 +527,6 @@ parameters:
 			identifier: varTag.nativeType
 			count: 1
 			path: app/Http/Controllers/Api/StripeController.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/Api/TeamController.php
-
-		-
-			message: '#^Parameter \#1 \$callback of method Illuminate\\Database\\Eloquent\\Collection\<int,App\\Models\\Absence\>\:\:map\(\) contains unresolvable type\.$#'
-			identifier: argument.unresolvableType
-			count: 1
-			path: app/Http/Controllers/Api/TeamController.php
-
-		-
-			message: '#^Using nullsafe property access on non\-nullable type App\\Models\\User\. Use \-\> instead\.$#'
-			identifier: nullsafe.neverNull
-			count: 1
-			path: app/Http/Controllers/Api/TeamController.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\TranslationProposal\:\:\$reviewer\.$#'

--- a/tests/Feature/TeamPrivacyDisclosureTest.php
+++ b/tests/Feature/TeamPrivacyDisclosureTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Absence;
+use App\Models\Booking;
+use App\Models\ParkingLot;
+use App\Models\ParkingSlot;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * What one colleague may learn about another.
+ *
+ * `booking_visibility` was honoured on exactly one endpoint. Two siblings
+ * returning the same population ignored it, and both are reachable by any
+ * authenticated user with no admin middleware — so an operator who set
+ * `booking_visibility=initials` to satisfy a works-council or GDPR
+ * requirement, verified it on the Team page, and shipped, was still
+ * disclosing everything through the other two.
+ */
+class TeamPrivacyDisclosureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function colleague(string $name = 'Dana Meyer'): User
+    {
+        return User::factory()->create(['role' => 'user', 'name' => $name]);
+    }
+
+    private function viewer(string $role = 'user'): array
+    {
+        $user = User::factory()->create(['role' => $role, 'name' => 'Viewer Person']);
+
+        return [$user, $user->createToken('test')->plainTextToken];
+    }
+
+    private function sickToday(User $user, string $note = 'chemo appointment'): Absence
+    {
+        return Absence::create([
+            'user_id' => $user->id,
+            'absence_type' => 'sick',
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->toDateString(),
+            'note' => $note,
+        ]);
+    }
+
+    // ── /team/today ───────────────────────────────────────────────────────
+
+    public function test_team_today_masks_colleague_names_per_booking_visibility(): void
+    {
+        Setting::set('booking_visibility', 'initials');
+        $dana = $this->colleague();
+        $this->sickToday($dana);
+        [, $token] = $this->viewer();
+
+        $body = json_encode($this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/team/today')->assertOk()->json());
+
+        $this->assertStringNotContainsString('Dana Meyer', (string) $body);
+    }
+
+    /**
+     * "Who is in the office today" is scheduling information. *Why* someone
+     * is away is health data when the answer is `sick`, and it is not
+     * needed to answer the question the page exists to answer.
+     */
+    public function test_team_today_does_not_disclose_why_a_colleague_is_absent(): void
+    {
+        $dana = $this->colleague();
+        $this->sickToday($dana);
+        [, $token] = $this->viewer();
+
+        $body = json_encode($this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/team/today')->assertOk()->json());
+
+        $this->assertStringNotContainsString('sick', (string) $body, 'sick leave was disclosed to a colleague');
+    }
+
+    public function test_admins_still_see_the_absence_reason(): void
+    {
+        $dana = $this->colleague();
+        $this->sickToday($dana);
+        [, $token] = $this->viewer('admin');
+
+        $body = json_encode($this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/team/today')->assertOk()->json());
+
+        $this->assertStringContainsString('sick', (string) $body, 'an admin lost information they need');
+    }
+
+    // ── /absences/team ────────────────────────────────────────────────────
+
+    public function test_team_absences_never_returns_the_private_note(): void
+    {
+        $dana = $this->colleague();
+        $this->sickToday($dana, 'chemo appointment');
+        [, $token] = $this->viewer();
+
+        $body = json_encode($this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/absences/team')->assertOk()->json());
+
+        $this->assertStringNotContainsString('chemo', (string) $body, 'a private absence note was disclosed');
+    }
+
+    /**
+     * `from`/`to` were taken off the query string unvalidated and unbounded,
+     * so one request dumped every absence the instance had ever held.
+     */
+    public function test_team_absences_rejects_an_unbounded_window(): void
+    {
+        [, $token] = $this->viewer();
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/absences/team?from=1900-01-01&to=2999-12-31')
+            ->assertStatus(422);
+    }
+
+    public function test_team_absences_rejects_a_malformed_date(): void
+    {
+        [, $token] = $this->viewer();
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/absences/team?from=not-a-date&to=also-not')
+            ->assertStatus(422);
+    }
+
+    public function test_team_absences_still_works_for_a_reasonable_window(): void
+    {
+        $dana = $this->colleague();
+        $this->sickToday($dana);
+        [, $token] = $this->viewer();
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/v1/absences/team?from='.now()->startOfMonth()->toDateString().'&to='.now()->endOfMonth()->toDateString())
+            ->assertOk();
+    }
+
+    // ── lot layout ────────────────────────────────────────────────────────
+
+    public function test_lot_layout_does_not_disclose_another_users_plate(): void
+    {
+        $lot = ParkingLot::create(['name' => 'Priv Lot', 'total_slots' => 4, 'available_slots' => 4, 'status' => 'open']);
+        $slot = ParkingSlot::create(['lot_id' => $lot->id, 'slot_number' => 'P1', 'status' => 'available']);
+        $dana = $this->colleague();
+
+        Booking::create([
+            'user_id' => $dana->id,
+            'lot_id' => $lot->id,
+            'slot_id' => $slot->id,
+            'lot_name' => $lot->name,
+            'slot_number' => 'P1',
+            'vehicle_plate' => 'B-XX-9999',
+            'start_time' => now()->subHour(),
+            'end_time' => now()->addHours(3),
+            'status' => Booking::STATUS_CONFIRMED,
+            'booking_type' => 'standard',
+        ]);
+
+        Setting::set('booking_visibility', 'initials');
+        [, $token] = $this->viewer();
+
+        $body = json_encode($this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson("/api/v1/lots/{$lot->id}")->assertOk()->json());
+
+        $this->assertStringNotContainsString('B-XX-9999', (string) $body, 'another user\'s licence plate was disclosed');
+        $this->assertStringNotContainsString('Dana Meyer', (string) $body);
+    }
+}


### PR DESCRIPTION
> **Stacked on #596** (it uses the `BookingVisibility` helper introduced there). GitHub will retarget this to `main` automatically when #596 merges. Review #596 first.

## The shape of the defect

`booking_visibility` was read in **exactly one place**. Three other surfaces returning the same population ignored it — all reachable by any authenticated user, none behind admin middleware.

So an operator who set `booking_visibility=initials` to satisfy a works-council or GDPR requirement, **verified it on the Team page**, and shipped, was still disclosing everything through the others. The control appeared to work.

| Endpoint | Disclosed |
|---|---|
| `GET /team/today` | real name + `absence_type` — and `sick` is a valid value, so this published *"<real name> is off sick today"* to the entire authenticated user base |
| `GET /absences/team` | `$a->toArray()` — the **whole absence row including the free-text `note`** — with `from`/`to` unvalidated and unbounded and no user/department filter. `?from=1900-01-01&to=2999-12-31` returned every absence record the instance ever held |
| `GET /lots/{id}` | `vehiclePlate` + `bookedBy` for every occupied slot, in the auto-generated layout |

## The fix

- **Names** masked by `booking_visibility`, as the team roster already did.
- **Absence reasons filtered, not blanket-hidden.** `homeoffice` / `vacation` / `training` are ordinary workplace scheduling information and stay visible; `sick` (special-category under GDPR Art. 9) and `other` (effectively free-form) reduce to `absent`. **Admins keep the real value.** This is why the existing `TeamTest` assertion on `vacation` still passes — I deliberately did not over-generalise.
- **The private `note` is never returned**, via an explicit column allow-list replacing the whole-row spread.
- **The team-absence window is validated and capped at 366 days.** An unbounded range is a bulk export, not a team view.
- **The lot layout returns the caller's own plate and nobody else's**; other occupants get the visibility label.

## A note on the type annotations

Identity resolution moves off the `user` relation onto explicit keyed lookups in all three places. `User` uses `SoftDeletes`, so an owner genuinely may not resolve — `Collection::get()` is honest about that where `@property-read User $user` is not, and a vanished user now degrades to the anonymous label instead of a raw name.

That honesty **removes four `phpstan-baseline.neon` entries** rather than adding any.

## Verification

8 new tests, including admin-still-sees-detail controls so this can't be "fixed" by simply hiding everything. Full PHP suite **1908 passed, 0 failures**; `pint` pass; `phpstan` no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pGb5Hp5WY9t8Tv7WbE81P